### PR TITLE
Add support to edit graphic fonts

### DIFF
--- a/skytemple_files/common/types/file_types.py
+++ b/skytemple_files/common/types/file_types.py
@@ -64,6 +64,8 @@ from skytemple_files.graphics.wtu.handler import WtuHandler
 from skytemple_files.graphics.zmappat.handler import ZMappaTHandler
 from skytemple_files.graphics.fonts.font_dat.handler import FontDatHandler
 from skytemple_files.graphics.fonts.font_sir0.handler import FontSir0Handler
+from skytemple_files.graphics.fonts.graphic_font.handler import GraphicFontHandler
+from skytemple_files.graphics.pal.handler import PalHandler
 from skytemple_files.list.actor.handler import ActorListBinHandler
 from skytemple_files.script.lsd.handler import LsdHandler
 from skytemple_files.script.ssa_sse_sss.handler import SsaHandler
@@ -105,6 +107,7 @@ class FileType:
 
     FONT_DAT = FontDatHandler
     FONT_SIR0 = FontSir0Handler
+    GRAPHIC_FONT = GraphicFontHandler
     
     WTE = WteHandler
     WTU = WtuHandler
@@ -120,6 +123,8 @@ class FileType:
     SSE = SsaHandler
     SSS = SsaHandler
     SSB = SsbHandler
+    
+    PAL = PalHandler
 
     SIR0 = Sir0Handler
     BIN_PACK = BinPackHandler

--- a/skytemple_files/graphics/fonts/abstract.py
+++ b/skytemple_files/graphics/fonts/abstract.py
@@ -56,13 +56,13 @@ class AbstractFont(ABC, AutoString):
         """Create an entry for a table"""
     
     @abstractmethod
-    def to_pil(self) -> Dict[int, 'Image']:
+    def to_pil(self) -> Dict[int, Image.Image]:
         """Returns all tables as a dictionnary of images"""
 
     @abstractmethod
-    def export_to_xml(self) -> Tuple[Element, Dict[int, 'Image']]:
+    def export_to_xml(self) -> Tuple[Element, Dict[int, Image.Image]]:
         """Exports all entries as xml with tables as a dictionnary of images"""
     
     @abstractmethod
-    def import_from_xml(self, xml: Element, tables: Dict[int, 'Image']):
+    def import_from_xml(self, xml: Element, tables: Dict[int, Image.Image]):
         """Imports all entries font xml with tables as a dictionnary of images"""

--- a/skytemple_files/graphics/fonts/font_dat/__init__.py
+++ b/skytemple_files/graphics/fonts/font_dat/__init__.py
@@ -15,28 +15,4 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
-from enum import Enum
-
-class FontType(Enum):
-    FONT_DAT = 0x00
-    FONT_SIR0 = 0x01
-
-FONT_ENTRY_LEN = 0x1C
-FONT_DEFAULT_BPROW = 2
-
-FONT_SIR0_DATA_LEN = 72
-FONT_SIR0_ENTRY_LEN = 0xC
-FONT_DEFAULT_CAT = 0x02
-FONT_DEFAULT_PADDING = 0xFF
-
-FONT_VALID_TABLES = [0x00, 0x81, 0x82, 0x83, 0x84, 0x87]
-
-XML_FONT = "Font"
-XML_TABLE = "Table"
-XML_TABLE__ID = "tableid"
-XML_CHAR = "Char"
-XML_CHAR__ID = "id"
-XML_CHAR__WIDTH = "width"
-XML_CHAR__BPROW = "bprow"
-XML_CHAR__CAT = "category"
-XML_CHAR__PADDING = "padding"
+FONT_DAT_ENTRY_LEN = 0x1C

--- a/skytemple_files/graphics/fonts/font_dat/writer.py
+++ b/skytemple_files/graphics/fonts/font_dat/writer.py
@@ -18,6 +18,7 @@
 
 from skytemple_files.common.util import *
 from skytemple_files.graphics.fonts import *
