### PR TITLE
Add support to edit default starters species

### DIFF
--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -96,6 +96,8 @@
         <Pointer name="LanguageInfoData" beg="0xAFCE8"/>
         <Pointer name="GameMode"         beg="0xAFF70"/>
         <Pointer name="NotifyNote"       beg="0xAFEF8"/>
+        <Block name="DefaultHeroId"  beg="0xAFEFC" end="0xAFEFE"/>
+        <Block name="DefaultPartnerId"  beg="0xAFEFE" end="0xAFF00"/>
         <Pointer name="DebugSpecialEpisodeType" beg="0x2AB4AC"/>
         <!-- RAM values -->
         <!--#TODO: probably not really part of arm9, it's only in memory anyway. -->
@@ -170,6 +172,8 @@
         <Pointer name="LanguageInfoData" beg="0xB05A8"/>
         <Pointer name="GameMode"         beg="0xB088C"/>
         <Pointer name="NotifyNote"       beg="0xB0814"/>
+        <Block name="DefaultHeroId"  beg="0xB0818" end="0xB081A"/>
+        <Block name="DefaultPartnerId"  beg="0xB081A" end="0xB081C"/>
         <Pointer name="DebugSpecialEpisodeType" beg="0x2ABDEC"/>
         <!-- RAM values -->
         <!--#TODO: probably not really part of arm9, it's only in memory anyway. -->

--- a/skytemple_files/hardcoded/default_starters.py
+++ b/skytemple_files/hardcoded/default_starters.py
@@ -1,0 +1,55 @@
+"""Module for editing hardcoded data regarding the default starters."""
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import List
+
+from skytemple_files.common.ppmdu_config.data import Pmd2Data
+from skytemple_files.common.util import read_uintle, write_uintle
+
+
+class HardcodedDefaultStarters:
+    @staticmethod
+    def get_partner_md_id(arm9: bytes, config: Pmd2Data) -> int:
+        """
+        Gets the monster.md index of the default partner starter
+        """
+        block = config.binaries['arm9.bin'].blocks['DefaultPartnerId']
+        return read_uintle(arm9, block.begin, 2)
+
+    @staticmethod
+    def set_partner_md_id(value: int, arm9: bytearray, config: Pmd2Data):
+        """
+        Sets the monster.md index of the default partner starter
+        """
+        block = config.binaries['arm9.bin'].blocks['DefaultPartnerId']
+        write_uintle(arm9, value, block.begin, 2)
+
+    @staticmethod
+    def get_player_md_id(arm9: bytes, config: Pmd2Data) -> int:
+        """
+        Gets the monster.md index of the default player starter
+        """
+        block = config.binaries['arm9.bin'].blocks['DefaultHeroId']
+        return read_uintle(arm9, block.begin, 2)
+
+    @staticmethod
+    def set_player_md_id(value: int, arm9: bytearray, config: Pmd2Data):
+        """
+        Sets the monster.md index of the default player starter
+        """
+        block = config.binaries['arm9.bin'].blocks['DefaultHeroId']
+        write_uintle(arm9, value, block.begin, 2)


### PR DESCRIPTION
Adds a module to read/write default starters species values.
Should fix #42.