### PR TITLE
Basic support for monochrome font files

### DIFF
--- a/skytemple_files/common/types/file_types.py
+++ b/skytemple_files/common/types/file_types.py
@@ -62,6 +62,8 @@ from skytemple_files.graphics.wan_wat.handler import WanHandler
 from skytemple_files.graphics.wte.handler import WteHandler
 from skytemple_files.graphics.wtu.handler import WtuHandler
 from skytemple_files.graphics.zmappat.handler import ZMappaTHandler
+from skytemple_files.graphics.fonts.font_dat.handler import FontDatHandler
+from skytemple_files.graphics.fonts.font_sir0.handler import FontSir0Handler
 from skytemple_files.list.actor.handler import ActorListBinHandler
 from skytemple_files.script.lsd.handler import LsdHandler
 from skytemple_files.script.ssa_sse_sss.handler import SsaHandler
@@ -101,6 +103,9 @@ class FileType:
     DMA = DmaHandler
     DBG = DbgHandler
 
+    FONT_DAT = FontDatHandler
+    FONT_SIR0 = FontSir0Handler
+    
     WTE = WteHandler
     WTU = WtuHandler
 

--- a/skytemple_files/graphics/fonts/__init__.py
+++ b/skytemple_files/graphics/fonts/__init__.py
@@ -1,0 +1,36 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+FONT_ENTRY_LEN = 0x1C
+FONT_DEFAULT_BPROW = 2
+
+FONT_SIR0_DATA_LEN = 72
+FONT_SIR0_ENTRY_LEN = 0xC
+FONT_DEFAULT_CAT = 0x02
+FONT_DEFAULT_PADDING = 0xFF
+
+FONT_VALID_TABLES = [0x00, 0x81, 0x82, 0x83, 0x84, 0x87]
+
+XML_FONT = "Font"
+XML_TABLE = "Table"
+XML_TABLE__ID = "tableid"
+XML_CHAR = "Char"
+XML_CHAR__ID = "id"
+XML_CHAR__WIDTH = "width"
+XML_CHAR__BPROW = "bprow"
+XML_CHAR__CAT = "category"
+XML_CHAR__PADDING = "padding"

--- a/skytemple_files/graphics/fonts/__init__.py
+++ b/skytemple_files/graphics/fonts/__init__.py
@@ -15,6 +15,12 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
+from enum import Enum
+
+class FontType(Enum):
+    FONT_DAT = 0x00
+    FONT_SIR0 = 0x01
+
 FONT_ENTRY_LEN = 0x1C
 FONT_DEFAULT_BPROW = 2
 

--- a/skytemple_files/graphics/fonts/abstract.py
+++ b/skytemple_files/graphics/fonts/abstract.py
@@ -1,0 +1,34 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Dict
+
+from abc import ABC, abstractmethod
+from xml.etree.ElementTree import Element
+
+from skytemple_files.common.util import *
+
+class AbstractFont(ABC, AutoString):
+    
+    @abstractmethod
+    def to_pil(self) -> Dict[int, 'Image']:pass
+
+    @abstractmethod
+    def export_to_xml(self) -> Tuple[Element, Dict[int, 'Image']]:pass
+    
+    @abstractmethod
+    def import_from_xml(self, xml: Element, tables: Dict[int, 'Image']):pass

--- a/skytemple_files/graphics/fonts/abstract.py
+++ b/skytemple_files/graphics/fonts/abstract.py
@@ -21,14 +21,48 @@ from abc import ABC, abstractmethod
 from xml.etree.ElementTree import Element
 
 from skytemple_files.common.util import *
+try:
+    from PIL import Image
+except ImportError:
+    from pil import Image
+
+class AbstractFontEntry(AutoString):
+    @classmethod
+    def get_class_properties(cls) -> List[str]:
+        """Returns a list of the properties of this class"""
+    @abstractmethod
+    def get_properties(self) -> Dict[str, int]:
+        """Returns a dictionnary of the properties of the entry"""
+    @abstractmethod
+    def set_properties(self, properties: Dict[str, int]):
+        """Sets a list of the properties of the entry"""
 
 class AbstractFont(ABC, AutoString):
     
     @abstractmethod
-    def to_pil(self) -> Dict[int, 'Image']:pass
-
-    @abstractmethod
-    def export_to_xml(self) -> Tuple[Element, Dict[int, 'Image']]:pass
+    def get_entry_properties(self) -> List[str]:
+        """Gets the properties of entries of this table"""
     
     @abstractmethod