+from skytemple_files.graphics.fonts.font_dat import *
 from skytemple_files.graphics.fonts.font_dat.model import FontDat
 
 
@@ -26,7 +27,7 @@ class FontDatWriter:
         self.model = model
 
     def write(self) -> bytes:
-        buffer = bytearray(FONT_ENTRY_LEN * len(self.model.entries))
+        buffer = bytearray(FONT_DAT_ENTRY_LEN * len(self.model.entries))
         write_uintle(buffer, len(self.model.entries), 0x00, 4)
 
         # Font Data
@@ -35,11 +36,11 @@ class FontDatWriter:
             if last==(e.char, e.table):
                 raise ValueError("Character {e.char} in table {e.table} is be defined multiple times in a font file!")
             last = (e.char, e.table)
-            off_start = 0x4 + (i * FONT_ENTRY_LEN)
+            off_start = 0x4 + (i * FONT_DAT_ENTRY_LEN)
             write_uintle(buffer, e.char, off_start + 0x00)
             write_uintle(buffer, e.table, off_start + 0x01)
             write_uintle(buffer, e.width, off_start + 0x02)
             write_uintle(buffer, e.bprow, off_start + 0x03)
-            buffer[off_start + 0x04:off_start + FONT_ENTRY_LEN] = e.data
+            buffer[off_start + 0x04:off_start + FONT_DAT_ENTRY_LEN] = e.data
 
         return buffer

--- a/skytemple_files/graphics/fonts/font_sir0/__init__.py
+++ b/skytemple_files/graphics/fonts/font_sir0/__init__.py
@@ -15,28 +15,5 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
-from enum import Enum
-
-class FontType(Enum):
-    FONT_DAT = 0x00
-    FONT_SIR0 = 0x01
-
-FONT_ENTRY_LEN = 0x1C
-FONT_DEFAULT_BPROW = 2
-
 FONT_SIR0_DATA_LEN = 72
 FONT_SIR0_ENTRY_LEN = 0xC
-FONT_DEFAULT_CAT = 0x02
-FONT_DEFAULT_PADDING = 0xFF
-
-FONT_VALID_TABLES = [0x00, 0x81, 0x82, 0x83, 0x84, 0x87]
-
-XML_FONT = "Font"
-XML_TABLE = "Table"
-XML_TABLE__ID = "tableid"
-XML_CHAR = "Char"
-XML_CHAR__ID = "id"
-XML_CHAR__WIDTH = "width"
-XML_CHAR__BPROW = "bprow"
-XML_CHAR__CAT = "category"
-XML_CHAR__PADDING = "padding"

--- a/skytemple_files/graphics/fonts/font_sir0/writer.py
+++ b/skytemple_files/graphics/fonts/font_sir0/writer.py
@@ -19,6 +19,7 @@ from typing import Optional
 
 from skytemple_files.common.util import *
 from skytemple_files.graphics.fonts import *
+from skytemple_files.graphics.fonts.font_sir0 import *
 from skytemple_files.graphics.fonts.font_sir0.model import FontSir0
 
 

--- a/skytemple_files/graphics/fonts/graphic_font/__init__.py
+++ b/skytemple_files/graphics/fonts/graphic_font/__init__.py
@@ -15,25 +15,4 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
-from enum import Enum
-
-class FontType(Enum):
-    FONT_DAT = 0x00
-    FONT_SIR0 = 0x01
-    GRAPHIC_FONT = 0x02
-
-FONT_DEFAULT_BPROW = 2
-FONT_DEFAULT_CAT = 0x02
-FONT_DEFAULT_PADDING = 0xFF
-
-FONT_VALID_TABLES = [0x00, 0x81, 0x82, 0x83, 0x84, 0x87]
-
-XML_FONT = "Font"
-XML_TABLE = "Table"
-XML_TABLE__ID = "tableid"
-XML_CHAR = "Char"
-XML_CHAR__ID = "id"
-XML_CHAR__WIDTH = "width"
-XML_CHAR__BPROW = "bprow"
-XML_CHAR__CAT = "category"
-XML_CHAR__PADDING = "padding"
+GRAPHIC_FONT_ENTRY_LEN = 0x4

