### PR TITLE
Prevent importing a portrait with a too big compressed size

### DIFF
--- a/skytemple_files/compression/px/decompressor.py
+++ b/skytemple_files/compression/px/decompressor.py
@@ -120,7 +120,8 @@ class PxDecompressor:
         Returns index or False
         """
         for idx, byte in enumerate(self.flags):
-            nbl = byte & 0xF
+            # The game compares with the entire byte, not just the lower nibble of the flag
+            nbl = byte
             if nbl == high_nibble:
                 return idx
         return False

--- a/skytemple_files/graphics/kao/model.py
+++ b/skytemple_files/graphics/kao/model.py
@@ -250,7 +250,8 @@ def pil_to_kao(pil: Image) -> Tuple[bytes, bytes]:
     # >>> uncompressed_kao_to_pil(new_palette, new_img).show()
 
     new_img_compressed = FileType.AT4PX.serialize(FileType.AT4PX.compress(new_img))
-
+    if len(new_img_compressed)>800:
+        raise AttributeError(f"This portrait does not compress well, the result size is greater than 800 bytes ({len(new_img_compressed)} bytes total).")
     # You can check if compression works, by uncompressing and checking the image again:
     # >>> unc = FileType.AT4PX.unserialize(new_img_compressed).decompress()
     # >>> uncompressed_kao_to_pil(new_palette, unc).show()


### PR DESCRIPTION
Related to issue #31.
Does not fix that issue, but at least prevents the user from importing a portrait with a compressed size greater than 800 bytes.
It should always be checked, because you will never be sure that after compression the portrait will have less than 800 bytes.