-    def import_from_xml(self, xml: Element, tables: Dict[int, 'Image']):pass
+    def get_entries_from_table(self, table) -> List[AbstractFontEntry]:
+        """Gets all entries of a specific table"""
+        
+    @abstractmethod
+    def delete_entry(self, entry: AbstractFontEntry):
+        """Deletes the specified entry"""
+        
+    @abstractmethod
+    def create_entry_for_table(self, table) -> AbstractFontEntry:
+        """Create an entry for a table"""
+    
+    @abstractmethod
+    def to_pil(self) -> Dict[int, 'Image']:
+        """Returns all tables as a dictionnary of images"""
+
+    @abstractmethod
+    def export_to_xml(self) -> Tuple[Element, Dict[int, 'Image']]:
+        """Exports all entries as xml with tables as a dictionnary of images"""
+    
+    @abstractmethod
+    def import_from_xml(self, xml: Element, tables: Dict[int, 'Image']):
+        """Imports all entries font xml with tables as a dictionnary of images"""

--- a/skytemple_files/graphics/fonts/font_dat/dbg/export_test.py
+++ b/skytemple_files/graphics/fonts/font_dat/dbg/export_test.py
@@ -1,0 +1,42 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+
+from ndspy.rom import NintendoDSRom
+
+from xml.etree.ElementTree import Element, ElementTree
+from skytemple_files.common.xml_util import prettify
+from skytemple_files.common.types.file_types import FileType
+from skytemple_files.common.util import get_files_from_rom_with_extension, get_ppmdu_config_for_rom
+from skytemple_files.graphics.fonts.font_dat.handler import FontDatHandler
+
+base_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', '..')
+out_dir = os.path.join(os.path.dirname(__file__), 'dbg_output')
+os.makedirs(out_dir, exist_ok=True)
+
+rom = NintendoDSRom.fromFile(os.path.join(base_dir, 'skyworkcopy_us.nds'))
+config = get_ppmdu_config_for_rom(rom)
+
+for fn in ["FONT/kanji_rd.dat", "FONT/unkno_rd.dat"]:
+    font = FontDatHandler.deserialize(rom.getFileByName(fn))
+    xml, tables = font.export_to_xml()
+    with open(os.path.join(out_dir, fn.replace('/', '_') + f'.xml'), 'w') as f:
+        f.write(prettify(xml))
+    for i, table in tables.items():
+        table.save(os.path.join(out_dir, fn.replace('/', '_') + f'.{i}.png'))
+    assert font == FontDatHandler.deserialize(FontDatHandler.serialize(font))

--- a/skytemple_files/graphics/fonts/font_dat/dbg/import_test.py
+++ b/skytemple_files/graphics/fonts/font_dat/dbg/import_test.py
@@ -1,0 +1,51 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+
+from ndspy.rom import NintendoDSRom
+
+from xml.etree.ElementTree import Element, ElementTree
+from skytemple_files.common.xml_util import prettify
+from skytemple_files.common.types.file_types import FileType
+from skytemple_files.common.util import get_files_from_rom_with_extension, get_ppmdu_config_for_rom
+from skytemple_files.graphics.fonts.font_dat.handler import FontDatHandler
+
+try:
+    from PIL import Image
+except ImportError:
+    from pil import Image
+
+base_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', '..')
+out_dir = os.path.join(os.path.dirname(__file__), 'dbg_output')
+os.makedirs(out_dir, exist_ok=True)
+
+rom = NintendoDSRom.fromFile(os.path.join(base_dir, 'skyworkcopy_us.nds'))
+
+for fn in ["FONT/kanji_rd.dat", "FONT/unkno_rd.dat"]:
+    font_ref = rom.getFileByName(fn)
+    font = FontDatHandler.deserialize(font_ref)
+    tree = ElementTree()
+    xml = tree.parse(os.path.join(out_dir, fn.replace('/', '_') + f'.xml'))
+    tables = dict()
+    for i in range(256):
+        path = os.path.join(out_dir, fn.replace('/', '_') + f'.{i}.png')
+        if os.path.exists(path):
+            tables[i] = Image.open(path, 'r')
+            
+    font.import_from_xml(xml, tables)
+    assert FontDatHandler.serialize(font)==font_ref