--- a/skytemple_files/graphics/fonts/graphic_font/dbg/export_test.py
+++ b/skytemple_files/graphics/fonts/graphic_font/dbg/export_test.py
@@ -1,0 +1,42 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.types.file_types import FileType
+from skytemple_files.common.util import get_files_from_rom_with_extension, get_ppmdu_config_for_rom
+from skytemple_files.graphics.fonts.graphic_font.handler import GraphicFontHandler
+from skytemple_files.graphics.pal.handler import PalHandler
+
+base_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', '..')
+out_dir = os.path.join(os.path.dirname(__file__), 'dbg_output')
+os.makedirs(out_dir, exist_ok=True)
+
+rom = NintendoDSRom.fromFile(os.path.join(base_dir, 'skyworkcopy_us.nds'))
+config = get_ppmdu_config_for_rom(rom)
+
+for fn in ["FONT/staffont", "FONT/markfont"]:
+    font = GraphicFontHandler.deserialize(rom.getFileByName(fn+".dat"))
+    pal = PalHandler.deserialize(rom.getFileByName(fn+".pal"))
+    font.set_palette(pal)
+    for i in range(font.get_nb_entries()):
+        e = font.get_entry(i)
+        if e:
+            e.save(os.path.join(out_dir, fn.replace('/', '_') + f'_{i:0>4}.png'))
+    assert rom.getFileByName(fn+".dat") == GraphicFontHandler.serialize(font)

--- a/skytemple_files/graphics/fonts/graphic_font/dbg/import_test.py
+++ b/skytemple_files/graphics/fonts/graphic_font/dbg/import_test.py
@@ -1,0 +1,52 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.types.file_types import FileType
+from skytemple_files.common.util import get_files_from_rom_with_extension, get_ppmdu_config_for_rom
+from skytemple_files.graphics.fonts.graphic_font.handler import GraphicFontHandler
+from skytemple_files.graphics.pal.handler import PalHandler
+
+try:
+    from PIL import Image
+except ImportError:
+    from pil import Image
+
+base_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', '..')
+out_dir = os.path.join(os.path.dirname(__file__), 'dbg_output')
+os.makedirs(out_dir, exist_ok=True)
+
+rom = NintendoDSRom.fromFile(os.path.join(base_dir, 'skyworkcopy_us.nds'))
+
+for fn in ["FONT/staffont", "FONT/markfont"]:
+    font_ref = rom.getFileByName(fn+".dat")
+    font = GraphicFontHandler.deserialize(font_ref)
+    pal_ref = rom.getFileByName(fn+".pal")
+    pal = PalHandler.deserialize(pal_ref)
+    font.set_palette(pal)
+    lst_entries = []
+    for i in range(font.get_nb_entries()):
+        path = os.path.join(out_dir, fn.replace('/', '_') + f'_{i:0>4}.png')
+        if os.path.exists(path):
+            lst_entries.append(Image.open(path, 'r'))
+        else:
+            lst_entries.append(None)
+    font.set_entries(lst_entries)
+    assert GraphicFontHandler.serialize(font)==font_ref

--- a/skytemple_files/graphics/fonts/graphic_font/handler.py
+++ b/skytemple_files/graphics/fonts/graphic_font/handler.py
@@ -15,25 +15,16 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
-from enum import Enum
+from skytemple_files.common.types.data_handler import DataHandler
+from skytemple_files.graphics.fonts.graphic_font.model import GraphicFont
+from skytemple_files.graphics.fonts.graphic_font.writer import GraphicFontWriter
 
