### PR TITLE
Add primitive support for zmappat file

### DIFF
--- a/skytemple_files/_resources/ppmdu_config/pmd2dungeondata.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2dungeondata.xml
@@ -63,7 +63,7 @@
         <BinPackFile idxfirst="1032"                type="WTU"                       name="1031.wtu"/>
         <BinPackFile idxfirst="1033"                type="DBIN_SIR0_IMAGE_1033"      name="%d.img1033.sir0"/>
         <BinPackFile idxfirst="1034"                type="DBIN_SIR0_IMAGE_1034"      name="%d.img1034.sir0"/>
-        <BinPackFile idxfirst="1035"                type="DBIN_SIR0_ZMAPPAT"         name="%d.zmappat"/>
+        <BinPackFile idxfirst="1035"                type="DBIN_SIR0_ZMAPPAT"         name="minimap.zmappat"/>
       </DungeonBinFiles>
 
       <!--**********************************************-->

--- a/skytemple_files/_resources/ppmdu_config/pmd2dungeondata.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2dungeondata.xml
@@ -63,7 +63,7 @@
         <BinPackFile idxfirst="1032"                type="WTU"                       name="1031.wtu"/>
         <BinPackFile idxfirst="1033"                type="DBIN_SIR0_IMAGE_1033"      name="%d.img1033.sir0"/>
         <BinPackFile idxfirst="1034"                type="DBIN_SIR0_IMAGE_1034"      name="%d.img1034.sir0"/>
-        <BinPackFile idxfirst="1035"                type="DBIN_SIR0_1035"            name="%d.unk.sir0"/>
+        <BinPackFile idxfirst="1035"                type="DBIN_SIR0_ZMAPPAT"         name="%d.zmappat"/>
       </DungeonBinFiles>
 
       <!--**********************************************-->

--- a/skytemple_files/common/types/file_types.py
+++ b/skytemple_files/common/types/file_types.py
@@ -28,7 +28,6 @@ from skytemple_files.container.dungeon_bin.sub.at4px_dpci import DbinAt4pxDpciHa
 from skytemple_files.container.dungeon_bin.sub.sir0_at4px import DbinSir0At4pxHandler
 from skytemple_files.container.dungeon_bin.sub.sir0_at4px_dma import DbinSir0At4pxDmaHandler
 from skytemple_files.container.dungeon_bin.sub.sir0_pkdpx import DbinSir0PkdpxHandler
-from skytemple_files.container.dungeon_bin.sub.sir0_1035 import DbinSir01035Handler
 from skytemple_files.container.dungeon_bin.sub.sir0_image_1033 import DbinSir0Image1033Handler
 from skytemple_files.container.dungeon_bin.sub.sir0_image_1034 import DbinSir0Image1034Handler
 from skytemple_files.container.dungeon_bin.sub.sir0_pkdpx_dbg import DbinSir0PkdpxDbgHandler
@@ -62,6 +61,7 @@ from skytemple_files.graphics.w16.handler import W16Handler
 from skytemple_files.graphics.wan_wat.handler import WanHandler
 from skytemple_files.graphics.wte.handler import WteHandler
 from skytemple_files.graphics.wtu.handler import WtuHandler
+from skytemple_files.graphics.zmappat.handler import ZMappaTHandler
 from skytemple_files.list.actor.handler import ActorListBinHandler
 from skytemple_files.script.lsd.handler import LsdHandler
 from skytemple_files.script.ssa_sse_sss.handler import SsaHandler
@@ -139,7 +139,7 @@ class FileType:
     DBIN_SIR0_WEIRD_DATA_FILE = DbinSir0WeirdDataFileHandler
     DBIN_SIR0_IMAGE_1033 = DbinSir0Image1033Handler
     DBIN_SIR0_IMAGE_1034 = DbinSir0Image1034Handler
-    DBIN_SIR0_1035 = DbinSir01035Handler
+    DBIN_SIR0_ZMAPPAT = ZMappaTHandler
 
     # Please don't use these directly, use them via the ppmdu_config instead!
     # (skytemple_files.common.util.get_ppmdu_config_for_rom).

--- a/skytemple_files/graphics/zmappat/__init__.py
+++ b/skytemple_files/graphics/zmappat/__init__.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
-
-# TODO
-DbinSir01035Handler = None
+ZMAPPAT_TILE_SIZE = 0x80
+ZMAPPAT_PALETTE_COLORS = 0x10
+ZMAPPAT_NB_TILES_PER_VARIATION = 256
+ZMAPPAT_NB_VARIATIONS = 3
+ZMAPPAT_NB_TILES_PER_LINE = 16

--- a/skytemple_files/graphics/zmappat/dbg/export_test.py
+++ b/skytemple_files/graphics/zmappat/dbg/export_test.py
@@ -1,0 +1,47 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.types.file_types import FileType
+from skytemple_files.common.util import get_ppmdu_config_for_rom
+from skytemple_files.graphics.zmappat import *
+from skytemple_files.graphics.zmappat.handler import ZMappaTHandler
+from skytemple_files.graphics.zmappat.model import ZMappaTVariation
+
+base_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', '..')
+out_dir = os.path.join(os.path.dirname(__file__), 'dbg_output')
+os.makedirs(out_dir, exist_ok=True)
+
+rom = NintendoDSRom.fromFile(os.path.join(base_dir, 'skyworkcopy_us.nds'))
+config = get_ppmdu_config_for_rom(rom)
+dungeon_bin = FileType.DUNGEON_BIN.deserialize(rom.getFileByName('DUNGEON/dungeon.bin'), config)
+
+for i, file in enumerate(dungeon_bin):
+    fn = dungeon_bin.get_filename(i)
+    if fn.endswith('.zmappat'):
+        print(f'dungeon.bin:{fn}')
+        for v in ZMappaTVariation:
+            file.to_pil_tiles(v).save(os.path.join(out_dir, 'dungeon.bin__' + fn.replace('/', '_') + f'.img-{v.value}.png'))
+            file.to_pil_masks(v).save(os.path.join(out_dir, 'dungeon.bin__' + fn.replace('/', '_') + f'.mask-{v.value}.png'))
+            file.to_pil_tiles_minimized(v).save(os.path.join(out_dir, 'dungeon.bin__' + fn.replace('/', '_') + f'.img-min-{v.value}.png'))
+            file.to_pil_masks_minimized(v).save(os.path.join(out_dir, 'dungeon.bin__' + fn.replace('/', '_') + f'.mask-min-{v.value}.png'))
+        with open(os.path.join(out_dir, 'dungeon.bin__' + fn.replace('/', '_')), 'wb') as f:
+            f.write(ZMappaTHandler.serialize(file))
+            f.close()