--- a/skytemple_files/graphics/fonts/font_dat/handler.py
+++ b/skytemple_files/graphics/fonts/font_dat/handler.py
@@ -1,0 +1,30 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from skytemple_files.common.types.data_handler import DataHandler
+from skytemple_files.graphics.fonts.font_dat.model import FontDat
+from skytemple_files.graphics.fonts.font_dat.writer import FontDatWriter
+
+
+class FontDatHandler(DataHandler[FontDat]):
+    @classmethod
+    def deserialize(cls, data: bytes, **kwargs) -> FontDat:
+        return FontDat(data)
+
+    @classmethod
+    def serialize(cls, data: FontDat, **kwargs) -> bytes:
+        return FontDatWriter(data).write()

--- a/skytemple_files/graphics/fonts/font_dat/model.py
+++ b/skytemple_files/graphics/fonts/font_dat/model.py
@@ -1,0 +1,152 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Dict
+
+from skytemple_files.common.util import *
+from skytemple_files.graphics.fonts import *
+from skytemple_files.graphics.fonts.abstract import *
+from xml.etree.ElementTree import Element
+from skytemple_files.common.xml_util import validate_xml_tag, XmlValidateError, validate_xml_attribs
+try:
+    from PIL import Image
+except ImportError:
+    from pil import Image
+
+
+
+class FontDatEntry(AutoString):
+    def __init__(self, char: int, table: int, width: int, bprow: int, data: bytes):
+        self.char = char
+        self.table = table
+        self.width = width
+        self.bprow = bprow # bytes per row; never checked by the game
+        self.data = data
+
+    def to_pil(self) -> Image:
+        data = []
+        for i in range(len(self.data)//self.bprow):
+            pos = 0
+            for j in range(self.bprow):
+                v = self.data[i*self.bprow+j]
+                for x in range(8):
+                    if pos<12:
+                        if v&(2**x):
+                            data.append(0xf)
+                        else:
+                            data.append(0x0)
+                    pos += 1
+        image = Image.frombytes(mode='P', size=(12,12), data=bytes(data))
+        return image
+
+    def to_xml(self) -> Element:
+        attrs = {
+                XML_CHAR__ID: str(self.char),
+                XML_CHAR__WIDTH: str(self.width)
+        }
+        if self.bprow!=FONT_DEFAULT_BPROW:
+            attrs[XML_CHAR__BPROW] = str(self.bprow)
+        xml_entry = Element(XML_CHAR, attrs)
+        return xml_entry
+    
+    @classmethod
+    def from_pil(cls, img: Image, char: int, table: int, width: int, bprow: int) -> 'FontDatEntry':
+        if img.mode!='P':
+            raise AttributeError("This must be a color indexed image!")
+        data = []
+        raw_data = img.tobytes("raw", "P")
+        for i in range(12):
+            data += [0]*bprow
+            for j in range(12):
+                v = raw_data[i*12+j]
+                pos = -bprow + j//8
+                if v:
+                    data[pos] = data[pos]|(2**(j%8))
+        return FontDatEntry(char, table, width, bprow, bytes(data))
+    
+    def __eq__(self, other):
+        if not isinstance(other, FontDatEntry):
+            return False
+        return self.char == other.char and \
+               self.table == other.table and \
+               self.width == other.width and \
+               self.data == other.data
+
+
+class FontDat(AbstractFont):
+    def __init__(self, data: bytes):
+        if not isinstance(data, memoryview):
+            data = memoryview(data)
+        number_entries = read_uintle(data, 0, 4)
+
+        self.entries = []
+        for i in range(4, 4 + number_entries * FONT_ENTRY_LEN, FONT_ENTRY_LEN):
+            self.entries.append(FontDatEntry(
+                read_uintle(data, i + 0x00),
+                read_uintle(data, i + 0x01),
+                read_uintle(data, i + 0x02),
+                read_uintle(data, i + 0x03),
+                data[i + 0x4:i + FONT_ENTRY_LEN]
+            ))
+    def to_pil(self) -> Dict[int, 'Image']:
+        tables = dict()
+        for t in FONT_VALID_TABLES:
+            tables[t] = Image.new(mode='P', size=(12*16, 12*16), color=0)
+            tables[t].putpalette([min(255, 256-(i//3)*16) for i in range(16*3)])
+        for item in self.entries:
+            if item.table in FONT_VALID_TABLES:
+                tables[item.table].paste(item.to_pil(), box=((item.char%16)*12, (item.char//16)*12))
+        return tables
+
+    def export_to_xml(self) -> Tuple[Element, Dict[int, 'Image']]:
+        font_xml = Element(XML_FONT)
+        
+        tables = dict()
+        for t in FONT_VALID_TABLES:
+            tables[t] = Element(XML_TABLE, {
+                XML_TABLE__ID: str(t)
+            })
+            font_xml.append(tables[t])
+        for item in self.entries:
+            if item.table in FONT_VALID_TABLES:
+                xml_char = item.to_xml()
+                validate_xml_tag(xml_char, XML_CHAR)
+                tables[item.table].append(xml_char)
+        return font_xml, self.to_pil()
+    
+    def import_from_xml(self, xml: Element, tables: Dict[int, 'Image']):
+        self.entries = []
+        validate_xml_tag(xml, XML_FONT)
+        for child in xml:
+            validate_xml_tag(child, XML_TABLE)
+            validate_xml_attribs(child, [XML_TABLE__ID])
+            t = int(child.get(XML_TABLE__ID))
+            if t in FONT_VALID_TABLES and t in tables:
+                for char in child:
+                    validate_xml_tag(char, XML_CHAR)
+                    validate_xml_attribs(char, [XML_CHAR__ID, XML_CHAR__WIDTH])
+                    charid = int(char.get(XML_CHAR__ID))
+                    width = int(char.get(XML_CHAR__WIDTH))
+                    bprow = int(char.get(XML_CHAR__BPROW, default=FONT_DEFAULT_BPROW))
+                    x = (charid%16)*12
+                    y = (charid//16)*12
+                    self.entries.append(FontDatEntry.from_pil(tables[t].crop(box=[x, y, x+12, y+12]), charid, t, width, bprow))
+        pass
+    def __eq__(self, other):
+        if not isinstance(other, FontDat):
+            return False
+        return self.entries == other.entries

--- a/skytemple_files/graphics/fonts/font_dat/writer.py
+++ b/skytemple_files/graphics/fonts/font_dat/writer.py
@@ -28,8 +28,13 @@ class FontDatWriter:
     def write(self) -> bytes:
         buffer = bytearray(FONT_ENTRY_LEN * len(self.model.entries))
         write_uintle(buffer, len(self.model.entries), 0x00, 4)
-        
-        for i, e in enumerate(self.model.entries):
+
+        # Font Data
+        last = (None, None)
+        for i, e in enumerate(sorted(self.model.entries, key=lambda x:(x.table, x.char))):
+            if last==(e.char, e.table):
+                raise ValueError("Character {e.char} in table {e.table} is be defined multiple times in a font file!")
+            last = (e.char, e.table)
             off_start = 0x4 + (i * FONT_ENTRY_LEN)
             write_uintle(buffer, e.char, off_start + 0x00)
             write_uintle(buffer, e.table, off_start + 0x01)

--- a/skytemple_files/graphics/fonts/font_dat/writer.py
+++ b/skytemple_files/graphics/fonts/font_dat/writer.py
@@ -1,0 +1,40 @@
+"""Converts FontDat models back into the binary format used by the game"""
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from skytemple_files.common.util import *
+from skytemple_files.graphics.fonts import *
+from skytemple_files.graphics.fonts.font_dat.model import FontDat
+
+
+class FontDatWriter:
+    def __init__(self, model: FontDat):
+        self.model = model
+
+    def write(self) -> bytes:
+        buffer = bytearray(FONT_ENTRY_LEN * len(self.model.entries))
+        write_uintle(buffer, len(self.model.entries), 0x00, 4)
+        
+        for i, e in enumerate(self.model.entries):
+            off_start = 0x4 + (i * FONT_ENTRY_LEN)
+            write_uintle(buffer, e.char, off_start + 0x00)
+            write_uintle(buffer, e.table, off_start + 0x01)
+            write_uintle(buffer, e.width, off_start + 0x02)
+            write_uintle(buffer, e.bprow, off_start + 0x03)
+            buffer[off_start + 0x04:off_start + FONT_ENTRY_LEN] = e.data
+
+        return buffer

--- a/skytemple_files/graphics/fonts/font_sir0/dbg/export_test.py
+++ b/skytemple_files/graphics/fonts/font_sir0/dbg/export_test.py
@@ -1,0 +1,42 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+
+from ndspy.rom import NintendoDSRom
+
+from xml.etree.ElementTree import Element, ElementTree
+from skytemple_files.common.xml_util import prettify
+from skytemple_files.common.types.file_types import FileType
+from skytemple_files.common.util import get_files_from_rom_with_extension, get_ppmdu_config_for_rom
+from skytemple_files.graphics.fonts.font_sir0.handler import FontSir0Handler
+
+base_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', '..')
+out_dir = os.path.join(os.path.dirname(__file__), 'dbg_output')
+os.makedirs(out_dir, exist_ok=True)
+
+rom = NintendoDSRom.fromFile(os.path.join(base_dir, 'skyworkcopy_us.nds'))
+config = get_ppmdu_config_for_rom(rom)
+
+for fn in ["FONT/kanji.dat", "FONT/kanji_b.dat", "FONT/unknown.dat"]: 
+    font = FontSir0Handler.deserialize(rom.getFileByName(fn))
+    xml, tables = font.export_to_xml()
+    with open(os.path.join(out_dir, fn.replace('/', '_') + f'.xml'), 'w') as f:
+        f.write(prettify(xml))
+    for i, table in tables.items():
+        table.save(os.path.join(out_dir, fn.replace('/', '_') + f'.{i}.png'))
+    assert font == FontSir0Handler.deserialize(FontSir0Handler.serialize(font))

--- a/skytemple_files/graphics/fonts/font_sir0/dbg/import_test.py
+++ b/skytemple_files/graphics/fonts/font_sir0/dbg/import_test.py
@@ -1,0 +1,51 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+
+from ndspy.rom import NintendoDSRom
+
+from xml.etree.ElementTree import Element, ElementTree
+from skytemple_files.common.xml_util import prettify
+from skytemple_files.common.types.file_types import FileType
+from skytemple_files.common.util import get_files_from_rom_with_extension, get_ppmdu_config_for_rom
+from skytemple_files.graphics.fonts.font_sir0.handler import FontSir0Handler
+
+try:
+    from PIL import Image
+except ImportError:
+    from pil import Image
+
+base_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', '..')
+out_dir = os.path.join(os.path.dirname(__file__), 'dbg_output')
+os.makedirs(out_dir, exist_ok=True)
+
+rom = NintendoDSRom.fromFile(os.path.join(base_dir, 'skyworkcopy_us.nds'))
+
+for fn in ["FONT/kanji.dat", "FONT/kanji_b.dat", "FONT/unknown.dat"]:
+    font_ref = rom.getFileByName(fn)
+    font = FontSir0Handler.deserialize(font_ref)
+    tree = ElementTree()
+    xml = tree.parse(os.path.join(out_dir, fn.replace('/', '_') + f'.xml'))
+    tables = dict()
+    for i in range(256):
+        path = os.path.join(out_dir, fn.replace('/', '_') + f'.{i}.png')
+        if os.path.exists(path):
+            tables[i] = Image.open(path, 'r')
+            
+    font.import_from_xml(xml, tables)
+    assert FontSir0Handler.serialize(font)==font_ref

--- a/skytemple_files/graphics/fonts/font_sir0/handler.py
+++ b/skytemple_files/graphics/fonts/font_sir0/handler.py
@@ -1,0 +1,32 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from skytemple_files.common.types.data_handler import DataHandler
+from skytemple_files.graphics.fonts.font_sir0.model import FontSir0
+from skytemple_files.graphics.fonts.font_sir0.writer import FontSir0Writer
+
+
+class FontSir0Handler(DataHandler[FontSir0]):
+    @classmethod
+    def deserialize(cls, data: bytes, **kwargs) -> 'FontSir0':
+        from skytemple_files.common.types.file_types import FileType
+        return FileType.SIR0.unwrap_obj(FileType.SIR0.deserialize(data), FontSir0)
+
+    @classmethod
+    def serialize(cls, data: 'FontSir0', **kwargs) -> bytes:
+        from skytemple_files.common.types.file_types import FileType
+        return FileType.SIR0.serialize(FileType.SIR0.wrap_obj(data))

--- a/skytemple_files/graphics/fonts/font_sir0/model.py
+++ b/skytemple_files/graphics/fonts/font_sir0/model.py
@@ -1,0 +1,157 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Dict, Optional
+
+from skytemple_files.common.util import *
+from skytemple_files.graphics.fonts import *
+from skytemple_files.graphics.fonts.abstract import AbstractFont
+from xml.etree.ElementTree import Element
+from skytemple_files.common.xml_util import validate_xml_tag, XmlValidateError, validate_xml_attribs
+from skytemple_files.common.ppmdu_config.data import Pmd2Data
+from skytemple_files.container.sir0.sir0_serializable import Sir0Serializable
+try:
+    from PIL import Image
+except ImportError:
+    from pil import Image
+
+
+
+class FontSir0Entry(AutoString):
+    def __init__(self, char: int, table: int, width: int, cat: int, padding: int, data: bytes):
+        self.char = char
+        self.table = table
+        self.width = width
+        self.cat = cat
+        self.padding = padding
+        self.data = data
+
+    def to_pil(self) -> Image:
+        data = b''.join([bytes([v%16, v//16]) for v in self.data])
+        image = Image.frombytes(mode='P', size=(12,12), data=data)
+        return image
+
+    def to_xml(self) -> Element:
+        attrs = {XML_CHAR__ID: str(self.char),
+                XML_CHAR__WIDTH: str(self.width)}
+        if self.cat!=FONT_DEFAULT_CAT:
+            attrs[XML_CHAR__CAT] = str(self.cat)
+        if self.padding!=FONT_DEFAULT_PADDING:
+            attrs[XML_CHAR__PADDING] = str(self.padding)
+        xml_entry = Element(XML_CHAR, attrs)
+        return xml_entry
+    
+    @classmethod
+    def from_pil(cls, img: Image, char: int, table: int, width: int, cat: int, padding: int) -> 'FontSir0Entry':
+        if img.mode!='P':
+            raise AttributeError("This must be a color indexed image!")
+        data = []
+        raw_data = img.tobytes("raw", "P")
+        for i in range(FONT_SIR0_DATA_LEN):
+            v = 0
+            for j in range(2):
+                v += raw_data[i*2+j]*(16**j)
+            data.append(v)
+        return FontSir0Entry(char, table, width, cat, padding, bytes(data))
+    
+    def __eq__(self, other):
+        if not isinstance(other, FontSir0Entry):
+            return False
+        return self.char == other.char and \
+               self.table == other.table and \
+               self.width == other.width and \
+               self.data == other.data
+
+
+class FontSir0(Sir0Serializable, AbstractFont):
+    def __init__(self, data: Optional[bytes], header_pnt: int):
+        if not isinstance(data, memoryview):
+            data = memoryview(data)
+        number_entries = read_uintle(data, header_pnt, 4)
+        pt_entries = read_uintle(data, header_pnt+0x4, 4)
+        
+        self.entries = []
+        for i in range(pt_entries, pt_entries + number_entries * FONT_SIR0_ENTRY_LEN, FONT_SIR0_ENTRY_LEN):
+            pt_data = read_uintle(data, i + 0x00, 4)
+            
+            self.entries.append(FontSir0Entry(
+                read_uintle(data, i + 0x04),
+                read_uintle(data, i + 0x05),
+                read_uintle(data, i + 0x06, 4),
+                read_uintle(data, i + 0x0A),
+                read_uintle(data, i + 0x0B),
+                data[pt_data:pt_data + FONT_SIR0_DATA_LEN]
+            ))
+    
+    @classmethod
+    def sir0_unwrap(cls, content_data: bytes, data_pointer: int,
+                    static_data: Optional[Pmd2Data] = None) -> 'Sir0Serializable':
+        return cls(content_data, data_pointer)
+
+    def sir0_serialize_parts(self) -> Tuple[bytes, List[int], Optional[int]]:
+        from skytemple_files.graphics.fonts.font_sir0.writer import FontSir0Writer
+        return FontSir0Writer(self).write()
+    
+    def to_pil(self) -> Dict[int, 'Image']:
+        tables = dict()
+        for t in FONT_VALID_TABLES:
+            tables[t] = Image.new(mode='P', size=(12*16, 12*16), color=0)
+            tables[t].putpalette([min(255, 256-(i//3)*16) for i in range(16*3)])
+        for item in self.entries:
+            if item.table in FONT_VALID_TABLES:
+                tables[item.table].paste(item.to_pil(), box=((item.char%16)*12, (item.char//16)*12))
+        return tables
+
+    def export_to_xml(self) -> Tuple[Element, Dict[int, 'Image']]:
+        font_xml = Element(XML_FONT)
+        
+        tables = dict()
+        for t in FONT_VALID_TABLES:
+            tables[t] = Element(XML_TABLE, {
+                XML_TABLE__ID: str(t)
+            })
+            font_xml.append(tables[t])
+        for item in self.entries:
+            if item.table in FONT_VALID_TABLES:
+                xml_char = item.to_xml()
+                validate_xml_tag(xml_char, XML_CHAR)
+                tables[item.table].append(xml_char)
+        return font_xml, self.to_pil()
+    
+    def import_from_xml(self, xml: Element, tables: Dict[int, 'Image']):
+        self.entries = []
+        validate_xml_tag(xml, XML_FONT)
+        for child in xml:
+            validate_xml_tag(child, XML_TABLE)
+            validate_xml_attribs(child, [XML_TABLE__ID])
+            t = int(child.get(XML_TABLE__ID))
+            if t in FONT_VALID_TABLES and t in tables:
+                for char in child:
+                    validate_xml_tag(char, XML_CHAR)
+                    validate_xml_attribs(char, [XML_CHAR__ID, XML_CHAR__WIDTH])
+                    charid = int(char.get(XML_CHAR__ID))
+                    width = int(char.get(XML_CHAR__WIDTH))
+                    cat = int(char.get(XML_CHAR__CAT, default=FONT_DEFAULT_CAT))
+                    padding = int(char.get(XML_CHAR__PADDING, default=FONT_DEFAULT_PADDING))
+                    x = (charid%16)*12
+                    y = (charid//16)*12
+                    self.entries.append(FontSir0Entry.from_pil(tables[t].crop(box=[x, y, x+12, y+12]), charid, t, width, cat, padding))
+        pass
+    def __eq__(self, other):
+        if not isinstance(other, FontSir0):
+            return False
+        return self.entries == other.entries

--- a/skytemple_files/graphics/fonts/font_sir0/writer.py
+++ b/skytemple_files/graphics/fonts/font_sir0/writer.py
@@ -1,0 +1,61 @@
+"""Converts FontSir0 models back into the binary format used by the game"""
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Optional
+
+from skytemple_files.common.util import *
+from skytemple_files.graphics.fonts import *
+from skytemple_files.graphics.fonts.font_sir0.model import FontSir0
+
+
+class FontSir0Writer:
+    def __init__(self, model: FontSir0):
+        self.model = model
+
+    def write(self) -> Tuple[bytes, List[int], Optional[int]]:
+        pointer_offsets = []
+        
+        buffer = bytearray()
+        # Image data
+        for i, e in enumerate(self.model.entries):
+            buffer += e.data
+
+        if len(buffer)%16!=0:
+            buffer += bytearray([0xAA] * (16 - len(buffer)%16))
+        # Character pointers
+        char_pointer = bytearray(len(self.model.entries) * FONT_SIR0_ENTRY_LEN)
+        char_pointer_offset = len(buffer)
+        for i, e in enumerate(self.model.entries):
+            pointer_offsets.append(len(buffer)+i * FONT_SIR0_ENTRY_LEN)
+            write_uintle(char_pointer, i * FONT_SIR0_DATA_LEN, i * FONT_SIR0_ENTRY_LEN, 4)
+            write_uintle(char_pointer, e.char, i * FONT_SIR0_ENTRY_LEN + 0x4)
+            write_uintle(char_pointer, e.table, i * FONT_SIR0_ENTRY_LEN + 0x5)
+            write_uintle(char_pointer, e.width, i * FONT_SIR0_ENTRY_LEN + 0x6, 4)
+            write_uintle(char_pointer, e.cat, i * FONT_SIR0_ENTRY_LEN + 0xA)
+            write_uintle(char_pointer, e.padding, i * FONT_SIR0_ENTRY_LEN + 0xB)
+        buffer += char_pointer
+        
+        # Header
+        header = bytearray(0x8)
+        write_uintle(header, len(self.model.entries), 0, 4)
+        pointer_offsets.append(len(buffer)+4)
+        write_uintle(header, char_pointer_offset, 0x4, 4)
+
+        header_pointer = len(buffer)
+        buffer += header
+
+        return buffer, pointer_offsets, header_pointer


### PR DESCRIPTION
This adds basic support for editing raw data (files with "rd" at the end; only present and used in EU and US versions) and sir0 (present in all versions but only used in JP version) monochrome font files, including:
 - reading, editing and writing files of those types;
 - importing and exporting fonts as xml + image files; note that both font file types use the same format for importing and exporting, which make them nearly compatible (there are some properties that aren't the same in each, but default values are provided if they don't exist in the xml file).