-class FontType(Enum):
-    FONT_DAT = 0x00
-    FONT_SIR0 = 0x01
-    GRAPHIC_FONT = 0x02
 
-FONT_DEFAULT_BPROW = 2
-FONT_DEFAULT_CAT = 0x02
-FONT_DEFAULT_PADDING = 0xFF
+class GraphicFontHandler(DataHandler[GraphicFont]):
+    @classmethod
+    def deserialize(cls, data: bytes, **kwargs) -> GraphicFont:
+        return GraphicFont(data)
 
-FONT_VALID_TABLES = [0x00, 0x81, 0x82, 0x83, 0x84, 0x87]
-
-XML_FONT = "Font"
-XML_TABLE = "Table"
-XML_TABLE__ID = "tableid"
-XML_CHAR = "Char"
-XML_CHAR__ID = "id"
-XML_CHAR__WIDTH = "width"
-XML_CHAR__BPROW = "bprow"
-XML_CHAR__CAT = "category"
-XML_CHAR__PADDING = "padding"
+    @classmethod
+    def serialize(cls, data: GraphicFont, **kwargs) -> bytes:
+        return GraphicFontWriter(data).write()

--- a/skytemple_files/graphics/fonts/graphic_font/model.py
+++ b/skytemple_files/graphics/fonts/graphic_font/model.py
@@ -1,0 +1,80 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Optional
+
+from skytemple_files.common.util import *
+from skytemple_files.graphics.fonts.graphic_font import *
+from skytemple_files.graphics.pal.model import Pal
+
+try:
+    from PIL import Image
+except ImportError:
+    from pil import Image
+
+class GraphicFont(AutoString):
+    def __init__(self, data: bytes):
+        if not isinstance(data, memoryview):
+            data = memoryview(data)
+        number_entries = read_uintle(data, 0x02, 2)//GRAPHIC_FONT_ENTRY_LEN
+
+        self.palette = None
+        self.entries: List[Optional[Image.Image]] = []
+        for i in range(0, number_entries * GRAPHIC_FONT_ENTRY_LEN, GRAPHIC_FONT_ENTRY_LEN):
+            width = read_uintle(data, i + 0x00)
+            height = read_uintle(data, i + 0x01)
+            offset = read_uintle(data, i + 0x02, 2)
+            if width>0 or height>0:
+                data_raw = data[offset:offset+width*height]
+                self.entries.append(Image.frombytes(mode='P', size=(width,height), data=bytes(data_raw)))
+            else:
+                self.entries.append(None)
+        
+    def set_palette(self, palette: Pal):
+        self.palette = palette
+        
+    def get_palette_raw(self) -> List[int]:
+        if self.palette:
+            return [0,0,255]*(0x80)+self.palette.get_palette_4bpc()[:0x80*3]
+        else:
+            return [0,0,255]*(0x80)+[(i//3)%16*16+(i//3)//16 for i in range(0x80*3)]
+    
+    def set_palette_raw(self, data: List[int]):
+        if self.palette:
+            self.palette.set_palette_4bpc(data[0x80*3:])
+    
+    def get_nb_entries(self) -> int:
+        return len(self.entries)
+    
+    def get_entry(self, index) -> Image.Image:
+        entry = self.entries[index]
+        if entry:
+            entry = entry.convert(mode="P")
+            entry.putpalette(self.get_palette_raw())
+        return entry
+    def set_entries(self, entries: List[Optional[Image.Image]]):
+        self.entries = entries
+        for e in entries:
+            if e:
+                self.set_palette_raw(list(e.palette.palette))
+                break
+    
+    def __eq__(self, other):
+        if not isinstance(other, GraphicFont):
+            return False
+        return self.entries == other.entries and \
+               self.palette == other.palette

--- a/skytemple_files/graphics/fonts/graphic_font/writer.py
+++ b/skytemple_files/graphics/fonts/graphic_font/writer.py
@@ -1,0 +1,43 @@
+"""Converts GraphicFont models back into the binary format used by the game"""
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from skytemple_files.common.util import *
+from skytemple_files.graphics.fonts import *
+from skytemple_files.graphics.fonts.graphic_font import *
+from skytemple_files.graphics.fonts.graphic_font.model import GraphicFont
+
+
+class GraphicFontWriter:
+    def __init__(self, model: GraphicFont):
+        self.model = model
+
+    def write(self) -> bytes:
+        buffer = bytearray(GRAPHIC_FONT_ENTRY_LEN * len(self.model.entries))
+        
+        # Font Data
+        for i, e in enumerate(self.model.entries):
+            if e:
+                write_uintle(buffer, e.width, i*GRAPHIC_FONT_ENTRY_LEN+0x00)
+                write_uintle(buffer, e.height, i*GRAPHIC_FONT_ENTRY_LEN+0x01)
+                write_uintle(buffer, len(buffer), i*GRAPHIC_FONT_ENTRY_LEN+0x02, 2)
+                data_raw = e.tobytes("raw", "P")
+                buffer += bytearray(data_raw)
+            else:
+                write_uintle(buffer, 0xffff0000, i*GRAPHIC_FONT_ENTRY_LEN+0x00, 4)
+
+        return buffer

--- a/skytemple_files/graphics/pal/__init__.py
+++ b/skytemple_files/graphics/pal/__init__.py
@@ -15,25 +15,3 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
-from enum import Enum
-
-class FontType(Enum):
-    FONT_DAT = 0x00
-    FONT_SIR0 = 0x01
-    GRAPHIC_FONT = 0x02
-
-FONT_DEFAULT_BPROW = 2
-FONT_DEFAULT_CAT = 0x02
-FONT_DEFAULT_PADDING = 0xFF
-
-FONT_VALID_TABLES = [0x00, 0x81, 0x82, 0x83, 0x84, 0x87]
-
-XML_FONT = "Font"
-XML_TABLE = "Table"
-XML_TABLE__ID = "tableid"
-XML_CHAR = "Char"
-XML_CHAR__ID = "id"
-XML_CHAR__WIDTH = "width"
-XML_CHAR__BPROW = "bprow"
-XML_CHAR__CAT = "category"
-XML_CHAR__PADDING = "padding"

--- a/skytemple_files/graphics/pal/handler.py
+++ b/skytemple_files/graphics/pal/handler.py
@@ -15,25 +15,16 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
-from enum import Enum
+from skytemple_files.common.types.data_handler import DataHandler
+from skytemple_files.graphics.pal.model import Pal
+from skytemple_files.graphics.pal.writer import PalWriter
 
-class FontType(Enum):
-    FONT_DAT = 0x00
-    FONT_SIR0 = 0x01
-    GRAPHIC_FONT = 0x02
 
-FONT_DEFAULT_BPROW = 2
-FONT_DEFAULT_CAT = 0x02
-FONT_DEFAULT_PADDING = 0xFF
+class PalHandler(DataHandler[Pal]):
+    @classmethod
+    def deserialize(cls, data: bytes, **kwargs) -> Pal:
+        return Pal(data)
 
-FONT_VALID_TABLES = [0x00, 0x81, 0x82, 0x83, 0x84, 0x87]
-
-XML_FONT = "Font"
-XML_TABLE = "Table"
-XML_TABLE__ID = "tableid"
-XML_CHAR = "Char"
-XML_CHAR__ID = "id"
-XML_CHAR__WIDTH = "width"
-XML_CHAR__BPROW = "bprow"
-XML_CHAR__CAT = "category"
-XML_CHAR__PADDING = "padding"
+    @classmethod
+    def serialize(cls, data: Pal, **kwargs) -> bytes:
+        return PalWriter(data).write()

--- a/skytemple_files/graphics/pal/model.py
+++ b/skytemple_files/graphics/pal/model.py
@@ -1,0 +1,76 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from skytemple_files.common.util import *
+
+
+class Pal(AutoString):
+    def __init__(self, data: bytes):
+        if not isinstance(data, memoryview):
+            data = memoryview(data)
+        self.palette = list(data)
+
+    def get_palette_2bpc(self) -> List[int]:
+        """Returns the palette converting the data from 2 bpc to 3 bpc"""
+        data = []
+        for x in range(len(self.palette//2)):
+            v = 0
+            for i in range(2):
+                v += self.palette[x*2+i]*(256**i)
+            data.append((v%32)*8)
+            data.append(((v<<5)%32)*8)
+            data.append(((v<<10)%32)*8)
+        return data
+        
+    def get_palette(self) -> List[int]:
+        """Returns the palette data"""
+        return self.palette
+        
+    def get_palette_4bpc(self) -> List[int]:
+        """Returns the palette converting the data from 4 bpc to 3 bpc"""
+        data = []
+        for i, x in enumerate(self.palette):
+            if i%4!=3:
+                data.append(x)
+        return data
+    
+    def set_palette_2bpc(self, data: List[int]):
+        """Sets the palette converting the data given from 3 bpc to 2 bpc"""
+        self.palette = []
+        for x in range(len(data//3)):
+            color = []
+            for i in range(3):
+                color.append(data[x*3+i])
+            v = color[0]//8 + (color[1]//8)>>5 + (color[2]//8)>>10
+            self.palette.append(v%256)
+            self.palette.append(v//256)
+    
+    def set_palette(self, data: List[int]):
+        """Sets the palette data"""
+        self.palette = data
+        
+    def set_palette_4bpc(self, data: List[int], padding=0xff):
+        """Sets the palette converting the data given from 3 bpc to 4 bpc"""
+        self.palette = []
+        for i, x in enumerate(data):
+            self.palette.append(x)
+            if i%3==2:
+                self.palette.append(padding)
+
+    def __eq__(self, other):
+        if not isinstance(other, Pal):
+            return False
+        return self.palette == other.palette

--- a/skytemple_files/graphics/pal/writer.py
+++ b/skytemple_files/graphics/pal/writer.py
@@ -1,3 +1,4 @@
+"""Converts Pal models back into the binary format used by the game"""
 #  Copyright 2020 Parakoopa
 #
 #  This file is part of SkyTemple.
@@ -15,25 +16,15 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
-from enum import Enum
+from skytemple_files.common.util import *
+from skytemple_files.graphics.pal.model import Pal
 
-class FontType(Enum):
-    FONT_DAT = 0x00
-    FONT_SIR0 = 0x01
-    GRAPHIC_FONT = 0x02
 
-FONT_DEFAULT_BPROW = 2
-FONT_DEFAULT_CAT = 0x02
-FONT_DEFAULT_PADDING = 0xFF
+class PalWriter:
+    def __init__(self, model: Pal):
+        self.model = model
 
-FONT_VALID_TABLES = [0x00, 0x81, 0x82, 0x83, 0x84, 0x87]
+    def write(self) -> bytes:
+        buffer = bytes(self.model.palette)
 
-XML_FONT = "Font"
-XML_TABLE = "Table"
-XML_TABLE__ID = "tableid"
-XML_CHAR = "Char"
-XML_CHAR__ID = "id"
-XML_CHAR__WIDTH = "width"
-XML_CHAR__BPROW = "bprow"
-XML_CHAR__CAT = "category"
-XML_CHAR__PADDING = "padding"
+        return buffer


### PR DESCRIPTION
Adds basic support to edit graphic font files (button, Orb and TM icons, etc. / staff roll font): 
- import/export entries of those files;
- associate them with a palette file (".pal" files).
Also adds support to open/edit/write raw palette files (mainly ".pal" files), since graphic fonts use them.