--- a/skytemple_files/graphics/zmappat/dbg/import_test.py
+++ b/skytemple_files/graphics/zmappat/dbg/import_test.py
@@ -1,0 +1,50 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+
+from PIL import Image
+from ndspy.rom import NintendoDSRom
+from skytemple_files.graphics.zmappat.handler import ZMappaTHandler
+
+base_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', '..')
+out_dir = os.path.join(os.path.dirname(__file__), 'dbg_output')
+os.makedirs(out_dir, exist_ok=True)
+
+rom = NintendoDSRom.fromFile(os.path.join(base_dir, 'skyworkcopy_us.nds'))
+
+tiles = []
+masks = []
+for i in range(3):
+    fn = f'dungeon.bin__1035.zmappat.img-{i}.png'
+    tiles.append(Image.open(os.path.join(out_dir, fn), 'r'))
+    fn = f'dungeon.bin__1035.zmappat.mask-{i}.png'
+    masks.append(Image.open(os.path.join(out_dir, fn), 'r'))
+zmappat = ZMappaTHandler.new(tiles, masks, False)
+tiles = []
+masks = []
+for i in range(3):
+    fn = f'dungeon.bin__1035.zmappat.img-min-{i}.png'
+    tiles.append(Image.open(os.path.join(out_dir, fn), 'r'))
+    fn = f'dungeon.bin__1035.zmappat.mask-min-{i}.png'
+    masks.append(Image.open(os.path.join(out_dir, fn), 'r'))
+zmappat_min = ZMappaTHandler.new(tiles, masks, True)
+assert zmappat==zmappat_min
+with open(os.path.join(out_dir, 'dungeon.bin__1035.zmappat'), 'rb') as f:
+    zmappat_ref = ZMappaTHandler.deserialize(f.read())
+    f.close()
+assert zmappat_min==zmappat_ref

--- a/skytemple_files/graphics/zmappat/dbg/import_test.py
+++ b/skytemple_files/graphics/zmappat/dbg/import_test.py
@@ -30,21 +30,21 @@ rom = NintendoDSRom.fromFile(os.path.join(base_dir, 'skyworkcopy_us.nds'))
 tiles = []
 masks = []
 for i in range(3):
-    fn = f'dungeon.bin__1035.zmappat.img-{i}.png'
+    fn = f'dungeon.bin__minimap.zmappat.img-{i}.png'
     tiles.append(Image.open(os.path.join(out_dir, fn), 'r'))
-    fn = f'dungeon.bin__1035.zmappat.mask-{i}.png'
+    fn = f'dungeon.bin__minimap.zmappat.mask-{i}.png'
     masks.append(Image.open(os.path.join(out_dir, fn), 'r'))
 zmappat = ZMappaTHandler.new(tiles, masks, False)
 tiles = []
 masks = []
 for i in range(3):
-    fn = f'dungeon.bin__1035.zmappat.img-min-{i}.png'
+    fn = f'dungeon.bin__minimap.zmappat.img-min-{i}.png'
     tiles.append(Image.open(os.path.join(out_dir, fn), 'r'))
-    fn = f'dungeon.bin__1035.zmappat.mask-min-{i}.png'
+    fn = f'dungeon.bin__minimap.zmappat.mask-min-{i}.png'
     masks.append(Image.open(os.path.join(out_dir, fn), 'r'))
 zmappat_min = ZMappaTHandler.new(tiles, masks, True)
 assert zmappat==zmappat_min
-with open(os.path.join(out_dir, 'dungeon.bin__1035.zmappat'), 'rb') as f:
+with open(os.path.join(out_dir, 'dungeon.bin__minimap.zmappat'), 'rb') as f:
     zmappat_ref = ZMappaTHandler.deserialize(f.read())
     f.close()
 assert zmappat_min==zmappat_ref

--- a/skytemple_files/graphics/zmappat/handler.py
+++ b/skytemple_files/graphics/zmappat/handler.py
@@ -14,6 +14,7 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import List
 
 try:
     from PIL import Image
@@ -42,7 +43,7 @@ class ZMappaTHandler():
         return FileType.SIR0.serialize(FileType.SIR0.wrap_obj(data))
 
     @classmethod
-    def new(cls, img: Image.Image, mask: Image.Image, minimized = False) -> ZMappaT:
+    def new(cls, img: List[Image.Image], mask: List[Image.Image], minimized=False) -> ZMappaT:
         zmappat = ZMappaT(None, 0)
         if minimized:
             zmappat.from_pil_minimized(img, mask)
@@ -52,7 +53,7 @@ class ZMappaTHandler():
 
     @classmethod
     def deserialize_raw(cls, data: bytes, **kwargs) -> 'ZMappaT':
-        return ZMappaT(data)
+        return ZMappaT(data, 0)
 
     @classmethod
     def serialize_raw(cls, data: 'ZMappaT', **kwargs) -> bytes:

--- a/skytemple_files/graphics/zmappat/handler.py
+++ b/skytemple_files/graphics/zmappat/handler.py
@@ -1,0 +1,59 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+try:
+    from PIL import Image
+except ImportError:
+    from pil import Image
+
+from skytemple_files.graphics.zmappat import *
+from skytemple_files.graphics.zmappat.model import ZMappaT
+from skytemple_files.graphics.zmappat.writer import ZMappaTWriter
+
+
+class ZMappaTHandler():
+    """
+    Deals with Sir0 wrapped models by default (assumes they are Sir0 wrapped).
+    Use the deserialize_raw / serialize_raw methods to work with the unwrapped models instead.
+    """
+
+    @classmethod
+    def deserialize(cls, data: bytes, **kwargs) -> 'ZMappaT':
+        from skytemple_files.common.types.file_types import FileType
+        return FileType.SIR0.unwrap_obj(FileType.SIR0.deserialize(data), ZMappaT)
+
+    @classmethod
+    def serialize(cls, data: 'ZMappaT', **kwargs) -> bytes:
+        from skytemple_files.common.types.file_types import FileType
+        return FileType.SIR0.serialize(FileType.SIR0.wrap_obj(data))
+
+    @classmethod
+    def new(cls, img: Image.Image, mask: Image.Image, minimized = False) -> ZMappaT:
+        zmappat = ZMappaT(None, 0)
+        if minimized:
+            zmappat.from_pil_minimized(img, mask)
+        else:
+            zmappat.from_pil(img, mask)
+        return zmappat
+
+    @classmethod
+    def deserialize_raw(cls, data: bytes, **kwargs) -> 'ZMappaT':
+        return ZMappaT(data)
+
+    @classmethod
+    def serialize_raw(cls, data: 'ZMappaT', **kwargs) -> bytes:
+        return ZMappaTWriter(data).write()[0]

--- a/skytemple_files/graphics/zmappat/model.py
+++ b/skytemple_files/graphics/zmappat/model.py
@@ -29,11 +29,13 @@ from skytemple_files.common.ppmdu_config.data import Pmd2Data
 from skytemple_files.container.sir0.sir0_serializable import Sir0Serializable
 
 logger = logging.getLogger(__name__)
+
+
 class ZMappaTVariation(Enum):
     SEMI_OPAQUE = 0x00, 'Semi-Opaque', "sopaque"
     TRANSPARENT = 0x01, 'Transparent', "trans"
-    OPAQUE      = 0x02, 'Opaque', "opaque"
-    
+    OPAQUE = 0x02, 'Opaque', "opaque"
+
     def __new__(cls, *args, **kwargs):
         obj = object.__new__(cls)
         obj._value_ = args[0]
@@ -46,6 +48,7 @@ class ZMappaTVariation(Enum):
         self.description = description
         self.filename = filename
 
+
 class ZMappaT(Sir0Serializable, AutoString):
     def __init__(self, data: Optional[bytes], header_pnt: int):
         """Constructs a ZMappaT model. Setting data to None will initialize an empty model."""
@@ -57,15 +60,15 @@ class ZMappaT(Sir0Serializable, AutoString):
 
         if not isinstance(data, memoryview):
             data = memoryview(data)
-        
+
         pointer_tiles = read_uintle(data, header_pnt, 4)
         pointer_pal = read_uintle(data, header_pnt + 0x4, 4)
 
