### PR TITLE
Fix map backgrounds rendered incorrectly

### DIFF
--- a/skytemple_files/graphics/bpc/model.py
+++ b/skytemple_files/graphics/bpc/model.py
@@ -164,16 +164,9 @@ class Bpc:
         warnings by the tiled_image module when this is the case.
         The mapping to BPA tiles has to be done programmatically using set_tile or set_chunk.
 
-        The palette rendering restrictions are honored (palettes 15/16 unusable).
-
         """
         width = width_in_mtiles * self.tiling_width * BPC_TILE_DIM
         height = math.ceil(self.layers[layer].chunk_tilemap_len / width_in_mtiles) * self.tiling_height * BPC_TILE_DIM
-        # Limit to 14 palettes
-        palettes = palettes.copy()
-        for p in range(14, 16):
-            if len(palettes) > p:
-                palettes[p] = [0] * 3 * 16
         return to_pil(
             self.layers[layer].tilemap, self.layers[layer].tiles, palettes, BPC_TILE_DIM,
             width, height, self.tiling_width, self.tiling_height
@@ -184,14 +177,7 @@ class Bpc:
         Convert a single chunk of the BPC to one big PIL image. For general notes, see chunks_to_pil.
 
         Does NOT export BPA tiles. Chunks that reference BPA tiles are replaced with empty tiles.
-
-        The palette rendering restrictions are honored (palettes 15/16 unusable).
         """
-        # Limit to 14 palettes
-        palettes = palettes.copy()
-        for p in range(14, 16):
-            if len(palettes) > p:
-                palettes[p] = [0] * 3 * 16
         mtidx = chunk_idx * self.tiling_width * self.tiling_height
         return to_pil(
             self.layers[layer].tilemap[mtidx:mtidx + 9], self.layers[layer].tiles, palettes, BPC_TILE_DIM,

--- a/skytemple_files/graphics/bpl/model.py
+++ b/skytemple_files/graphics/bpl/model.py
@@ -25,6 +25,9 @@ BPL_PAL_LEN = 15
 BPL_IMG_PAL_LEN = BPL_PAL_LEN + 1
 # Maximum number of palettes
 BPL_MAX_PAL = 16
+# Maximum number of normal palettes
+BPL_NORMAL_MAX_PAL = 14
+
 # Number of color bytes per palette entry. Fourth is always 0x00.
 BPL_PAL_ENTRY_LEN = 4
 # Size of a single palette in bytes

--- a/skytemple_files/graphics/bpl/model.py
+++ b/skytemple_files/graphics/bpl/model.py
@@ -72,7 +72,7 @@ class Bpl:
                 self.palettes.append(self.current_palette)
                 self.current_palette = [0, 0, 0]  # Transparent first color - see above!
                 colors_read_for_current_palette = 0
-
+        self.set_palettes(self.palettes)
         # If the second flag is set (has_second_color_table) then there should be
         # more data. Otherwise not!
         #assert len(data) - pal_end == 0 if not self.has_second_color_table else len(data) - pal_end > 0
@@ -148,8 +148,19 @@ class Bpl:
         return f_palettes
 
     def is_palette_affected_by_animation(self, pal_idx):
-        """Returns whether or not the palette with that index is affected by animation"""
+        """Returns whether or not the palette with that index is affected by animation. """
         if not self.has_palette_animation:
             return False
         spec = self.animation_specs[pal_idx]
         return spec.number_of_frames > 0
+
+    def get_real_palettes(self):
+        """Gets the actual palettes defined (without dummy grayscale entries). """
+        return self.palettes[:self.number_palettes]
+        
+    def set_palettes(self, palettes):
+        """Sets the palette properly, adding dummy grayscale entries if needed. """
+        self.palettes = palettes
+        self.number_palettes = len(palettes)
+        while len(self.palettes)<0x10:
+            self.palettes.append([(i//3)*16 for i in range(16*3)])

--- a/skytemple_files/graphics/bpl/model.py
+++ b/skytemple_files/graphics/bpl/model.py
@@ -165,5 +165,5 @@ class Bpl:
         """Sets the palette properly, adding dummy grayscale entries if needed. """
         self.palettes = palettes
         self.number_palettes = len(palettes)
-        while len(self.palettes)<0x10:
-            self.palettes.append([(i//3)*16 for i in range(16*3)])
+        while len(self.palettes)<BPL_MAX_PAL:
+            self.palettes.append([(i//3)*BPL_MAX_PAL for i in range(BPL_MAX_PAL*3)])

--- a/skytemple_files/graphics/bpl/writer.py
+++ b/skytemple_files/graphics/bpl/writer.py
@@ -44,7 +44,7 @@ class BplWriter:
         self._write_16uintle(self.model.number_palettes)
         self._write_16uintle(self.model.has_palette_animation)
 
-        for palette in self.model.palettes:
+        for palette in self.model.get_real_palettes():
             # Palettes [Starts with transparent color! This is removed!]
             for i, color in enumerate(palette[3:]):
                 self._write_byte(color)


### PR DESCRIPTION
Adds dummy grayscale palette entries for map backgrounds when the palette file doesn't have enough palettes, and adds a getter and a setter to get/set those palettes without the dummy entries.

This must be combined with the pull request in SkyTemple/skytemple.
This should fix #11.