-        self.tiles, self.masks = self._read_tiles(data, pointer_tiles, (pointer_pal-pointer_tiles)//4)
+        self.tiles, self.masks = self._read_tiles(data, pointer_tiles, (pointer_pal - pointer_tiles) // 4)
         self.palette = self._read_palette(data, pointer_pal)
 
-        assert len(self.tiles)==ZMAPPAT_NB_TILES_PER_VARIATION*ZMAPPAT_NB_VARIATIONS
-        assert len(self.masks)==ZMAPPAT_NB_TILES_PER_VARIATION*ZMAPPAT_NB_VARIATIONS
+        assert len(self.tiles) == ZMAPPAT_NB_TILES_PER_VARIATION * ZMAPPAT_NB_VARIATIONS
+        assert len(self.masks) == ZMAPPAT_NB_TILES_PER_VARIATION * ZMAPPAT_NB_VARIATIONS
 
     @classmethod
     def sir0_unwrap(cls, content_data: bytes, data_pointer: int,
@@ -76,85 +79,92 @@ class ZMappaT(Sir0Serializable, AutoString):
         from skytemple_files.graphics.zmappat.writer import ZMappaTWriter
         return ZMappaTWriter(self).write()
 
-    def _read_tiles(self, data: memoryview, pointer_tiles, nb_tiles) -> memoryview:
+    def _read_tiles(self, data: memoryview, pointer_tiles, nb_tiles) -> Tuple[List[bytearray], List[bytearray]]:
         tiles = []
         masks = []
         for i in range(nb_tiles):
-            offset = read_uintle(data, pointer_tiles + i*0x4, 4)
-            data_tile = data[offset:offset+ZMAPPAT_TILE_SIZE]
-            current_mask = bytearray(ZMAPPAT_TILE_SIZE//2)
-            current_tile = bytearray(ZMAPPAT_TILE_SIZE//2)
-            for chunks in range(ZMAPPAT_TILE_SIZE//8):
-                current_mask[chunks*4:(chunks+1)*4] = data_tile[chunks*8:chunks*8+4]
-                current_tile[chunks*4:(chunks+1)*4] = data_tile[chunks*8+4:chunks*8+8]
+            offset = read_uintle(data, pointer_tiles + i * 0x4, 4)
+            data_tile = data[offset:offset + ZMAPPAT_TILE_SIZE]
+            current_mask = bytearray(ZMAPPAT_TILE_SIZE // 2)
+            current_tile = bytearray(ZMAPPAT_TILE_SIZE // 2)
+            for chunks in range(ZMAPPAT_TILE_SIZE // 8):
+                current_mask[chunks * 4:(chunks + 1) * 4] = data_tile[chunks * 8:chunks * 8 + 4]
+                current_tile[chunks * 4:(chunks + 1) * 4] = data_tile[chunks * 8 + 4:chunks * 8 + 8]
             masks.append(current_mask)
             tiles.append(current_tile)
         return tiles, masks
 
     def _read_palette(self, data: memoryview, pointer_pal) -> List[int]:
         pal = []
-        data = data[pointer_pal:pointer_pal+(16*4)]
+        data = data[pointer_pal:pointer_pal + (16 * 4)]
         for i, (r, g, b, x) in enumerate(iter_bytes(data, 4)):
             pal.append(r)
             pal.append(g)
             pal.append(b)
         return pal
-    
-    def _to_pil_chunk(self, chunks, variation:ZMappaTVariation) -> Image.Image:
-        """ Returns an image using the chunks given."""
-        dimensions = (8*ZMAPPAT_NB_TILES_PER_LINE, 8*ZMAPPAT_NB_TILES_PER_VARIATION//ZMAPPAT_NB_TILES_PER_LINE)
-        pil_img_data = bytearray(ZMAPPAT_NB_TILES_PER_VARIATION*64)
 
-        for i, t in enumerate(chunks[ZMAPPAT_NB_TILES_PER_VARIATION*variation.value:ZMAPPAT_NB_TILES_PER_VARIATION*(variation.value+1)]):
-            x_tile = i%ZMAPPAT_NB_TILES_PER_LINE
-            y_tile = i//ZMAPPAT_NB_TILES_PER_LINE
+    def _to_pil_chunk(self, chunks, variation: ZMappaTVariation) -> Image.Image:
+        """ Returns an image using the chunks given."""
+        dimensions = (8 * ZMAPPAT_NB_TILES_PER_LINE, 8 * ZMAPPAT_NB_TILES_PER_VARIATION // ZMAPPAT_NB_TILES_PER_LINE)
+        pil_img_data = bytearray(ZMAPPAT_NB_TILES_PER_VARIATION * 64)
+
+        for i, t in enumerate(chunks[ZMAPPAT_NB_TILES_PER_VARIATION * variation.value:ZMAPPAT_NB_TILES_PER_VARIATION * (
+                variation.value + 1)]):
+            x_tile = i % ZMAPPAT_NB_TILES_PER_LINE
+            y_tile = i // ZMAPPAT_NB_TILES_PER_LINE
             for y in range(8):
-                start = (y_tile*64+y*8)*ZMAPPAT_NB_TILES_PER_LINE+x_tile*8
-                pil_img_data[start:start+8] = t[y*8:y*8+8]
+                start = (y_tile * 64 + y * 8) * ZMAPPAT_NB_TILES_PER_LINE + x_tile * 8
+                pil_img_data[start:start + 8] = t[y * 8:y * 8 + 8]
         im = Image.frombuffer('P', dimensions, pil_img_data, 'raw', 'P', 0, 1)
         return im
-    def _to_pil_chunk_minimized(self, chunks, variation:ZMappaTVariation) -> Image.Image:
+
+    def _to_pil_chunk_minimized(self, chunks, variation: ZMappaTVariation) -> Image.Image:
         """ Returns an image using the chunks given.
         This is the minimized version. """
-        dimensions = (4*(ZMAPPAT_NB_TILES_PER_LINE//2), 4*(ZMAPPAT_NB_TILES_PER_VARIATION//ZMAPPAT_NB_TILES_PER_LINE)//2)
-        pil_img_data = bytearray(ZMAPPAT_NB_TILES_PER_VARIATION*4)
+        dimensions = (
+        4 * (ZMAPPAT_NB_TILES_PER_LINE // 2), 4 * (ZMAPPAT_NB_TILES_PER_VARIATION // ZMAPPAT_NB_TILES_PER_LINE) // 2)
+        pil_img_data = bytearray(ZMAPPAT_NB_TILES_PER_VARIATION * 4)
 
-        for i, t in enumerate(chunks[ZMAPPAT_NB_TILES_PER_VARIATION*variation.value:ZMAPPAT_NB_TILES_PER_VARIATION*(variation.value+1)]):
-            if i%4==0:
-                x_tile = (i//4)%(ZMAPPAT_NB_TILES_PER_LINE//2)
-                y_tile = (i//4)//(ZMAPPAT_NB_TILES_PER_LINE//2)
+        for i, t in enumerate(chunks[ZMAPPAT_NB_TILES_PER_VARIATION * variation.value:ZMAPPAT_NB_TILES_PER_VARIATION * (
+                variation.value + 1)]):
+            if i % 4 == 0:
+                x_tile = (i // 4) % (ZMAPPAT_NB_TILES_PER_LINE // 2)
+                y_tile = (i // 4) // (ZMAPPAT_NB_TILES_PER_LINE // 2)
                 for y in range(4):
-                    start = (y_tile*16+y*4)*ZMAPPAT_NB_TILES_PER_LINE//2+x_tile*4
-                    pil_img_data[start:start+4] = t[y*8:y*8+4]
+                    start = (y_tile * 16 + y * 4) * ZMAPPAT_NB_TILES_PER_LINE // 2 + x_tile * 4
+                    pil_img_data[start:start + 4] = t[y * 8:y * 8 + 4]
         im = Image.frombuffer('P', dimensions, pil_img_data, 'raw', 'P', 0, 1)
         return im
-    
-    def to_pil_tiles(self, variation:ZMappaTVariation) -> Image.Image:
+
+    def to_pil_tiles(self, variation: ZMappaTVariation) -> Image.Image:
         """ Returns an image representing all the tiles of this zmappat file."""
         im = self._to_pil_chunk(self.tiles, variation)
         im.putpalette(self.palette)
         return im
-    def to_pil_masks(self, variation:ZMappaTVariation) -> Image.Image:
+
+    def to_pil_masks(self, variation: ZMappaTVariation) -> Image.Image:
         """ Returns an image representing all the masks of this zmappat file."""
         im = self._to_pil_chunk(self.masks, variation)
-        im.putpalette([i//3 for i in range(256*3)])
+        im.putpalette([i // 3 for i in range(256 * 3)])
         return im
-    def to_pil_tiles_minimized(self, variation:ZMappaTVariation) -> Image.Image:
+
+    def to_pil_tiles_minimized(self, variation: ZMappaTVariation) -> Image.Image:
         """ Returns an image representing all the tiles of this zmappat file.
         This is the minimized version."""
         im = self._to_pil_chunk_minimized(self.tiles, variation)
         im.putpalette(self.palette)
         return im
-    def to_pil_masks_minimized(self, variation:ZMappaTVariation) -> Image.Image:
+
+    def to_pil_masks_minimized(self, variation: ZMappaTVariation) -> Image.Image:
         """ Returns an image representing all the masks of this zmappat file.
         This is the minimized version."""
         im = self._to_pil_chunk_minimized(self.masks, variation)
-        im.putpalette([i//3 for i in range(256*3)])
+        im.putpalette([i // 3 for i in range(256 * 3)])
         return im
 
     def from_pil(self, imgs: List[Image.Image], masks: List[Image.Image]) -> 'ZMappaT':
         """ Replace the tile/mask data by the new ones passed in argument. """
-        if len(imgs)!=ZMAPPAT_NB_VARIATIONS or len(masks)!=ZMAPPAT_NB_VARIATIONS:
+        if len(imgs) != ZMAPPAT_NB_VARIATIONS or len(masks) != ZMAPPAT_NB_VARIATIONS:
             raise ValueError("Tile and masks list must have exactly 3 items")
         new_tiles = []
         new_masks = []
@@ -162,37 +172,37 @@ class ZMappaT(Sir0Serializable, AutoString):
             if imgs[v].mode != 'P' or masks[v].mode != 'P':
                 raise AttributeError('Can not convert PIL image to ZMAPPAT: Must be indexed images (=using a palette)')
             for i in range(ZMAPPAT_NB_TILES_PER_VARIATION):
-                x_tile = i%ZMAPPAT_NB_TILES_PER_LINE
-                y_tile = i//ZMAPPAT_NB_TILES_PER_LINE
-                tile_img = imgs[v].crop(box=[x_tile*8,y_tile*8,(x_tile+1)*8,(y_tile+1)*8])
-                mask_img = masks[v].crop(box=[x_tile*8,y_tile*8,(x_tile+1)*8,(y_tile+1)*8])
+                x_tile = i % ZMAPPAT_NB_TILES_PER_LINE
+                y_tile = i // ZMAPPAT_NB_TILES_PER_LINE
+                tile_img = imgs[v].crop(box=[x_tile * 8, y_tile * 8, (x_tile + 1) * 8, (y_tile + 1) * 8])
+                mask_img = masks[v].crop(box=[x_tile * 8, y_tile * 8, (x_tile + 1) * 8, (y_tile + 1) * 8])
                 new_tiles.append(bytearray(tile_img.tobytes("raw", "P")))
                 new_masks.append(bytearray(mask_img.tobytes("raw", "P")))
         self.tiles = new_tiles
         self.masks = new_masks
         self.palette = [x for x in memoryview(imgs[0].palette.palette)]
-    
+
     def from_pil_minimized(self, imgs: List[Image.Image], masks: List[Image.Image]) -> 'ZMappaT':
         """ Replace the tile/mask data by the new ones passed in argument.
         This is for the minimized version. """
-        if len(imgs)!=ZMAPPAT_NB_VARIATIONS or len(masks)!=ZMAPPAT_NB_VARIATIONS:
+        if len(imgs) != ZMAPPAT_NB_VARIATIONS or len(masks) != ZMAPPAT_NB_VARIATIONS:
             raise ValueError("Tile and masks list must have exactly 3 items")
         new_tiles = []
         new_masks = []
         for v in range(ZMAPPAT_NB_VARIATIONS):
             if imgs[v].mode != 'P' or masks[v].mode != 'P':
                 raise AttributeError('Can not convert PIL image to ZMAPPAT: Must be indexed images (=using a palette)')
-            for i in range(ZMAPPAT_NB_TILES_PER_VARIATION//4):
-                x_tile = i%(ZMAPPAT_NB_TILES_PER_LINE//2)
-                y_tile = i//(ZMAPPAT_NB_TILES_PER_LINE//2)
-                mini_tile_img = imgs[v].crop(box=[x_tile*4,y_tile*4,(x_tile+1)*4,(y_tile+1)*4])
-                mini_mask_img = masks[v].crop(box=[x_tile*4,y_tile*4,(x_tile+1)*4,(y_tile+1)*4])
+            for i in range(ZMAPPAT_NB_TILES_PER_VARIATION // 4):
+                x_tile = i % (ZMAPPAT_NB_TILES_PER_LINE // 2)
+                y_tile = i // (ZMAPPAT_NB_TILES_PER_LINE // 2)
+                mini_tile_img = imgs[v].crop(box=[x_tile * 4, y_tile * 4, (x_tile + 1) * 4, (y_tile + 1) * 4])
+                mini_mask_img = masks[v].crop(box=[x_tile * 4, y_tile * 4, (x_tile + 1) * 4, (y_tile + 1) * 4])
                 for y in range(2):
                     for x in range(2):
-                        tile_img = Image.new(mode='P', size=(8,8), color=0)
-                        tile_img.paste(mini_tile_img, (x*4, y*4))
-                        mask_img = Image.new(mode='P', size=(8,8), color=255)
-                        mask_img.paste(mini_mask_img, (x*4, y*4))
+                        tile_img = Image.new(mode='P', size=(8, 8), color=0)
+                        tile_img.paste(mini_tile_img, (x * 4, y * 4))
+                        mask_img = Image.new(mode='P', size=(8, 8), color=255)
+                        mask_img.paste(mini_mask_img, (x * 4, y * 4))
                         new_tiles.append(bytearray(tile_img.tobytes("raw", "P")))
                         new_masks.append(bytearray(mask_img.tobytes("raw", "P")))
         self.tiles = new_tiles
@@ -203,5 +213,5 @@ class ZMappaT(Sir0Serializable, AutoString):
         if not isinstance(other, ZMappaT):
             return False
         return self.tiles == other.tiles and \
-            self.masks == other.masks and \
-            self.palette == other.palette
+               self.masks == other.masks and \
+               self.palette == other.palette

--- a/skytemple_files/graphics/zmappat/model.py
+++ b/skytemple_files/graphics/zmappat/model.py
@@ -30,9 +30,9 @@ from skytemple_files.container.sir0.sir0_serializable import Sir0Serializable
 
 logger = logging.getLogger(__name__)
 class ZMappaTVariation(Enum):
-    SEMI_OPAQUE = 0x00, 'Semi-opaque'
-    TRANSPARENT = 0x01, 'Transparent'
-    FULL_OPAQUE = 0x02, 'Opaque'
+    SEMI_OPAQUE = 0x00, 'Semi-Opaque', "sopaque"
+    TRANSPARENT = 0x01, 'Transparent', "trans"
+    OPAQUE      = 0x02, 'Opaque', "opaque"
     
     def __new__(cls, *args, **kwargs):
         obj = object.__new__(cls)
@@ -41,13 +41,14 @@ class ZMappaTVariation(Enum):
 
     # ignore the first param since it's already set by __new__
     def __init__(
-            self, _: int, description: str
+            self, _: int, description: str, filename: str
     ):
         self.description = description
+        self.filename = filename
 
 class ZMappaT(Sir0Serializable, AutoString):
     def __init__(self, data: Optional[bytes], header_pnt: int):
-        """Constructs a Wte model. Setting data to None will initialize an empty model."""
+        """Constructs a ZMappaT model. Setting data to None will initialize an empty model."""
         if data is None:
             self.tiles = []
             self.masks = []

--- a/skytemple_files/graphics/zmappat/model.py
+++ b/skytemple_files/graphics/zmappat/model.py
@@ -1,0 +1,204 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+import logging
+from enum import Enum
+from typing import Optional
+
+try:
+    from PIL import Image
+except ImportError:
+    from pil import Image
+
+from skytemple_files.common.util import *
+from skytemple_files.graphics.zmappat import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data
+from skytemple_files.container.sir0.sir0_serializable import Sir0Serializable
+
+logger = logging.getLogger(__name__)
+class ZMappaTVariation(Enum):
+    SEMI_OPAQUE = 0x00, 'Semi-opaque'
+    TRANSPARENT = 0x01, 'Transparent'
+    FULL_OPAQUE = 0x02, 'Opaque'
+    
+    def __new__(cls, *args, **kwargs):
+        obj = object.__new__(cls)
+        obj._value_ = args[0]
+        return obj
+
+    # ignore the first param since it's already set by __new__
+    def __init__(
+            self, _: int, description: str
+    ):
+        self.description = description
+
+class ZMappaT(Sir0Serializable, AutoString):
+    def __init__(self, data: Optional[bytes], header_pnt: int):
+        """Constructs a Wte model. Setting data to None will initialize an empty model."""
+        if data is None:
+            self.tiles = []
+            self.masks = []
+            self.palette = []
+            return
+
+        if not isinstance(data, memoryview):
+            data = memoryview(data)
+        
+        pointer_tiles = read_uintle(data, header_pnt, 4)
+        pointer_pal = read_uintle(data, header_pnt + 0x4, 4)
+
+        self.tiles, self.masks = self._read_tiles(data, pointer_tiles, (pointer_pal-pointer_tiles)//4)
+        self.palette = self._read_palette(data, pointer_pal)
+
+        assert len(self.tiles)==ZMAPPAT_NB_TILES_PER_VARIATION*ZMAPPAT_NB_VARIATIONS
+        assert len(self.masks)==ZMAPPAT_NB_TILES_PER_VARIATION*ZMAPPAT_NB_VARIATIONS
+
+    @classmethod
+    def sir0_unwrap(cls, content_data: bytes, data_pointer: int,
+                    static_data: Optional[Pmd2Data] = None) -> 'Sir0Serializable':
+        return cls(content_data, data_pointer)
+
+    def sir0_serialize_parts(self) -> Tuple[bytes, List[int], Optional[int]]:
+        from skytemple_files.graphics.zmappat.writer import ZMappaTWriter
+        return ZMappaTWriter(self).write()
+
+    def _read_tiles(self, data: memoryview, pointer_tiles, nb_tiles) -> memoryview:
+        tiles = []
+        masks = []
+        for i in range(nb_tiles):
+            offset = read_uintle(data, pointer_tiles + i*0x4, 4)
+            data_tile = data[offset:offset+ZMAPPAT_TILE_SIZE]
+            current_mask = bytearray(ZMAPPAT_TILE_SIZE//2)
+            current_tile = bytearray(ZMAPPAT_TILE_SIZE//2)
+            for chunks in range(ZMAPPAT_TILE_SIZE//8):
+                current_mask[chunks*4:(chunks+1)*4] = data_tile[chunks*8:chunks*8+4]
+                current_tile[chunks*4:(chunks+1)*4] = data_tile[chunks*8+4:chunks*8+8]
+            masks.append(current_mask)
+            tiles.append(current_tile)
+        return tiles, masks
+
+    def _read_palette(self, data: memoryview, pointer_pal) -> List[int]:
+        pal = []
+        data = data[pointer_pal:pointer_pal+(16*4)]
+        for i, (r, g, b, x) in enumerate(iter_bytes(data, 4)):
+            pal.append(r)
+            pal.append(g)
+            pal.append(b)
+        return pal
+    
+    def _to_pil_chunk(self, chunks, variation:ZMappaTVariation) -> Image.Image:
+        """ Returns an image using the chunks given."""
+        dimensions = (8*ZMAPPAT_NB_TILES_PER_LINE, 8*ZMAPPAT_NB_TILES_PER_VARIATION//ZMAPPAT_NB_TILES_PER_LINE)
+        pil_img_data = bytearray(ZMAPPAT_NB_TILES_PER_VARIATION*64)
+
+        for i, t in enumerate(chunks[ZMAPPAT_NB_TILES_PER_VARIATION*variation.value:ZMAPPAT_NB_TILES_PER_VARIATION*(variation.value+1)]):
+            x_tile = i%ZMAPPAT_NB_TILES_PER_LINE
+            y_tile = i//ZMAPPAT_NB_TILES_PER_LINE
+            for y in range(8):
+                start = (y_tile*64+y*8)*ZMAPPAT_NB_TILES_PER_LINE+x_tile*8
+                pil_img_data[start:start+8] = t[y*8:y*8+8]
+        im = Image.frombuffer('P', dimensions, pil_img_data, 'raw', 'P', 0, 1)
+        return im
+    def _to_pil_chunk_minimized(self, chunks, variation:ZMappaTVariation) -> Image.Image:
+        """ Returns an image using the chunks given."""
+        dimensions = (4*(ZMAPPAT_NB_TILES_PER_LINE//2), 4*(ZMAPPAT_NB_TILES_PER_VARIATION//ZMAPPAT_NB_TILES_PER_LINE)//2)
+        pil_img_data = bytearray(ZMAPPAT_NB_TILES_PER_VARIATION*4)
+
+        for i, t in enumerate(chunks[ZMAPPAT_NB_TILES_PER_VARIATION*variation.value:ZMAPPAT_NB_TILES_PER_VARIATION*(variation.value+1)]):
+            if i%4==0:
+                x_tile = (i//4)%(ZMAPPAT_NB_TILES_PER_LINE//2)
+                y_tile = (i//4)//(ZMAPPAT_NB_TILES_PER_LINE//2)
+                for y in range(4):
+                    start = (y_tile*16+y*4)*ZMAPPAT_NB_TILES_PER_LINE//2+x_tile*4
+                    pil_img_data[start:start+4] = t[y*8:y*8+4]
+        im = Image.frombuffer('P', dimensions, pil_img_data, 'raw', 'P', 0, 1)
+        return im
+    
+    def to_pil_tiles(self, variation:ZMappaTVariation) -> Image.Image:
+        """ Returns an image representing all the tiles of this zmappat file."""
+        im = self._to_pil_chunk(self.tiles, variation)
+        im.putpalette(self.palette)
+        return im
+    def to_pil_masks(self, variation:ZMappaTVariation) -> Image.Image:
+        """ Returns an image representing all the masks of this zmappat file."""
+        im = self._to_pil_chunk(self.masks, variation)
+        im.putpalette([i//3 for i in range(256*3)])
+        return im
+    def to_pil_tiles_minimized(self, variation:ZMappaTVariation) -> Image.Image:
+        """ Returns an image representing all the tiles of this zmappat file.
+        This is the minimized version."""
+        im = self._to_pil_chunk_minimized(self.tiles, variation)
+        im.putpalette(self.palette)
+        return im
+    def to_pil_masks_minimized(self, variation:ZMappaTVariation) -> Image.Image:
+        """ Returns an image representing all the masks of this zmappat file.
+        This is the minimized version."""
+        im = self._to_pil_chunk_minimized(self.masks, variation)
+        im.putpalette([i//3 for i in range(256*3)])
+        return im
+
+    def from_pil(self, imgs: List[Image.Image], masks: List[Image.Image]) -> 'ZMappaT':
+        """ Replace the tile data by the new ones passed in argument. """
+        if len(imgs)!=ZMAPPAT_NB_VARIATIONS or len(masks)!=ZMAPPAT_NB_VARIATIONS:
+            raise ValueError("Tile and masks list must have exactly 3 items")
+        new_tiles = []
+        new_masks = []
+        for v in range(ZMAPPAT_NB_VARIATIONS):
+            if imgs[v].mode != 'P' or masks[v].mode != 'P':
+                raise AttributeError('Can not convert PIL image to ZMAPPAT: Must be indexed images (=using a palette)')
+            for i in range(ZMAPPAT_NB_TILES_PER_VARIATION):
+                x_tile = i%ZMAPPAT_NB_TILES_PER_LINE
+                y_tile = i//ZMAPPAT_NB_TILES_PER_LINE
+                tile_img = imgs[v].crop(box=[x_tile*8,y_tile*8,(x_tile+1)*8,(y_tile+1)*8])
+                mask_img = masks[v].crop(box=[x_tile*8,y_tile*8,(x_tile+1)*8,(y_tile+1)*8])
+                new_tiles.append(bytearray(tile_img.tobytes("raw", "P")))
+                new_masks.append(bytearray(mask_img.tobytes("raw", "P")))
+        self.tiles = new_tiles
+        self.masks = new_masks
+        self.palette = [x for x in memoryview(imgs[0].palette.palette)]
+    
+    def from_pil_minimized(self, imgs: List[Image.Image], masks: List[Image.Image]) -> 'ZMappaT':
+        """ Replace the tile data by the new ones passed in argument. """
+        if len(imgs)!=ZMAPPAT_NB_VARIATIONS or len(masks)!=ZMAPPAT_NB_VARIATIONS:
+            raise ValueError("Tile and masks list must have exactly 3 items")
+        new_tiles = []
+        new_masks = []
+        for v in range(ZMAPPAT_NB_VARIATIONS):
+            if imgs[v].mode != 'P' or masks[v].mode != 'P':
+                raise AttributeError('Can not convert PIL image to ZMAPPAT: Must be indexed images (=using a palette)')
+            for i in range(ZMAPPAT_NB_TILES_PER_VARIATION//4):
+                x_tile = i%(ZMAPPAT_NB_TILES_PER_LINE//2)
+                y_tile = i//(ZMAPPAT_NB_TILES_PER_LINE//2)
+                mini_tile_img = imgs[v].crop(box=[x_tile*4,y_tile*4,(x_tile+1)*4,(y_tile+1)*4])
+                mini_mask_img = masks[v].crop(box=[x_tile*4,y_tile*4,(x_tile+1)*4,(y_tile+1)*4])
+                for y in range(2):
+                    for x in range(2):
+                        tile_img = Image.new(mode='P', size=(8,8), color=0)
+                        tile_img.paste(mini_tile_img, (x*4, y*4))
+                        mask_img = Image.new(mode='P', size=(8,8), color=255)
+                        mask_img.paste(mini_mask_img, (x*4, y*4))
+                        new_tiles.append(bytearray(tile_img.tobytes("raw", "P")))
+                        new_masks.append(bytearray(mask_img.tobytes("raw", "P")))
+        self.tiles = new_tiles
+        self.masks = new_masks
+        self.palette = [x for x in memoryview(imgs[0].palette.palette)]
+
+    def __eq__(self, other):
+        if not isinstance(other, ZMappaT):
+            return False
+        return self.tiles == other.tiles and \
+            self.masks == other.masks and \
+            self.palette == other.palette

--- a/skytemple_files/graphics/zmappat/model.py
+++ b/skytemple_files/graphics/zmappat/model.py
@@ -114,7 +114,8 @@ class ZMappaT(Sir0Serializable, AutoString):
         im = Image.frombuffer('P', dimensions, pil_img_data, 'raw', 'P', 0, 1)
         return im
     def _to_pil_chunk_minimized(self, chunks, variation:ZMappaTVariation) -> Image.Image:
-        """ Returns an image using the chunks given."""
+        """ Returns an image using the chunks given.
+        This is the minimized version. """
         dimensions = (4*(ZMAPPAT_NB_TILES_PER_LINE//2), 4*(ZMAPPAT_NB_TILES_PER_VARIATION//ZMAPPAT_NB_TILES_PER_LINE)//2)
         pil_img_data = bytearray(ZMAPPAT_NB_TILES_PER_VARIATION*4)
 
@@ -152,7 +153,7 @@ class ZMappaT(Sir0Serializable, AutoString):
         return im
 
     def from_pil(self, imgs: List[Image.Image], masks: List[Image.Image]) -> 'ZMappaT':
-        """ Replace the tile data by the new ones passed in argument. """
+        """ Replace the tile/mask data by the new ones passed in argument. """
         if len(imgs)!=ZMAPPAT_NB_VARIATIONS or len(masks)!=ZMAPPAT_NB_VARIATIONS:
             raise ValueError("Tile and masks list must have exactly 3 items")
         new_tiles = []
@@ -172,7 +173,8 @@ class ZMappaT(Sir0Serializable, AutoString):
         self.palette = [x for x in memoryview(imgs[0].palette.palette)]
     
     def from_pil_minimized(self, imgs: List[Image.Image], masks: List[Image.Image]) -> 'ZMappaT':
-        """ Replace the tile data by the new ones passed in argument. """
+        """ Replace the tile/mask data by the new ones passed in argument.
+        This is for the minimized version. """
         if len(imgs)!=ZMAPPAT_NB_VARIATIONS or len(masks)!=ZMAPPAT_NB_VARIATIONS:
             raise ValueError("Tile and masks list must have exactly 3 items")
         new_tiles = []

--- a/skytemple_files/graphics/zmappat/writer.py
+++ b/skytemple_files/graphics/zmappat/writer.py
@@ -1,0 +1,73 @@
+"""Converts Wte models back into the binary format used by the game"""
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Optional
+
+from skytemple_files.common.util import *
+from skytemple_files.graphics.zmappat import *
+from skytemple_files.graphics.zmappat.model import ZMappaT
+
+class ZMappaTWriter:
+    def __init__(self, model: ZMappaT):
+        self.model = model
+
+    def write(self) -> Tuple[bytes, List[int], Optional[int]]:
+        pointer_offsets = []
+        buffer = bytearray()
+
+        # Insert the tiles with their masks
+        tile_table = []
+        for i in range(len(self.model.tiles)):
+            tile_table.append(len(buffer))
+            current_mask = self.model.masks[i]
+            current_tile = self.model.tiles[i]
+            for x in range(ZMAPPAT_TILE_SIZE//8):
+                buffer += current_mask[x*4:x*4+4]+current_tile[x*4:x*4+4]
+                
+
+        # Insert the tile pointers table
+        table = bytearray(len(tile_table)*4)
+        table_pointer = len(buffer)
+        for i, x in enumerate(tile_table):
+            pointer_offsets.append(len(buffer)+i*4)
+            write_uintle(table, x, i*4, 4)
+        buffer += table
+
+        # The palette
+        palette_pointer = len(buffer)
+        palette_buffer = bytearray(len(self.model.palette) * 4 // 3)
+        j = 0
+        for i, p in enumerate(self.model.palette):
+            write_uintle(palette_buffer, p, j)
+            j += 1
+            if i % 3 == 2:
+                # Insert the fourth color
+                write_uintle(palette_buffer, 0, j)
+                j += 1
+        assert j == len(palette_buffer)
+        buffer += palette_buffer
+
+        # The header
+        header_pointer = len(buffer)
+        header = bytearray(0x8)
+        pointer_offsets.append(len(buffer))
+        pointer_offsets.append(len(buffer)+4)
+        write_uintle(header, table_pointer, 0, 4)
+        write_uintle(header, palette_pointer, 4, 4)
+        
+        buffer += header
+        return buffer, pointer_offsets, header_pointer


### PR DESCRIPTION
The zmappat file is entry 1035 in the dungeon bin.
It contains the image tiles data used to render the mini-map in dungeons.
This pull request provides: 
- Support for reading/handling/writing zmappat files.
- Support for exporting zmappat file to image files.
- Support for importing zmappat file from image files.