### PR TITLE
Rework Containers and Compression Algorithms

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/atupx_support/eu/change_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/atupx_support/eu/change_arm9.asm
@@ -1,0 +1,434 @@
+; For use with ARMIPS
+; 2021/01/10
+; For Explorers of Sky European ONLY!
+; Should not be used with any other version!
+; ------------------------------------------------------------------------------
+; This file is auto-generated!
+; ------------------------------------------------------------------------------
+;
+.relativeinclude on
+.nds
+.arm
+
+
+
+.org 0x0201F748
+.area 0x8
+	mov  r1,r0
+	b 0x20a5388
+
+.endarea
+
+
+.org 0x0201FBAC
+.area 0x8
+	mov  r1,r0
+	b 0x20a53e0
+
+.endarea
+
+
+.org 0x020200F8
+.area 0x4
+	b 0x20a5438
+
+.endarea
+
+
+.org 0x02020604
+.area 0x8
+	ldreqb r1,[r0, #+0x2]
+	cmpeq r1,#0x33
+
+.endarea
+
+
+.org 0x02020610
+.area 0x4
+	bne 0x20a5494
+
+.endarea
+
+
+.org 0x020A4EF8
+.area 0x5e0
+	tst r5,#0x4
+	beq 0x20a4f18
+	mov  r0,r5,lsr #0x3
+	and  r0,r0,#0x3
+	add  r8,r0,#0x3
+	add  r4,r4,#0x5
+	mov  r5,r5,lsr #0x5
+	bx r14
+	tst r5,#0x8
+	beq 0x20a4f38
+	mov  r0,r5,lsr #0x4
+	and  r0,r0,#0x7
+	add  r8,r0,#0x7
+	add  r4,r4,#0x7
+	mov  r5,r5,lsr #0x7
+	bx r14
+	tst r5,#0x10
+	beq 0x20a4f58
+	mov  r0,r5,lsr #0x5
+	and  r0,r0,#0xF
+	add  r8,r0,#0xF
+	add  r4,r4,#0x9
+	mov  r5,r5,lsr #0x9
+	bx r14
+	tst r5,#0x20
+	beq 0x20a4f78
+	mov  r0,r5,lsr #0x6
+	and  r0,r0,#0x1F
+	add  r8,r0,#0x1F
+	add  r4,r4,#0xB
+	mov  r5,r5,lsr #0xb
+	bx r14
+	tst r5,#0x40
+	beq 0x20a4f98
+	mov  r0,r5,lsr #0x7
+	and  r0,r0,#0x3F
+	add  r8,r0,#0x3F
+	add  r4,r4,#0xD
+	mov  r5,r5,lsr #0xd
+	bx r14
+	tst r5,#0x80
+	beq 0x20a4fb8
+	mov  r0,r5,lsr #0x8
+	and  r0,r0,#0x7F
+	add  r8,r0,#0x7F
+	add  r4,r4,#0xF
+	mov  r5,r5,lsr #0xf
+	bx r14
+	tst r5,#0x100
+	beq 0x20a5004
+	add  r4,r4,#0x9
+	sub  r2,r11,r4
+	cmp r2,#0x10
+	mov  r5,r5,lsr #0x9
+	bge 0x20a4ff0
+	ldr r0,[r13, #+0x4]
+	mov  r4,#0x0
+	mvn  r10,r0,lsl r2
+	ldrh r0,[r9],#+0x2
+	and  r10,r5,r10
+	add  r11,r2,#0x10
+	orr  r5,r10,r0,lsl r2
+	and  r0,r5,#0xFF
+	add  r8,r0,#0xFF
+	add  r4,r4,#0x8
+	mov  r5,r5,lsr #0x8
+	bx r14
+	mov  r8,#0x0
+	stmdb  r13!,{r14}
+	bl 0x207bfb8
+	ldmia  r13!,{r15}
+	stmdb  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r14}
+	sub  r13,r13,#0x8
+	ldrb r6,[r0, #+0x0]
+	mov  r11,#0x0
+	str r2,[r13, #+0x0]
+	cmp r2,#0x1
+	mov  r4,r11
+	mov  r5,r11
+	add  r9,r0,#0x2
+	mov  r7,#0x1
+	addle  r13,r13,#0x8
+	mov  r10,r6
+	strb r6,[r1, #+0x0]
+	ldmleia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
+	mvn  r0,#0x0
+	str r0,[r13, #+0x4]
+	sub  r3,r11,r4
+	cmp r3,#0x10
+	bge 0x20a507c
+	ldr r0,[r13, #+0x4]
+	add  r11,r3,#0x10
+	mvn  r2,r0,lsl r3
+	ldrh r0,[r9],#+0x2
+	and  r2,r5,r2
+	mov  r4,#0x0
+	orr  r5,r2,r0,lsl r3
+	tst r5,#0x1
+	beq 0x20a5094
+	add  r4,r4,#0x1
+	mov  r5,r5,lsr #0x1
+	bl 0x20a5110
+	b 0x20a50f8
+	tst r5,#0x2
+	beq 0x20a50cc
+	mov  r0,r5,lsr #0x2
+	and  r0,r0,#0x1
+	add  r8,r0,#0x1
+	cmp r8,#0x1
+	add  r4,r4,#0x3
+	mov  r5,r5,lsr #0x3
+	bne 0x20a50d0
+	mov  r2,r10
+	mov  r10,r6
+	mov  r6,r2
+	bl 0x20a5110
+	b 0x20a50f8
+	bl 0x20a4ef8
+	tst r8,#0x1
+	moveq  r8,r8,asr #0x1
+	subne  r0,r8,#0x2
+	mvnne  r0,r0
+	movne  r0,r0,asr #0x1
+	orrne  r8,r0,#0x80
+	add  r0,r8,r6
+	mov  r10,r6
+	and  r6,r0,#0xF
+	bl 0x20a5110
+	ldr r0,[r13, #+0x0]
+	add  r7,r7,#0x1
+	cmp r0,r7,asr #0x1
+	bgt 0x20a5054
+	add  r13,r13,#0x8
+	ldmia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
+	tst r7,#0x1
+	mov  r7,r7,asr #0x1
+	bne 0x20a5128
+	strb r6,[r1, +r7]
+	mov  r7,r7,lsl #0x1
+	bx r14
+	ldrb r2,[r1, +r7]
+	mov  r6,r6,lsl #0x4
+	orr  r2,r2,r6
+	strb r2,[r1, +r7]
+	mov  r6,r6,asr #0x4
+	mov  r7,r7,lsl #0x1
+	orr  r7,r7,#0x1
+	bx r14
+	stmdb  r13!,{r4,r5,r6,r7,r8,r9,r10,r11,r14}
+	sub  r13,r13,#0xC
+	str r3,[r13, #+0x8]
+	ldrb r6,[r0, #+0x0]
+	mov  r11,#0x0
+	str r2,[r13, #+0x0]
+	mov  r4,r11
+	mov  r5,r11
+	add  r9,r0,#0x2
+	mov  r7,#0x0
+	mov  r10,r6
+	bl 0x20a5248
+	cmp r2,#0x1
+	ble 0x20a5240
+	mov  r7,#0x1
+	mvn  r0,#0x0
+	str r0,[r13, #+0x4]
+	sub  r3,r11,r4
+	cmp r3,#0x10
+	bge 0x20a51b4
+	ldr r0,[r13, #+0x4]
+	add  r11,r3,#0x10
+	mvn  r2,r0,lsl r3
+	ldrh r0,[r9],#+0x2
+	and  r2,r5,r2
+	mov  r4,#0x0
+	orr  r5,r2,r0,lsl r3
+	tst r5,#0x1
+	beq 0x20a51cc
+	add  r4,r4,#0x1
+	mov  r5,r5,lsr #0x1
+	bl 0x20a5248
+	b 0x20a5230
+	tst r5,#0x2
+	beq 0x20a5204
+	mov  r0,r5,lsr #0x2
+	and  r0,r0,#0x1
+	add  r8,r0,#0x1
+	cmp r8,#0x1
+	add  r4,r4,#0x3
+	mov  r5,r5,lsr #0x3
+	bne 0x20a5208
+	mov  r2,r10
+	mov  r10,r6
+	mov  r6,r2
+	bl 0x20a5248
+	b 0x20a5230
+	bl 0x20a4ef8
+	tst r8,#0x1
+	moveq  r8,r8,asr #0x1
+	subne  r0,r8,#0x2
+	mvnne  r0,r0
+	movne  r0,r0,asr #0x1
+	orrne  r8,r0,#0x80
+	add  r0,r8,r6
+	mov  r10,r6
+	and  r6,r0,#0xF
+	bl 0x20a5248
+	ldr r0,[r13, #+0x0]
+	add  r7,r7,#0x1
+	cmp r0,r7,asr #0x1
+	bgt 0x20a518c
+	add  r13,r13,#0xC
+	ldmia  r13!,{r4,r5,r6,r7,r8,r9,r10,r11,r15}
+	cmp r6,#0x0
+	ldrneb r2,[r13, #+0x8]
+	moveq r2, #0x0
+	orr  r2,r2,r6
+	strb r2,[r1, +r7]
+	bx r14
+	stmdb  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r14}
+	sub  r13,r13,#0xC
+	ldrb r6,[r0, #+0x0]
+	mov  r11,#0x0
+	str r2,[r13, #+0x0]
+	cmp r2,#0x1
+	mov  r4,r11
+	mov  r5,r11
+	add  r9,r0,#0x2
+	mov  r7,#0x1
+	addle  r13,r13,#0xC
+	mov  r10,r6
+	strb r6,[r13, #+0x8]
+	ldmleia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
+	mvn  r0,#0x0
+	str r0,[r13, #+0x4]
+	sub  r3,r11,r4
+	cmp r3,#0x10
+	bge 0x20a52c8
+	ldr r0,[r13, #+0x4]
+	add  r11,r3,#0x10
+	mvn  r2,r0,lsl r3
+	ldrh r0,[r9],#+0x2
+	and  r2,r5,r2
+	mov  r4,#0x0
+	orr  r5,r2,r0,lsl r3
+	tst r5,#0x1
+	beq 0x20a52e0
+	add  r4,r4,#0x1
+	mov  r5,r5,lsr #0x1
+	bl 0x20a535c
+	b 0x20a5344
+	tst r5,#0x2
+	beq 0x20a5318
+	mov  r0,r5,lsr #0x2
+	and  r0,r0,#0x1
+	add  r8,r0,#0x1
+	cmp r8,#0x1
+	add  r4,r4,#0x3
+	mov  r5,r5,lsr #0x3
+	bne 0x20a531c
+	mov  r2,r10
+	mov  r10,r6
+	mov  r6,r2
+	bl 0x20a535c
+	b 0x20a5344
+	bl 0x20a4ef8
+	tst r8,#0x1
+	moveq  r8,r8,asr #0x1
+	subne  r0,r8,#0x2
+	mvnne  r0,r0
+	movne  r0,r0,asr #0x1
+	orrne  r8,r0,#0x80
+	add  r0,r8,r6
+	mov  r10,r6
+	and  r6,r0,#0xF
+	bl 0x20a535c
+	ldr r0,[r13, #+0x0]
+	add  r7,r7,#0x1
+	cmp r0,r7,asr #0x1
+	bgt 0x20a52a0
+	add  r13,r13,#0xC
+	ldmia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
+	tst r7,#0x1
+	bne 0x20a536c
+	strb r6,[r13, #+0x8]
+	bx r14
+	ldrb r2,[r13, #+0x8]
+	mov  r6,r6,lsl #0x4
+	orr  r0,r2,r6
+	stmdb  r13!,{r14}
+	bl 0x202050c
+	mov  r6,r6,asr #0x4
+	ldmia  r13!,{r15}
+	mov  r0,#0x0
+	ldrb r5,[r2, #+0x0]
+	cmp r5,#0x41
+	ldreqb r5,[r2, #+0x1]
+	cmpeq r5,#0x54
+	ldreqb r5,[r2, #+0x2]
+	cmpeq r5,#0x55
+	ldreqb r5,[r2, #+0x3]
+	cmpeq r5,#0x50
+	bne 0x201faa4
+	ldrb r6,[r2, #+0x7]
+	ldrb r5,[r2, #+0x8]
+	ldrb r7,[r2, #+0x9]
+	ldrb r4,[r2, #+0xa]
+	add  r5,r6,r5,lsl #0x8
+	add  r5,r5,r7,lsl #0x10
+	add  r4,r5,r4,lsl #0x18
+	add  r0,r2,#0xB
+	mov  r2,r4
+	bl 0x20a5014
+	mov  r0,r4
+	b 0x201faa4
+	ldrb r5,[r2, #+0x0]
+	cmp r5,#0x41
+	ldreqb r5,[r2, #+0x1]
+	cmpeq r5,#0x54
+	ldreqb r5,[r2, #+0x2]
+	cmpeq r5,#0x55
+	ldreqb r5,[r2, #+0x3]
+	cmpeq r5,#0x50
+	mov  r0,#0x0
+	bne 0x201ffe0
+	ldrb r6,[r2, #+0x7]
+	ldrb r5,[r2, #+0x8]
+	ldrb r7,[r2, #+0x9]
+	ldrb r4,[r2, #+0xa]
+	add  r5,r6,r5,lsl #0x8
+	add  r5,r5,r7,lsl #0x10
+	add  r4,r5,r4,lsl #0x18
+	add  r0,r2,#0xB
+	mov  r2,r4
+	bl 0x20a5148
+	mov  r0,r4
+	b 0x201ffe0
+	ldrb r1,[r5, #+0x0]
+	cmp r1,#0x41
+	ldreqb r1,[r5, #+0x1]
+	cmpeq r1,#0x54
+	ldreqb r1,[r5, #+0x2]
+	cmpeq r1,#0x55
+	ldreqb r1,[r5, #+0x3]
+	cmpeq r1,#0x50
+	mov  r0,#0x0
+	bne 0x2020500
+	ldrb r1,[r5, #+0x7]
+	ldrb r0,[r5, #+0x8]
+	ldrb r2,[r5, #+0x9]
+	ldrb r3,[r5, #+0xa]
+	add  r0,r1,r0,lsl #0x8
+	add  r0,r0,r2,lsl #0x10
+	add  r0,r0,r3,lsl #0x18
+	mov  r2,r0
+	mov  r3,r0
+	add  r0,r5,#0xB
+	bl 0x20a5260
+	mov  r2,r0
+	b 0x2020500
+	cmp r2,#0x41
+	ldreqb r1,[r0, #+0x1]
+	cmpeq r1,#0x54
+	ldreqb r1,[r0, #+0x2]
+	cmpeq r1,#0x55
+	ldreqb r1,[r0, #+0x3]
+	cmpeq r1,#0x50
+	movne  r0,#0x0
+	bxne r14
+	ldrb r2,[r0, #+0x7]
+	ldrb r1,[r0, #+0x8]
+	ldrb r3,[r0, #+0x9]
+	ldrb r12,[r0, #+0xa]
+	add  r0,r2,r1,lsl #0x8
+	add  r0,r0,r3,lsl #0x10
+	add  r0,r0,r12,lsl #0x18
+	bx r14
+
+.endarea
+
+

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/atupx_support/na/change_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/atupx_support/na/change_arm9.asm
@@ -1,0 +1,434 @@
+; For use with ARMIPS
+; 2021/01/09
+; For Explorers of Sky North American ONLY!
+; Should not be used with any other version!
+; ------------------------------------------------------------------------------
+; This file is auto-generated!
+; ------------------------------------------------------------------------------
+;
+.relativeinclude on
+.nds
+.arm
+
+
+
+.org 0x0201F6AC
+.area 0x8
+	mov  r1,r0
+	b 0x20a4d88
+
+.endarea
+
+
+.org 0x0201FB10
+.area 0x8
+	mov  r1,r0
+	b 0x20a4de0
+
+.endarea
+
+
+.org 0x0202005C
+.area 0x4
+	b 0x20a4e38
+
+.endarea
+
+
+.org 0x02020568
+.area 0x8
+	ldreqb r1,[r0, #+0x2]
+	cmpeq r1,#0x33
+
+.endarea
+
+
+.org 0x02020574
+.area 0x4
+	bne 0x20a4e94
+
+.endarea
+
+
+.org 0x020A48F8
+.area 0x5e0
+	tst r5,#0x4
+	beq 0x20a4918
+	mov  r0,r5,lsr #0x3
+	and  r0,r0,#0x3
+	add  r8,r0,#0x3
+	add  r4,r4,#0x5
+	mov  r5,r5,lsr #0x5
+	bx r14
+	tst r5,#0x8
+	beq 0x20a4938
+	mov  r0,r5,lsr #0x4
+	and  r0,r0,#0x7
+	add  r8,r0,#0x7
+	add  r4,r4,#0x7
+	mov  r5,r5,lsr #0x7
+	bx r14
+	tst r5,#0x10
+	beq 0x20a4958
+	mov  r0,r5,lsr #0x5
+	and  r0,r0,#0xF
+	add  r8,r0,#0xF
+	add  r4,r4,#0x9
+	mov  r5,r5,lsr #0x9
+	bx r14
+	tst r5,#0x20
+	beq 0x20a4978
+	mov  r0,r5,lsr #0x6
+	and  r0,r0,#0x1F
+	add  r8,r0,#0x1F
+	add  r4,r4,#0xB
+	mov  r5,r5,lsr #0xb
+	bx r14
+	tst r5,#0x40
+	beq 0x20a4998
+	mov  r0,r5,lsr #0x7
+	and  r0,r0,#0x3F
+	add  r8,r0,#0x3F
+	add  r4,r4,#0xD
+	mov  r5,r5,lsr #0xd
+	bx r14
+	tst r5,#0x80
+	beq 0x20a49b8
+	mov  r0,r5,lsr #0x8
+	and  r0,r0,#0x7F
+	add  r8,r0,#0x7F
+	add  r4,r4,#0xF
+	mov  r5,r5,lsr #0xf
+	bx r14
+	tst r5,#0x100
+	beq 0x20a4a04
+	add  r4,r4,#0x9
+	sub  r2,r11,r4
+	cmp r2,#0x10
+	mov  r5,r5,lsr #0x9
+	bge 0x20a49f0
+	ldr r0,[r13, #+0x4]
+	mov  r4,#0x0
+	mvn  r10,r0,lsl r2
+	ldrh r0,[r9],#+0x2
+	and  r10,r5,r10
+	add  r11,r2,#0x10
+	orr  r5,r10,r0,lsl r2
+	and  r0,r5,#0xFF
+	add  r8,r0,#0xFF
+	add  r4,r4,#0x8
+	mov  r5,r5,lsr #0x8
+	bx r14
+	mov  r8,#0x0
+	stmdb  r13!,{r14}
+	bl 0x207bc20
+	ldmia  r13!,{r15}
+	stmdb  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r14}
+	sub  r13,r13,#0x8
+	ldrb r6,[r0, #+0x0]
+	mov  r11,#0x0
+	str r2,[r13, #+0x0]
+	cmp r2,#0x1
+	mov  r4,r11
+	mov  r5,r11
+	add  r9,r0,#0x2
+	mov  r7,#0x1
+	addle  r13,r13,#0x8
+	mov  r10,r6
+	strb r6,[r1, #+0x0]
+	ldmleia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
+	mvn  r0,#0x0
+	str r0,[r13, #+0x4]
+	sub  r3,r11,r4
+	cmp r3,#0x10
+	bge 0x20a4a7c
+	ldr r0,[r13, #+0x4]
+	add  r11,r3,#0x10
+	mvn  r2,r0,lsl r3
+	ldrh r0,[r9],#+0x2
+	and  r2,r5,r2
+	mov  r4,#0x0
+	orr  r5,r2,r0,lsl r3
+	tst r5,#0x1
+	beq 0x20a4a94
+	add  r4,r4,#0x1
+	mov  r5,r5,lsr #0x1
+	bl 0x20a4b10
+	b 0x20a4af8
+	tst r5,#0x2
+	beq 0x20a4acc
+	mov  r0,r5,lsr #0x2
+	and  r0,r0,#0x1
+	add  r8,r0,#0x1
+	cmp r8,#0x1
+	add  r4,r4,#0x3
+	mov  r5,r5,lsr #0x3
+	bne 0x20a4ad0
+	mov  r2,r10
+	mov  r10,r6
+	mov  r6,r2
+	bl 0x20a4b10
+	b 0x20a4af8
+	bl 0x20a48f8
+	tst r8,#0x1
+	moveq  r8,r8,asr #0x1
+	subne  r0,r8,#0x2
+	mvnne  r0,r0
+	movne  r0,r0,asr #0x1
+	orrne  r8,r0,#0x80
+	add  r0,r8,r6
+	mov  r10,r6
+	and  r6,r0,#0xF
+	bl 0x20a4b10
+	ldr r0,[r13, #+0x0]
+	add  r7,r7,#0x1
+	cmp r0,r7,asr #0x1
+	bgt 0x20a4a54
+	add  r13,r13,#0x8
+	ldmia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
+	tst r7,#0x1
+	mov  r7,r7,asr #0x1
+	bne 0x20a4b28
+	strb r6,[r1, +r7]
+	mov  r7,r7,lsl #0x1
+	bx r14
+	ldrb r2,[r1, +r7]
+	mov  r6,r6,lsl #0x4
+	orr  r2,r2,r6
+	strb r2,[r1, +r7]
+	mov  r6,r6,asr #0x4
+	mov  r7,r7,lsl #0x1
+	orr  r7,r7,#0x1
+	bx r14
+	stmdb  r13!,{r4,r5,r6,r7,r8,r9,r10,r11,r14}
+	sub  r13,r13,#0xC
+	str r3,[r13, #+0x8]
+	ldrb r6,[r0, #+0x0]
+	mov  r11,#0x0
+	str r2,[r13, #+0x0]
+	mov  r4,r11
+	mov  r5,r11
+	add  r9,r0,#0x2
+	mov  r7,#0x0
+	mov  r10,r6
+	bl 0x20a4c48
+	cmp r2,#0x1
+	ble 0x20a4c40
+	mov  r7,#0x1
+	mvn  r0,#0x0
+	str r0,[r13, #+0x4]
+	sub  r3,r11,r4
+	cmp r3,#0x10
+	bge 0x20a4bb4
+	ldr r0,[r13, #+0x4]
+	add  r11,r3,#0x10
+	mvn  r2,r0,lsl r3
+	ldrh r0,[r9],#+0x2
+	and  r2,r5,r2
+	mov  r4,#0x0
+	orr  r5,r2,r0,lsl r3
+	tst r5,#0x1
+	beq 0x20a4bcc
+	add  r4,r4,#0x1
+	mov  r5,r5,lsr #0x1
+	bl 0x20a4c48
+	b 0x20a4c30
+	tst r5,#0x2
+	beq 0x20a4c04
+	mov  r0,r5,lsr #0x2
+	and  r0,r0,#0x1
+	add  r8,r0,#0x1
+	cmp r8,#0x1
+	add  r4,r4,#0x3
+	mov  r5,r5,lsr #0x3
+	bne 0x20a4c08
+	mov  r2,r10
+	mov  r10,r6
+	mov  r6,r2
+	bl 0x20a4c48
+	b 0x20a4c30
+	bl 0x20a48f8
+	tst r8,#0x1
+	moveq  r8,r8,asr #0x1
+	subne  r0,r8,#0x2
+	mvnne  r0,r0
+	movne  r0,r0,asr #0x1
+	orrne  r8,r0,#0x80
+	add  r0,r8,r6
+	mov  r10,r6
+	and  r6,r0,#0xF
+	bl 0x20a4c48
+	ldr r0,[r13, #+0x0]
+	add  r7,r7,#0x1
+	cmp r0,r7,asr #0x1
+	bgt 0x20a4b8c
+	add  r13,r13,#0xC
+	ldmia  r13!,{r4,r5,r6,r7,r8,r9,r10,r11,r15}
+	cmp r6,#0x0
+	ldrneb r2,[r13, #+0x8]
+	moveq r2, #0x0
+	orr  r2,r2,r6
+	strb r2,[r1, +r7]
+	bx r14
+	stmdb  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r14}
+	sub  r13,r13,#0xC
+	ldrb r6,[r0, #+0x0]
+	mov  r11,#0x0
+	str r2,[r13, #+0x0]
+	cmp r2,#0x1
+	mov  r4,r11
+	mov  r5,r11
+	add  r9,r0,#0x2
+	mov  r7,#0x1
+	addle  r13,r13,#0xC
+	mov  r10,r6
+	strb r6,[r13, #+0x8]
+	ldmleia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
+	mvn  r0,#0x0
+	str r0,[r13, #+0x4]
+	sub  r3,r11,r4
+	cmp r3,#0x10
+	bge 0x20a4cc8
+	ldr r0,[r13, #+0x4]
+	add  r11,r3,#0x10
+	mvn  r2,r0,lsl r3
+	ldrh r0,[r9],#+0x2
+	and  r2,r5,r2
+	mov  r4,#0x0
+	orr  r5,r2,r0,lsl r3
+	tst r5,#0x1
+	beq 0x20a4ce0
+	add  r4,r4,#0x1
+	mov  r5,r5,lsr #0x1
+	bl 0x20a4d5c
+	b 0x20a4d44
+	tst r5,#0x2
+	beq 0x20a4d18
+	mov  r0,r5,lsr #0x2
+	and  r0,r0,#0x1
+	add  r8,r0,#0x1
+	cmp r8,#0x1
+	add  r4,r4,#0x3
+	mov  r5,r5,lsr #0x3
+	bne 0x20a4d1c
+	mov  r2,r10
+	mov  r10,r6
+	mov  r6,r2
+	bl 0x20a4d5c
+	b 0x20a4d44
+	bl 0x20a48f8
+	tst r8,#0x1
+	moveq  r8,r8,asr #0x1
+	subne  r0,r8,#0x2
+	mvnne  r0,r0
+	movne  r0,r0,asr #0x1
+	orrne  r8,r0,#0x80
+	add  r0,r8,r6
+	mov  r10,r6
+	and  r6,r0,#0xF
+	bl 0x20a4d5c
+	ldr r0,[r13, #+0x0]
+	add  r7,r7,#0x1
+	cmp r0,r7,asr #0x1
+	bgt 0x20a4ca0
+	add  r13,r13,#0xC
+	ldmia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
+	tst r7,#0x1
+	bne 0x20a4d6c
+	strb r6,[r13, #+0x8]
+	bx r14
+	ldrb r2,[r13, #+0x8]
+	mov  r6,r6,lsl #0x4
+	orr  r0,r2,r6
+	stmdb  r13!,{r14}
+	bl 0x2020470
+	mov  r6,r6,asr #0x4
+	ldmia  r13!,{r15}
+	mov  r0,#0x0
+	ldrb r5,[r2, #+0x0]
+	cmp r5,#0x41
+	ldreqb r5,[r2, #+0x1]
+	cmpeq r5,#0x54
+	ldreqb r5,[r2, #+0x2]
+	cmpeq r5,#0x55
+	ldreqb r5,[r2, #+0x3]
+	cmpeq r5,#0x50
+	bne 0x201fa08
+	ldrb r6,[r2, #+0x7]
+	ldrb r5,[r2, #+0x8]
+	ldrb r7,[r2, #+0x9]
+	ldrb r4,[r2, #+0xa]
+	add  r5,r6,r5,lsl #0x8
+	add  r5,r5,r7,lsl #0x10
+	add  r4,r5,r4,lsl #0x18
+	add  r0,r2,#0xB
+	mov  r2,r4
+	bl 0x20a4a14
+	mov  r0,r4
+	b 0x201fa08
+	ldrb r5,[r2, #+0x0]
+	cmp r5,#0x41
+	ldreqb r5,[r2, #+0x1]
+	cmpeq r5,#0x54
+	ldreqb r5,[r2, #+0x2]
+	cmpeq r5,#0x55
+	ldreqb r5,[r2, #+0x3]
+	cmpeq r5,#0x50
+	mov  r0,#0x0
+	bne 0x201ff44
+	ldrb r6,[r2, #+0x7]
+	ldrb r5,[r2, #+0x8]
+	ldrb r7,[r2, #+0x9]
+	ldrb r4,[r2, #+0xa]
+	add  r5,r6,r5,lsl #0x8
+	add  r5,r5,r7,lsl #0x10
+	add  r4,r5,r4,lsl #0x18
+	add  r0,r2,#0xB
+	mov  r2,r4
+	bl 0x20a4b48
+	mov  r0,r4
+	b 0x201ff44
+	ldrb r1,[r5, #+0x0]
+	cmp r1,#0x41
+	ldreqb r1,[r5, #+0x1]
+	cmpeq r1,#0x54
+	ldreqb r1,[r5, #+0x2]
+	cmpeq r1,#0x55
+	ldreqb r1,[r5, #+0x3]
+	cmpeq r1,#0x50
+	mov  r0,#0x0
+	bne 0x2020464
+	ldrb r1,[r5, #+0x7]
+	ldrb r0,[r5, #+0x8]
+	ldrb r2,[r5, #+0x9]
+	ldrb r3,[r5, #+0xa]
+	add  r0,r1,r0,lsl #0x8
+	add  r0,r0,r2,lsl #0x10
+	add  r0,r0,r3,lsl #0x18
+	mov  r2,r0
+	mov  r3,r0
+	add  r0,r5,#0xB
+	bl 0x20a4c60
+	mov  r2,r0
+	b 0x2020464
+	cmp r2,#0x41
+	ldreqb r1,[r0, #+0x1]
+	cmpeq r1,#0x54
+	ldreqb r1,[r0, #+0x2]
+	cmpeq r1,#0x55
+	ldreqb r1,[r0, #+0x3]
+	cmpeq r1,#0x50
+	movne  r0,#0x0
+	bxne r14
+	ldrb r2,[r0, #+0x7]
+	ldrb r1,[r0, #+0x8]
+	ldrb r3,[r0, #+0x9]
+	ldrb r12,[r0, #+0xa]
+	add  r0,r2,r1,lsl #0x8
+	add  r0,r0,r3,lsl #0x10
+	add  r0,r0,r12,lsl #0x18
+	bx r14
+
+.endarea
+
+

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/atupx_support/selector_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/atupx_support/selector_arm9.asm
@@ -1,0 +1,17 @@
+; For use with ARMIPS
+; 2021/01/09
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/change_arm9.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/change_arm9.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -613,6 +613,15 @@
           </OpenBin>
         </Patch>
 
+        <!-- A patch to provide support for ATUPX containers -->
+        <Patch id="ProvideATUPXSupport" >
+          <!--Open each binaries for processing and include the appropriate files-->
+          <!--The openfile statements will be appropriately generated based on the data in this file, and on the rom path!-->
+          <OpenBin filepath="arm9.bin">
+	  	<Include filename ="irdkwia_asm_mods/atupx_support/selector_arm9.asm"/>
+	  </OpenBin>
+        </Patch>
+        
         <!-- A patch that fixes the unused dungeon chance -->
         <Patch id="UnusedDungeonChancePatch" >
           <OpenBin filepath="overlay/overlay_0029.bin">

--- a/skytemple_files/common/types/file_types.py
+++ b/skytemple_files/common/types/file_types.py
@@ -53,9 +53,13 @@ from skytemple_files.graphics.dpci.handler import DpciHandler
 from skytemple_files.graphics.dpl.handler import DplHandler
 from skytemple_files.graphics.dpla.handler import DplaHandler
 from skytemple_files.graphics.kao.handler import KaoHandler
+from skytemple_files.compression_container.common_at.handler import CommonAtHandler
+from skytemple_files.compression_container.at3px.handler import At3pxHandler
 from skytemple_files.compression_container.at4px.handler import At4pxHandler
+from skytemple_files.compression_container.atupx.handler import AtupxHandler
 from skytemple_files.compression_container.at4pn.handler import At4pnHandler
 from skytemple_files.compression.px.handler import PxHandler
+from skytemple_files.compression.custom_999.handler import Custom999Handler
 from skytemple_files.compression.rle_nibble.handler import RleNibbleHandler
 from skytemple_files.graphics.bg_list_dat.handler import BgListDatHandler
 from skytemple_files.graphics.w16.handler import W16Handler
@@ -82,11 +86,15 @@ class FileType:
 
     KAO = KaoHandler
 
+    COMMON_AT = CommonAtHandler
+    AT3PX = At3pxHandler
     AT4PX = At4pxHandler
+    ATUPX = AtupxHandler
     PKDPX = PkdpxHandler
     AT4PN = At4pnHandler
 
     PX = PxHandler
+    CUSTOM_999 = Custom999Handler
     GENERIC_NRL = GenericNrlHandler
     
     RLE_NIBBLE = RleNibbleHandler

--- a/skytemple_files/compression/custom_999/__init__.py
+++ b/skytemple_files/compression/custom_999/__init__.py
@@ -14,23 +14,3 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
-
-from skytemple_files.common.types.data_handler import DataHandler
-from skytemple_files.graphics.bgp.model import Bgp
-from skytemple_files.graphics.bgp.writer import BgpWriter
-
-
-class BgpHandler(DataHandler[Bgp]):
-    @classmethod
-    def deserialize(cls, data: bytes, **kwargs) -> Bgp:
-        from skytemple_files.common.types.file_types import FileType
-        return Bgp(FileType.COMMON_AT.deserialize(data).decompress())
-
-    @classmethod
-    def serialize(cls, data: Bgp, **kwargs) -> bytes:
-        from skytemple_files.common.types.file_types import FileType
-        return FileType.COMMON_AT.serialize(
-            FileType.COMMON_AT.compress(
-                BgpWriter(data).write()
-            )
-        )

--- a/skytemple_files/compression/custom_999/compressor.py
+++ b/skytemple_files/compression/custom_999/compressor.py
@@ -1,0 +1,90 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from skytemple_files.common.util import *
+
+class Custom999Compressor:
+    def __init__(self, uncompressed_data: bytes):
+        if not isinstance(uncompressed_data, memoryview):
+            uncompressed_data = memoryview(uncompressed_data)
+        self.uncompressed_data = uncompressed_data
+
+    def compress(self) -> bytes:
+
+        new_data = []
+        for b in self.uncompressed_data:
+            new_data.append(b%16)
+            new_data.append(b//16)
+        data = bytes(new_data)
+
+        # For the original algorithm:
+        # data = self.uncompressed_data
+        
+        compressed = []
+        compressed.append(data[0])
+        # Add another 0 byte for the original algorithm
+        # compressed.append(0)
+        prev = data[0]
+        current = data[0]
+        bit_list = []
+        for b in data[1:]:
+            if b==current:
+                bit_list.append(1)
+            elif b==prev:
+                bit_list.append(0)
+                bit_list.append(1)
+                bit_list.append(0)
+                t = prev
+                prev = current
+                current = t
+            else:
+                prev = current
+                diff = b-current
+                if diff<0:
+                    diff = abs(diff)
+                    sign = -1
+                else:
+                    sign = 1
+                
+                if diff>=0x8: # For the original algorithm: diff>=0x80
+                    diff = 0x10-diff # For the original algorithm: diff = 0x100-diff
+                    sign = -sign
+                if sign>0:
+                    code = 0
+                else:
+                    code = 1
+                code += diff<<1
+
+                len_code = len(bin(code+1))-2 - 1
+                code = (code+1)%(2**len_code)
+                
+                tmp = []
+                for i in range(len_code):
+                    bit_list.append(0)
+                    tmp.append(code % 2)
+                    code //= 2
+                bit_list.append(1)
+                bit_list += tmp
+                current = b
+        while len(bit_list)>0:
+                current = bit_list[:8]
+                bit_list = bit_list[8:]
+                compressed.append(0)
+                for i, b in enumerate(current):
+                    compressed[-1] += b * (2**i)
+        return bytes(compressed)
+    

--- a/skytemple_files/compression/custom_999/decompressor.py
+++ b/skytemple_files/compression/custom_999/decompressor.py
@@ -1,0 +1,78 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>
+
+from skytemple_files.common.util import *
+
+class Custom999Decompressor:
+    def __init__(self, compressed_data: bytes, decompressed_size: int):
+        self.compressed_data = compressed_data
+        self.decompressed_size = decompressed_size
+
+    def decompress(self) -> bytes:
+        offset = 0
+        code = self.compressed_data[offset]
+        decompressed = [code]
+        prev = code
+
+        # In the original 999 algorithm: 
+        # offset += 2
+        
+        offset += 1
+
+        nbits = 0
+        flags = 0
+        
+        while len(decompressed) < self.decompressed_size*2:
+            while nbits < 17:
+                if offset < len(self.compressed_data):
+                    flags |= self.compressed_data[offset] << nbits
+                    offset += 1
+                nbits += 8
+            nbit = 0
+            while nbit<=8:
+                if (flags & (1 << nbit)) != 0:
+                    break
+                nbit += 1
+            
+            n = (1 << nbit) - 1
+            n += (flags >> (nbit + 1)) & n
+
+            current_flag = offset - nbits//8
+            if nbits%8!=0:
+                current_flag -= 1
+            if n == 1:
+                decompressed.append(prev)
+
+                t = prev
+                prev = code
+                code = t
+            else:
+                if n != 0:
+                    prev = code
+                code = (code + (n >> 1) * (1 - 2 * (n & 1))) & 0xF # & 0xFF in the original algorithm
+                decompressed.append(code)
+            
+            flags >>= 2 * nbit + 1
+            nbits  -= 2 * nbit + 1
+
+        # In the original algorithm: 
+        # return bytes(decompressed)
+        
+        new_data = []
+        for l, h in chunks(decompressed, 2):
+            new_data.append(l+h*16)
+        return bytes(new_data)

--- a/skytemple_files/compression/custom_999/handler.py
+++ b/skytemple_files/compression/custom_999/handler.py
@@ -1,0 +1,46 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+#
+#  This compression format is a modified version of
+#  the AT6P container compression format used in 999
+#  Changes made to the original algorithm are documented in the code
+#  As this is based on AT6P,
+#  the algorithm itself is based on this code (an AT6P decompressor): 
+#  https://github.com/pleonex/tinke/blob/master/Plugins/999HRPERDOOR/999HRPERDOOR/AT6P.cs
+
+
+from typing import Tuple
+
+from skytemple_files.compression.custom_999.compressor import Custom999Compressor
+from skytemple_files.compression.custom_999.decompressor import Custom999Decompressor
+
+
+class Custom999Handler:
+    """
+    Deals with the compression algorithm, originally from 999.
+    Does not follow default DataHandler pattern,
+    is more complex as it also needs the decompressed size.
+    """
+    @classmethod
+    def decompress(cls, compressed_data: bytes, decompressed_size: int) -> bytes:
+        """Decompresses data stored."""
+        return Custom999Decompressor(compressed_data, decompressed_size).decompress()
+
+    @classmethod
+    def compress(cls, uncompressed_data: bytes) -> bytes:
+        """Compresses data and returns the compressed data."""
+        return Custom999Compressor(uncompressed_data).compress()

--- a/skytemple_files/compression/px/README.rst
+++ b/skytemple_files/compression/px/README.rst
@@ -2,7 +2,7 @@ PX Compression
 ==============
 
 The PX compression format, for a lack of better name, is a custom compression format.
-Most of the files using this compression method are contained within either PKDPX_ or AT4PX_ containers.
+Most of the files using this compression method are contained within either PKDPX_, AT4PX_ or AT3PX_ containers.
 
 Usage
 -----
@@ -56,4 +56,5 @@ Based on following documentations:
 .. _Zhorken:                        https://github.com/Zhorken
 
 .. _AT4PX:                          https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression_container/at4px
+.. _AT3PX:                          https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression_container/at3px
 .. _PKDPX:                          https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression_container/pkdpx

--- a/skytemple_files/compression/px/compressor.py
+++ b/skytemple_files/compression/px/compressor.py
@@ -251,7 +251,7 @@ class PxCompressor:
         # Count the nb of occurrences for each nibble
         nibbles_matches = []
         for i in range(0, len(nibbles)):
-            nibbles[i] = nibbles.count(nibbles[i])
+            nibbles_matches.append(nibbles.count(nibbles[i]))
 
         # We got at least 3 values that come back 3 times
         if nibbles_matches.count(3) == 3:

--- a/skytemple_files/compression/rle_nibble/compressor.py
+++ b/skytemple_files/compression/rle_nibble/compressor.py
@@ -15,8 +15,6 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
-# directly based off https://github.com/PsyCommando/ppmdu/blob/master/src/ppmdu/fmts/px_compression.cpp
-
 from skytemple_files.common.util import *
 
 MAX_COPY = 0x7

--- a/skytemple_files/compression_container/at3px/README.rst
+++ b/skytemple_files/compression_container/at3px/README.rst
@@ -1,0 +1,62 @@
+AT3PX File Format
+=================
+
+The AT3PX container is a format very similar to AT4PX, the only difference is that the decompressed data field is omitted, 
+which free 2 bytes as opposed to AT4PX.
+
+Its not unusual to find AT3PX containers wrapped itself by a SIR0_ container.
+Its content is compressed using a custom compression format dubbed `PX`_ Compression for the lack of a better name.
+
+Usage
+-----
+Use the class ``At3pxHandler`` of the ``handler`` module, to open and save
+models from binary data. The model that the handler returns is in the
+module ``model``.
+
+File Format
+-----------
+
++---------+--------+-----------+---------------------+-------------------------------------------------------------+
+| Offset  | Length | Type      | Name                | Description                                                 |
++=========+========+===========+=====================+=============================================================+
+| 0x00    | 5      | string    | Magic Number        | ASCII "AT3PX"                                               |
++---------+--------+-----------+---------------------+-------------------------------------------------------------+
+| 0x05    | 2      | uint16le  | Container Length    | The length from the beginning of the header(!) to the end   |
+|         |        |           |                     | of the compressed data.                                     |
++---------+--------+-----------+---------------------+-------------------------------------------------------------+
+| 0x07    | 9      |           | Control Flags       | A list of flags to be used in decompressing the container's |
+|         |        |           |                     | content.                                                    |
+|         |        |           |                     | More detail about their purpose in the PX_ README.          |
+|         |        |           |                     | Flags are stored in lower half of each byte.                |
++---------+--------+-----------+---------------------+-------------------------------------------------------------+
+| 0x10    | Varies | PX_       | PX_ Compressed Data                                                               |
++---------+--------+-----------+---------------------+-------------------------------------------------------------+
+
+Credits
+-------
+I didn't do much of the work figuring out the file format. Without the following people, this implementation
+wouldn't have been possible:
+
+- psy_commando_ (C++ implementation, documentation and most of the research work!)
+- Zhorken_ (Figured out PX compression and header)
+
+(There are propably more people that worked on this! I collected the names from existing documentation I found.
+If I missed you, please open an Issue!)
+
+Based on following documentations:
+
+- `Project Pokémon documentation`_ (Documentation mostly adapted from there!)
+- `psy_commando Dropbox`_
+
+
+.. Links:
+
+.. _Project Pokémon documentation:  https://projectpokemon.org/docs/mystery-dungeon-nds/at4px-file-format-r40/
+.. _psy_commando Dropbox:           https://www.dropbox.com/sh/8on92uax2mf79gv/AADCmlKOD9oC_NhHnRXVdmMSa?dl=0
+
+.. _psy_commando:                   https://github.com/PsyCommando/
+.. _Zhorken:                        https://github.com/Zhorken
+
+.. _PKDPX:                          https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression_container/pkdpx
+.. _SIR0:                           https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/container/sir0
+.. _PX:                             https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression/px

--- a/skytemple_files/compression_container/at3px/README.rst
+++ b/skytemple_files/compression_container/at3px/README.rst
@@ -3,8 +3,9 @@ AT3PX File Format
 
 The AT3PX container is a format very similar to AT4PX, the only difference is that the decompressed data field is omitted, 
 which free 2 bytes as opposed to AT4PX.
+This is natively supported by the game, but never used. This is likely because this format can't provide the decompressed
+size, which is used sometimes by the game (but not always!)
 
-Its not unusual to find AT3PX containers wrapped itself by a SIR0_ container.
 Its content is compressed using a custom compression format dubbed `PX`_ Compression for the lack of a better name.
 
 Usage

--- a/skytemple_files/compression_container/at3px/__init__.py
+++ b/skytemple_files/compression_container/at3px/__init__.py
@@ -15,22 +15,3 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
-from skytemple_files.common.types.data_handler import DataHandler
-from skytemple_files.graphics.bgp.model import Bgp
-from skytemple_files.graphics.bgp.writer import BgpWriter
-
-
-class BgpHandler(DataHandler[Bgp]):
-    @classmethod
-    def deserialize(cls, data: bytes, **kwargs) -> Bgp:
-        from skytemple_files.common.types.file_types import FileType
-        return Bgp(FileType.COMMON_AT.deserialize(data).decompress())
-
-    @classmethod
-    def serialize(cls, data: Bgp, **kwargs) -> bytes:
-        from skytemple_files.common.types.file_types import FileType
-        return FileType.COMMON_AT.serialize(
-            FileType.COMMON_AT.compress(
-                BgpWriter(data).write()
-            )
-        )

--- a/skytemple_files/compression_container/at3px/handler.py
+++ b/skytemple_files/compression_container/at3px/handler.py
@@ -17,40 +17,35 @@
 
 from skytemple_files.common.types.data_handler import DataHandler
 from skytemple_files.common.util import read_bytes
-from skytemple_files.compression_container.at4pn.model import At4pn
+from skytemple_files.compression_container.at3px.model import At3px
 
 
-class At4pnHandler(DataHandler[At4pn]):
+class At3pxHandler(DataHandler[At3px]):
     @classmethod
-    def deserialize(cls, data: bytes, **kwargs) -> At4pn:
-        """Load a AT4PX container into a high-level representation"""
+    def deserialize(cls, data: bytes, **kwargs) -> At3px:
+        """Load a AT3PX container into a high-level representation"""
         if not cls.matches(data):
-            raise ValueError("The provided data is not an AT4PN container.")
-        return At4pn(data)
+            raise ValueError("The provided data is not an AT3PX container.")
+        return At3px(data)
 
     @classmethod
-    def serialize(cls, data: At4pn, **kwargs) -> bytes:
-        """Convert the high-level AT4PN representation back into bytes."""
+    def serialize(cls, data: At3px, **kwargs) -> bytes:
+        """Convert the high-level AT3PX representation back into a BitStream."""
         return data.to_bytes()
 
     @classmethod
-    def new(cls, data: bytes) -> At4pn:
-        """Turn uncompressed data into a new AT4PN container"""
-        return At4pn(data, new=True)
+    def compress(cls, data: bytes) -> At3px:
+        """Turn uncompressed data into a new AT3PX container"""
+        return At3px.compress(data)
 
     @classmethod
     def cont_size(cls, data: bytes, byte_offset=0):
-        """Get the size of an AT4PN container starting at the given offset in data."""
+        """Get the size of an AT3PX container starting at the given offset in data."""
         if not cls.matches(data, byte_offset):
-            raise ValueError("The provided data is not an AT4PN container.")
-        return At4pn.cont_size(data, byte_offset)
+            raise ValueError("The provided data is not an AT3PX container.")
+        return At4px.cont_size(data, byte_offset)
 
     @classmethod
     def matches(cls, data: bytes, byte_offset=0):
-        """Check if the given data is a At4pn container"""
-        return read_bytes(data, byte_offset, 5) == b'AT4PN'
-
-    # For compatibility with other AT formats
-    @classmethod
-    def compress(cls, data: bytes) -> At4pn:
-        return At4pn.compress(data)
+        """Check if the given data stream is a At3px container"""
+        return read_bytes(data, byte_offset, 5) == b'AT3PX'

--- a/skytemple_files/compression_container/at3px/handler.py
+++ b/skytemple_files/compression_container/at3px/handler.py
@@ -43,7 +43,7 @@ class At3pxHandler(DataHandler[At3px]):
         """Get the size of an AT3PX container starting at the given offset in data."""
         if not cls.matches(data, byte_offset):
             raise ValueError("The provided data is not an AT3PX container.")
-        return At4px.cont_size(data, byte_offset)
+        return At3px.cont_size(data, byte_offset)
 
     @classmethod
     def matches(cls, data: bytes, byte_offset=0):

--- a/skytemple_files/compression_container/at3px/model.py
+++ b/skytemple_files/compression_container/at3px/model.py
@@ -19,33 +19,29 @@ from skytemple_files.common.util import *
 from skytemple_files.compression_container.common_at.model import CommonAt
 
 
-class At4px(CommonAt):
+class At3px(CommonAt):
     def __init__(self, data: bytes=None):
         """
-        Create a AT4PX container from already compressed data.
+        Create a AT3PX container from already compressed data.
         Setting data None is private, use compress instead for compressing data.
         """
         if data:
             self.length_compressed = self.cont_size(data)
             self.compression_flags = read_bytes(data, 7, 9)
-            self.length_decompressed = read_uintle(data, 0x10, 2)
-            self.compressed_data = data[0x12:]
+            self.compressed_data = data[0x10:]
 
     def decompress(self) -> bytes:
         """Returns the uncompressed data stored in the container"""
         from skytemple_files.common.types.file_types import FileType
 
-        data = FileType.PX.decompress(self.compressed_data[:self.length_compressed - 0x12], self.compression_flags)
-        # Sanity assertion, if everything is implemented correctly this doesn't fail.
-        assert len(data) == self.length_decompressed
+        data = FileType.PX.decompress(self.compressed_data[:self.length_compressed - 0x10], self.compression_flags)
         return data
 
     def to_bytes(self) -> bytes:
         """Converts the container back into a bit (compressed) representation"""
-        return b'AT4PX'\
+        return b'AT3PX'\
                + self.length_compressed.to_bytes(2, 'little') \
                + self.compression_flags \
-               + self.length_decompressed.to_bytes(2, 'little') \
                + self.compressed_data
 
     @classmethod
@@ -54,14 +50,13 @@ class At4px(CommonAt):
 
     @classmethod
     def compress(cls, data: bytes) -> CommonAt:
-        """Create a new AT4PX container from originally uncompressed data."""
+        """Create a new AT3PX container from originally uncompressed data."""
         from skytemple_files.common.types.file_types import FileType
 
         new_container = cls()
         flags, px_data = FileType.PX.compress(data)
 
         new_container.compression_flags = flags
-        new_container.length_decompressed = len(data)
         new_container.compressed_data = px_data
-        new_container.length_compressed = len(px_data) + 0x12
+        new_container.length_compressed = len(px_data) + 0x10
         return new_container

--- a/skytemple_files/compression_container/at4pn/model.py
+++ b/skytemple_files/compression_container/at4pn/model.py
@@ -16,9 +16,9 @@
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
 from skytemple_files.common.util import *
+from skytemple_files.compression_container.common_at.model import CommonAt
 
-
-class At4pn:
+class At4pn(CommonAt):
     def __init__(self, data: bytes, new=False):
         """
         Create a AT4PN container from data.
@@ -43,3 +43,12 @@ class At4pn:
     @classmethod
     def cont_size(cls, data: bytes, byte_offset=0):
         return read_uintle(data, byte_offset + 5, 2)
+
+
+    # For compatibility with other AT formats
+    def decompress(self) -> bytes:
+        return self.get()
+
+    @classmethod
+    def compress(cls, data: bytes) -> CommonAt:
+        return At4pn(data, new=True)

--- a/skytemple_files/compression_container/atupx/README.rst
+++ b/skytemple_files/compression_container/atupx/README.rst
@@ -50,3 +50,4 @@ Based on following documentations:
 .. Links:
 
 .. _AT6P Decompressor Class:  https://github.com/pleonex/tinke/blob/master/Plugins/999HRPERDOOR/999HRPERDOOR/AT6P.cs
+.. _CUSTOM999:  https://github.com/SkyTemple/skytemple-files/tree/master/skytemple_files/compression/custom_999

--- a/skytemple_files/compression_container/atupx/README.rst
+++ b/skytemple_files/compression_container/atupx/README.rst
@@ -1,0 +1,62 @@
+AT3PX File Format
+=================
+
+The AT3PX container is a format very similar to AT4PX, the only difference is that the decompressed data field is omitted, 
+which free 2 bytes as opposed to AT4PX.
+
+Its not unusual to find AT3PX containers wrapped itself by a SIR0_ container.
+Its content is compressed using a custom compression format dubbed `PX`_ Compression for the lack of a better name.
+
+Usage
+-----
+Use the class ``At3pxHandler`` of the ``handler`` module, to open and save
+models from binary data. The model that the handler returns is in the
+module ``model``.
+
+File Format
+-----------
+
++---------+--------+-----------+---------------------+-------------------------------------------------------------+
+| Offset  | Length | Type      | Name                | Description                                                 |
++=========+========+===========+=====================+=============================================================+
+| 0x00    | 5      | string    | Magic Number        | ASCII "AT3PX"                                               |
++---------+--------+-----------+---------------------+-------------------------------------------------------------+
+| 0x05    | 2      | uint16le  | Container Length    | The length from the beginning of the header(!) to the end   |
+|         |        |           |                     | of the compressed data.                                     |
++---------+--------+-----------+---------------------+-------------------------------------------------------------+
+| 0x07    | 9      |           | Control Flags       | A list of flags to be used in decompressing the container's |
+|         |        |           |                     | content.                                                    |
+|         |        |           |                     | More detail about their purpose in the PX_ README.          |
+|         |        |           |                     | Flags are stored in lower half of each byte.                |
++---------+--------+-----------+---------------------+-------------------------------------------------------------+
+| 0x10    | Varies | PX_       | PX_ Compressed Data                                                               |
++---------+--------+-----------+---------------------+-------------------------------------------------------------+
+
+Credits
+-------
+I didn't do much of the work figuring out the file format. Without the following people, this implementation
+wouldn't have been possible:
+
+- psy_commando_ (C++ implementation, documentation and most of the research work!)
+- Zhorken_ (Figured out PX compression and header)
+
+(There are propably more people that worked on this! I collected the names from existing documentation I found.
+If I missed you, please open an Issue!)
+
+Based on following documentations:
+
+- `Project Pokémon documentation`_ (Documentation mostly adapted from there!)
+- `psy_commando Dropbox`_
+
+
+.. Links:
+
+.. _Project Pokémon documentation:  https://projectpokemon.org/docs/mystery-dungeon-nds/at4px-file-format-r40/
+.. _psy_commando Dropbox:           https://www.dropbox.com/sh/8on92uax2mf79gv/AADCmlKOD9oC_NhHnRXVdmMSa?dl=0
+
+.. _psy_commando:                   https://github.com/PsyCommando/
+.. _Zhorken:                        https://github.com/Zhorken
+
+.. _PKDPX:                          https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression_container/pkdpx
+.. _SIR0:                           https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/container/sir0
+.. _PX:                             https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression/px

--- a/skytemple_files/compression_container/atupx/README.rst
+++ b/skytemple_files/compression_container/atupx/README.rst
@@ -1,15 +1,16 @@
-AT3PX File Format
+ATUPX File Format
 =================
 
-The AT3PX container is a format very similar to AT4PX, the only difference is that the decompressed data field is omitted, 
-which free 2 bytes as opposed to AT4PX.
+The ATUPX container is a custom format.
 
-Its not unusual to find AT3PX containers wrapped itself by a SIR0_ container.
-Its content is compressed using a custom compression format dubbed `PX`_ Compression for the lack of a better name.
+Its content is compressed using a custom compression format dubbed `Custom999`_ Compression.
+This compression format is a modified version of the AT6P container compression format used in 999.
+Changes made to the original algorithm are documented in the code.
+This isn't natively supported by the game, but can be added via asm patching.
 
 Usage
 -----
-Use the class ``At3pxHandler`` of the ``handler`` module, to open and save
+Use the class ``AtupxHandler`` of the ``handler`` module, to open and save
 models from binary data. The model that the handler returns is in the
 module ``model``.
 
@@ -19,17 +20,16 @@ File Format
 +---------+--------+-----------+---------------------+-------------------------------------------------------------+
 | Offset  | Length | Type      | Name                | Description                                                 |
 +=========+========+===========+=====================+=============================================================+
-| 0x00    | 5      | string    | Magic Number        | ASCII "AT3PX"                                               |
+| 0x00    | 5      | string    | Magic Number        | ASCII "ATUPX"                                               |
 +---------+--------+-----------+---------------------+-------------------------------------------------------------+
 | 0x05    | 2      | uint16le  | Container Length    | The length from the beginning of the header(!) to the end   |
 |         |        |           |                     | of the compressed data.                                     |
 +---------+--------+-----------+---------------------+-------------------------------------------------------------+
-| 0x07    | 9      |           | Control Flags       | A list of flags to be used in decompressing the container's |
-|         |        |           |                     | content.                                                    |
-|         |        |           |                     | More detail about their purpose in the PX_ README.          |
-|         |        |           |                     | Flags are stored in lower half of each byte.                |
+| 0x07    | 4      | uint16le  | Decompressed data   | The length of the dcompressed data.                         |
+|         |        |           | Length              |                                                             |
 +---------+--------+-----------+---------------------+-------------------------------------------------------------+
-| 0x10    | Varies | PX_       | PX_ Compressed Data                                                               |
+| 0x0b    | Varies | Custom999_| Custom999_                                                                        |
+|         |        |           | Compressed Data                                                                   |
 +---------+--------+-----------+---------------------+-------------------------------------------------------------+
 
 Credits
@@ -37,26 +37,16 @@ Credits
 I didn't do much of the work figuring out the file format. Without the following people, this implementation
 wouldn't have been possible:
 
-- psy_commando_ (C++ implementation, documentation and most of the research work!)
-- Zhorken_ (Figured out PX compression and header)
+- pleoNeX and CUE (for the decompression algorithm of the original format).
 
 (There are propably more people that worked on this! I collected the names from existing documentation I found.
 If I missed you, please open an Issue!)
 
 Based on following documentations:
 
-- `Project Pokémon documentation`_ (Documentation mostly adapted from there!)
-- `psy_commando Dropbox`_
+- The `AT6P Decompressor Class`_ (Documentation mostly adapted from there!)
 
 
 .. Links:
 
-.. _Project Pokémon documentation:  https://projectpokemon.org/docs/mystery-dungeon-nds/at4px-file-format-r40/
-.. _psy_commando Dropbox:           https://www.dropbox.com/sh/8on92uax2mf79gv/AADCmlKOD9oC_NhHnRXVdmMSa?dl=0
-
-.. _psy_commando:                   https://github.com/PsyCommando/
-.. _Zhorken:                        https://github.com/Zhorken
-
-.. _PKDPX:                          https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression_container/pkdpx
-.. _SIR0:                           https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/container/sir0
-.. _PX:                             https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression/px
+.. _AT6P Decompressor Class:  https://github.com/pleonex/tinke/blob/master/Plugins/999HRPERDOOR/999HRPERDOOR/AT6P.cs

--- a/skytemple_files/compression_container/atupx/__init__.py
+++ b/skytemple_files/compression_container/atupx/__init__.py
@@ -15,22 +15,3 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
-from skytemple_files.common.types.data_handler import DataHandler
-from skytemple_files.graphics.bgp.model import Bgp
-from skytemple_files.graphics.bgp.writer import BgpWriter
-
-
-class BgpHandler(DataHandler[Bgp]):
-    @classmethod
-    def deserialize(cls, data: bytes, **kwargs) -> Bgp:
-        from skytemple_files.common.types.file_types import FileType
-        return Bgp(FileType.COMMON_AT.deserialize(data).decompress())
-
-    @classmethod
-    def serialize(cls, data: Bgp, **kwargs) -> bytes:
-        from skytemple_files.common.types.file_types import FileType
-        return FileType.COMMON_AT.serialize(
-            FileType.COMMON_AT.compress(
-                BgpWriter(data).write()
-            )
-        )

--- a/skytemple_files/compression_container/atupx/handler.py
+++ b/skytemple_files/compression_container/atupx/handler.py
@@ -17,40 +17,35 @@
 
 from skytemple_files.common.types.data_handler import DataHandler
 from skytemple_files.common.util import read_bytes
-from skytemple_files.compression_container.at4pn.model import At4pn
+from skytemple_files.compression_container.atupx.model import Atupx
 
 
-class At4pnHandler(DataHandler[At4pn]):
+class AtupxHandler(DataHandler[Atupx]):
     @classmethod
-    def deserialize(cls, data: bytes, **kwargs) -> At4pn:
-        """Load a AT4PX container into a high-level representation"""
+    def deserialize(cls, data: bytes, **kwargs) -> Atupx:
+        """Load a ATUPX container into a high-level representation"""
         if not cls.matches(data):
-            raise ValueError("The provided data is not an AT4PN container.")
-        return At4pn(data)
+            raise ValueError("The provided data is not an ATUPX container.")
+        return Atupx(data)
 
     @classmethod
-    def serialize(cls, data: At4pn, **kwargs) -> bytes:
-        """Convert the high-level AT4PN representation back into bytes."""
+    def serialize(cls, data: Atupx, **kwargs) -> bytes:
+        """Convert the high-level ATUPX representation back into a BitStream."""
         return data.to_bytes()
 
     @classmethod
-    def new(cls, data: bytes) -> At4pn:
-        """Turn uncompressed data into a new AT4PN container"""
-        return At4pn(data, new=True)
+    def compress(cls, data: bytes) -> Atupx:
+        """Turn uncompressed data into a new AT3PX container"""
+        return Atupx.compress(data)
 
     @classmethod
     def cont_size(cls, data: bytes, byte_offset=0):
-        """Get the size of an AT4PN container starting at the given offset in data."""
+        """Get the size of an ATUPX container starting at the given offset in data."""
         if not cls.matches(data, byte_offset):
-            raise ValueError("The provided data is not an AT4PN container.")
-        return At4pn.cont_size(data, byte_offset)
+            raise ValueError("The provided data is not an ATUPX container.")
+        return Atupx.cont_size(data, byte_offset)
 
     @classmethod
     def matches(cls, data: bytes, byte_offset=0):
-        """Check if the given data is a At4pn container"""
-        return read_bytes(data, byte_offset, 5) == b'AT4PN'
-
-    # For compatibility with other AT formats
-    @classmethod
-    def compress(cls, data: bytes) -> At4pn:
-        return At4pn.compress(data)
+        """Check if the given data stream is a Atupx container"""
+        return read_bytes(data, byte_offset, 5) == b'ATUPX'

--- a/skytemple_files/compression_container/common_at/README.rst
+++ b/skytemple_files/compression_container/common_at/README.rst
@@ -1,0 +1,62 @@
+AT3PX File Format
+=================
+
+The AT3PX container is a format very similar to AT4PX, the only difference is that the decompressed data field is omitted, 
+which free 2 bytes as opposed to AT4PX.
+
+Its not unusual to find AT3PX containers wrapped itself by a SIR0_ container.
+Its content is compressed using a custom compression format dubbed `PX`_ Compression for the lack of a better name.
+
+Usage
+-----
+Use the class ``At3pxHandler`` of the ``handler`` module, to open and save
+models from binary data. The model that the handler returns is in the
+module ``model``.
+
+File Format
+-----------
+
++---------+--------+-----------+---------------------+-------------------------------------------------------------+
+| Offset  | Length | Type      | Name                | Description                                                 |
++=========+========+===========+=====================+=============================================================+
+| 0x00    | 5      | string    | Magic Number        | ASCII "AT3PX"                                               |
++---------+--------+-----------+---------------------+-------------------------------------------------------------+
+| 0x05    | 2      | uint16le  | Container Length    | The length from the beginning of the header(!) to the end   |
+|         |        |           |                     | of the compressed data.                                     |
++---------+--------+-----------+---------------------+-------------------------------------------------------------+
+| 0x07    | 9      |           | Control Flags       | A list of flags to be used in decompressing the container's |
+|         |        |           |                     | content.                                                    |
+|         |        |           |                     | More detail about their purpose in the PX_ README.          |
+|         |        |           |                     | Flags are stored in lower half of each byte.                |
++---------+--------+-----------+---------------------+-------------------------------------------------------------+
+| 0x10    | Varies | PX_       | PX_ Compressed Data                                                               |
++---------+--------+-----------+---------------------+-------------------------------------------------------------+
+
+Credits
+-------
+I didn't do much of the work figuring out the file format. Without the following people, this implementation
+wouldn't have been possible:
+
+- psy_commando_ (C++ implementation, documentation and most of the research work!)
+- Zhorken_ (Figured out PX compression and header)
+
+(There are propably more people that worked on this! I collected the names from existing documentation I found.
+If I missed you, please open an Issue!)
+
+Based on following documentations:
+
+- `Project Pokémon documentation`_ (Documentation mostly adapted from there!)
+- `psy_commando Dropbox`_
+
+
+.. Links:
+
+.. _Project Pokémon documentation:  https://projectpokemon.org/docs/mystery-dungeon-nds/at4px-file-format-r40/
+.. _psy_commando Dropbox:           https://www.dropbox.com/sh/8on92uax2mf79gv/AADCmlKOD9oC_NhHnRXVdmMSa?dl=0
+
+.. _psy_commando:                   https://github.com/PsyCommando/
+.. _Zhorken:                        https://github.com/Zhorken
+
+.. _PKDPX:                          https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression_container/pkdpx
+.. _SIR0:                           https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/container/sir0
+.. _PX:                             https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression/px

--- a/skytemple_files/compression_container/common_at/README.rst
+++ b/skytemple_files/compression_container/common_at/README.rst
@@ -1,15 +1,14 @@
-AT3PX File Format
+AT File Format
 =================
 
-The AT3PX container is a format very similar to AT4PX, the only difference is that the decompressed data field is omitted, 
-which free 2 bytes as opposed to AT4PX.
+The common file format for AT3PX, AT4PX, PKDPX and AT4PN files.
+All those files formats can be swapped when the game needs one of those.
 
-Its not unusual to find AT3PX containers wrapped itself by a SIR0_ container.
-Its content is compressed using a custom compression format dubbed `PX`_ Compression for the lack of a better name.
+Its not unusual to find AT containers wrapped itself by a SIR0_ container.
 
 Usage
 -----
-Use the class ``At3pxHandler`` of the ``handler`` module, to open and save
+Use the class ``CommonAtHandler`` of the ``handler`` module, to open and save
 models from binary data. The model that the handler returns is in the
 module ``model``.
 
@@ -19,17 +18,10 @@ File Format
 +---------+--------+-----------+---------------------+-------------------------------------------------------------+
 | Offset  | Length | Type      | Name                | Description                                                 |
 +=========+========+===========+=====================+=============================================================+
-| 0x00    | 5      | string    | Magic Number        | ASCII "AT3PX"                                               |
+| 0x00    | 5      | string    | Magic Number        | Varies depending on the AT container                        |
 +---------+--------+-----------+---------------------+-------------------------------------------------------------+
-| 0x05    | 2      | uint16le  | Container Length    | The length from the beginning of the header(!) to the end   |
-|         |        |           |                     | of the compressed data.                                     |
-+---------+--------+-----------+---------------------+-------------------------------------------------------------+
-| 0x07    | 9      |           | Control Flags       | A list of flags to be used in decompressing the container's |
-|         |        |           |                     | content.                                                    |
-|         |        |           |                     | More detail about their purpose in the PX_ README.          |
-|         |        |           |                     | Flags are stored in lower half of each byte.                |
-+---------+--------+-----------+---------------------+-------------------------------------------------------------+
-| 0x10    | Varies | PX_       | PX_ Compressed Data                                                               |
+| 0x05    | 2      | uint16le  | Container Length    | For most the length of the whole container                  |
+|         |        |           |                     | Only the length of the data for AT4PN files                 |
 +---------+--------+-----------+---------------------+-------------------------------------------------------------+
 
 Credits
@@ -58,5 +50,7 @@ Based on following documentations:
 .. _Zhorken:                        https://github.com/Zhorken
 
 .. _PKDPX:                          https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression_container/pkdpx
+.. _AT3PX:                          https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression_container/at3px
+.. _AT4PX:                          https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression_container/at4px
+.. _AT4PN:                          https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression_container/at4pn
 .. _SIR0:                           https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/container/sir0
-.. _PX:                             https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression/px

--- a/skytemple_files/compression_container/common_at/__init__.py
+++ b/skytemple_files/compression_container/common_at/__init__.py
@@ -15,22 +15,3 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
-from skytemple_files.common.types.data_handler import DataHandler
-from skytemple_files.graphics.bgp.model import Bgp
-from skytemple_files.graphics.bgp.writer import BgpWriter
-
-
-class BgpHandler(DataHandler[Bgp]):
-    @classmethod
-    def deserialize(cls, data: bytes, **kwargs) -> Bgp:
-        from skytemple_files.common.types.file_types import FileType
-        return Bgp(FileType.COMMON_AT.deserialize(data).decompress())
-
-    @classmethod
-    def serialize(cls, data: Bgp, **kwargs) -> bytes:
-        from skytemple_files.common.types.file_types import FileType
-        return FileType.COMMON_AT.serialize(
-            FileType.COMMON_AT.compress(
-                BgpWriter(data).write()
-            )
-        )

--- a/skytemple_files/compression_container/common_at/handler.py
+++ b/skytemple_files/compression_container/common_at/handler.py
@@ -47,14 +47,11 @@ class CommonAtType(Enum):
         self.auto_allowed = auto_allowed
 
 # Pre-built lists for compression
-COMMON_AT_BEST_3 = COMMON_AT_BEST_4 = COMMON_AT_MUST_COMPRESS_3 = COMMON_AT_MUST_COMPRESS_4 = COMMON_AT_PKD = [CommonAtType.ATUPX]
-"""
 COMMON_AT_BEST_3 = [CommonAtType.AT4PN, CommonAtType.ATUPX, CommonAtType.AT3PX, CommonAtType.PKDPX]
 COMMON_AT_BEST_4 = [CommonAtType.AT4PN, CommonAtType.ATUPX, CommonAtType.AT4PX, CommonAtType.PKDPX]
 COMMON_AT_MUST_COMPRESS_3 = [CommonAtType.ATUPX, CommonAtType.AT3PX, CommonAtType.PKDPX]
 COMMON_AT_MUST_COMPRESS_4 = [CommonAtType.ATUPX, CommonAtType.AT4PX, CommonAtType.PKDPX]
 COMMON_AT_PKD = [CommonAtType.PKDPX]
-"""
 
 DEBUG = False
 

--- a/skytemple_files/compression_container/common_at/handler.py
+++ b/skytemple_files/compression_container/common_at/handler.py
@@ -1,0 +1,120 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from enum import Enum, auto
+from typing import Optional, List
+
+from skytemple_files.common.types.data_handler import DataHandler
+from skytemple_files.common.util import read_bytes
+from skytemple_files.compression_container.common_at.model import CommonAt
+from skytemple_files.compression_container.atupx.handler import AtupxHandler
+from skytemple_files.compression_container.at4px.handler import At4pxHandler
+from skytemple_files.compression_container.at3px.handler import At3pxHandler
+from skytemple_files.compression_container.at4pn.handler import At4pnHandler
+from skytemple_files.compression_container.pkdpx.handler import PkdpxHandler
+
+class CommonAtType(Enum):
+    AT4PN = auto(), At4pnHandler, True
+    AT3PX = auto(), At3pxHandler, True
+    AT4PX = auto(), At4pxHandler, True
+    ATUPX = auto(), AtupxHandler, False
+    PKDPX = auto(), PkdpxHandler, True
+    
+    def __new__(cls, *args, **kwargs):
+        obj = object.__new__(cls)
+        obj._value_ = args[0]
+        return obj
+
+    # ignore the first param since it's already set by __new__
+    def __init__(
+            self, _: int, handler: Optional[DataHandler[CommonAt]], auto_allowed: bool
+    ):
+        self.handler = handler
+        self.auto_allowed = auto_allowed
+
+# Pre-built lists for compression
+COMMON_AT_BEST_3 = [CommonAtType.ATUPX, CommonAtType.AT4PN, CommonAtType.AT3PX]
+COMMON_AT_BEST_4 = [CommonAtType.ATUPX, CommonAtType.AT4PN, CommonAtType.AT4PX]
+COMMON_AT_MUST_COMPRESS_3 = [CommonAtType.ATUPX, CommonAtType.AT3PX]
+COMMON_AT_MUST_COMPRESS_4 = [CommonAtType.ATUPX, CommonAtType.AT4PX]
+COMMON_AT_PKD = [CommonAtType.PKDPX]
+
+class CommonAtHandler(DataHandler[CommonAt]):
+    allowed_types = set()
+    for t in CommonAtType:
+        if t.auto_allowed:
+            allowed_types.add(t)
+    
+    @classmethod
+    def allow(cls, compression_type: CommonAtType):
+        cls.allowed_types.add(compression_type)
+        print(cls.allowed_types)
+    @classmethod
+    def disallow(cls, compression_type: CommonAtType):
+        try:
+            cls.allowed_types.remove(compression_type)
+        except KeyError as ke:pass #TODO, add warning
+        print(cls.allowed_types)
+    
+    @classmethod
+    def deserialize(cls, data: bytes, **kwargs) -> CommonAt:
+        """Load a Common At container into a high-level representation"""
+        for t in CommonAtType:
+            if t.handler!=None:
+                if t.handler.matches(data):
+                    print(t)
+                    return t.handler.deserialize(data, **kwargs)
+        raise ValueError(f"The provided data is not an AT container ({read_bytes(data, 0, 5)}).")
+
+    @classmethod
+    def serialize(cls, data: CommonAt, **kwargs) -> bytes:
+        """Convert the high-level AT representation back into a BitStream."""
+        return data.to_bytes()
+
+    @classmethod
+    def compress(cls, data: bytes, compression_type: List[CommonAtType] = COMMON_AT_BEST_4) -> CommonAt:
+        """Turn uncompressed data into a new AT container"""
+        new_data = None
+        new_size = -1
+        for t in compression_type:
+            if t in CommonAtHandler.allowed_types:
+                try:
+                    cont = t.handler.compress(data)
+                    size = len(cont.to_bytes())
+                    print(t, size)
+                    if new_data==None or size<new_size:
+                        new_data = cont
+                        new_size = size
+                except:pass
+        if new_data==None:
+            raise ValueError("No useable compression algorithm.")
+        return new_data
+
+    @classmethod
+    def cont_size(cls, data: bytes, byte_offset=0):
+        for t in CommonAtType:
+            if t.handler.matches(data, byte_offset):
+                return t.handler.cont_size(data, byte_offset)
+        raise ValueError("The provided data is not an AT container.")
+
+    @classmethod
+    def matches(cls, data: bytes, byte_offset=0):
+        """Check if the given data stream is an AT container"""
+        for t in CommonAtType:
+            if t.handler.matches(data, byte_offset):
+                return True
+        return False

--- a/skytemple_files/compression_container/common_at/model.py
+++ b/skytemple_files/compression_container/common_at/model.py
@@ -15,22 +15,25 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
-from skytemple_files.common.types.data_handler import DataHandler
-from skytemple_files.graphics.bgp.model import Bgp
-from skytemple_files.graphics.bgp.writer import BgpWriter
+from abc import ABC, abstractmethod
+from skytemple_files.common.util import *
 
 
-class BgpHandler(DataHandler[Bgp]):
+
+class CommonAt(ABC):
+
+    @abstractmethod
+    def decompress(self) -> bytes:
+        """Returns the uncompressed data stored in the container"""
+
+    @abstractmethod
+    def to_bytes(self) -> bytes:
+        """Converts the container back into a bit (compressed) representation"""
+
     @classmethod
-    def deserialize(cls, data: bytes, **kwargs) -> Bgp:
-        from skytemple_files.common.types.file_types import FileType
-        return Bgp(FileType.COMMON_AT.deserialize(data).decompress())
+    def cont_size(cls, data: bytes, byte_offset=0):
+        """Returns the container size"""
 
     @classmethod
-    def serialize(cls, data: Bgp, **kwargs) -> bytes:
-        from skytemple_files.common.types.file_types import FileType
-        return FileType.COMMON_AT.serialize(
-            FileType.COMMON_AT.compress(
-                BgpWriter(data).write()
-            )
-        )
+    def compress(cls, data: bytes) -> 'CommonAt':
+        """Create a new AT container from originally uncompressed data."""

--- a/skytemple_files/compression_container/pkdpx/model.py
+++ b/skytemple_files/compression_container/pkdpx/model.py
@@ -16,9 +16,10 @@
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
 from skytemple_files.common.util import *
+from skytemple_files.compression_container.common_at.model import CommonAt
 
 
-class Pkdpx:
+class Pkdpx(CommonAt):
     def __init__(self, data: bytes=None):
         """
         Create a PKDPX container from already compressed data.
@@ -52,7 +53,7 @@ class Pkdpx:
         return read_uintle(data, byte_offset + 5, 2)
 
     @classmethod
-    def compress(cls, data: bytes) -> 'Pkdpx':
+    def compress(cls, data: bytes) -> CommonAt:
         """Create a new PKDPX container from originally uncompressed data."""
         from skytemple_files.common.types.file_types import FileType
 

--- a/skytemple_files/container/dungeon_bin/dbg/corrupt_test.py
+++ b/skytemple_files/container/dungeon_bin/dbg/corrupt_test.py
@@ -27,7 +27,7 @@ from skytemple_files.common.util import get_ppmdu_config_for_rom, iter_bytes, it
     read_uintle
 from skytemple_files.container.dungeon_bin.handler import DungeonBinHandler
 from skytemple_files.container.dungeon_bin.sub.sir0_at4px import DbinSir0At4pxHandler
-from skytemple_files.compression_container.at4px.model import At4px
+from skytemple_files.compression_container.common_at.model import CommonAt
 
 from itertools import islice
 
@@ -53,7 +53,7 @@ def corrupt171():
     img171 = dungeon_bin[171].decompress()
     # Make the first entry tile 2
     img171 = b'\x02' * len(img171)
-    dungeon_bin[171] = FileType.AT4PX.compress(img171)
+    dungeon_bin[171] = FileType.COMMON_AT.compress(img171)
 
 
 def corrupt341():
@@ -102,7 +102,7 @@ def corrupt341():
 
     with open('/tmp/corrupt.bin', 'wb') as f:
         f.write(img341new)
-    dungeon_bin[341] = FileType.AT4PX.compress(img341new)
+    dungeon_bin[341] = FileType.COMMON_AT.compress(img341new)
 
 
 def corrupt511():
@@ -115,7 +115,7 @@ def corrupt511():
             img511new[i] = img511[i]
         else:
             img511new[i] = 2
-    dungeon_bin[511] = FileType.AT4PX.compress(img511new)
+    dungeon_bin[511] = FileType.COMMON_AT.compress(img511new)
 
 # -- /
 

--- a/skytemple_files/container/dungeon_bin/dbg/export_test.py
+++ b/skytemple_files/container/dungeon_bin/dbg/export_test.py
@@ -23,7 +23,7 @@ from ndspy.rom import NintendoDSRom
 from skytemple_files.common.tiled_image import to_pil, TilemapEntry
 from skytemple_files.common.util import get_ppmdu_config_for_rom, iter_bytes
 from skytemple_files.container.dungeon_bin.handler import DungeonBinHandler
-from skytemple_files.compression_container.at4px.model import At4px
+from skytemple_files.compression_container.common_at.model import CommonAt
 
 from itertools import islice
 
@@ -74,9 +74,9 @@ def output_raw_palette(fn: str, file: Dpl):
     out_img.save(os.path.join(output_dir, fn + '.png'))
 
 
-def output_at4px_water_tiles(fn: str, at4px: At4px, pal: Dpla):
-    print("Outputting water AT4PX as image.")
-    img_bin = at4px.decompress()
+def output_at_water_tiles(fn: str, common_at: CommonAt, pal: Dpla):
+    print("Outputting water AT as image.")
+    img_bin = common_at.decompress()
     tiles = list(iter_bytes(img_bin, int(8 * 8 / 2)))
     # create a dummy tile map containing all the tiles
     tilemap = []
@@ -96,9 +96,9 @@ def output_at4px_water_tiles(fn: str, at4px: At4px, pal: Dpla):
     out_img.save(os.path.join(output_dir, fn + '.png'))
 
 
-def output_at4px_dungeon_tiles(fn: str, at4px: At4px, pal: Dpla):
-    print("Outputting dungeon AT4PX as image.")
-    img_bin = at4px.decompress()
+def output_at_dungeon_tiles(fn: str, common_at: CommonAt, pal: Dpla):
+    print("Outputting dungeon AT as image.")
+    img_bin = common_at.decompress()
     tiles = list(iter_bytes(img_bin, int(8 * 8)))
     # create a dummy tile map containing all the tiles
     tilemap = []
@@ -133,15 +133,15 @@ for i, file in enumerate(dungeon_bin):
     print(i, type(file), fn)
     if isinstance(file, Dpla):
         output_dpla(fn, file)
-    elif isinstance(file, At4px):
+    elif isinstance(file, CommonAt):
         # As the palette, we use one of the first 170 files, matching the modulo index.
         # TODO: This is currently using the animated palette actually...
         pal = dungeon_bin[i % 170]
         assert isinstance(pal, Dpla)
         if fdef.name == "dungeon%i.bpci":
-            output_at4px_water_tiles(fn, file, pal)
+            output_at_water_tiles(fn, file, pal)
         else:
-            output_at4px_dungeon_tiles(fn, file, pal)
+            output_at_dungeon_tiles(fn, file, pal)
     elif isinstance(file, Dpl):
         output_raw_palette(fn, file)
     elif isinstance(file, bytes):
@@ -160,6 +160,6 @@ for i, file in enumerate(dungeon_bin.get_files_bytes()):
 
 for i, file in enumerate(dungeon_bin):
     fn = dungeon_bin.get_filename(i)
-    if fn.endswith('.pkdpx.sir0'):
+    if fn.endswith('.at.sir0'):
         with open(os.path.join(output_dir, 'test', fn), 'wb') as f:
             f.write(file.decompress())

--- a/skytemple_files/container/dungeon_bin/sub/at4px_dpc.py
+++ b/skytemple_files/container/dungeon_bin/sub/at4px_dpc.py
@@ -16,7 +16,7 @@
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 from skytemple_files.common.types.data_handler import DataHandler
 from skytemple_files.graphics.dpc.model import Dpc
-
+from skytemple_files.compression_container.common_at.handler import COMMON_AT_BEST_3
 
 class DbinAt4pxDpcHandler(DataHandler[Dpc]):
 
@@ -31,5 +31,5 @@ class DbinAt4pxDpcHandler(DataHandler[Dpc]):
         from skytemple_files.common.types.file_types import FileType
         serialized = FileType.DPC.serialize(data)
         return FileType.COMMON_AT.serialize(
-            FileType.COMMON_AT.compress(serialized)
+            FileType.COMMON_AT.compress(serialized, COMMON_AT_BEST_3)
         )

--- a/skytemple_files/container/dungeon_bin/sub/at4px_dpc.py
+++ b/skytemple_files/container/dungeon_bin/sub/at4px_dpc.py
@@ -23,13 +23,13 @@ class DbinAt4pxDpcHandler(DataHandler[Dpc]):
     @classmethod
     def deserialize(cls, data: bytes, **kwargs) -> Dpc:
         from skytemple_files.common.types.file_types import FileType
-        at4px = FileType.AT4PX.deserialize(data)
-        return FileType.DPC.deserialize(at4px.decompress())
+        at = FileType.COMMON_AT.deserialize(data)
+        return FileType.DPC.deserialize(at.decompress())
 
     @classmethod
     def serialize(cls, data: Dpc, **kwargs) -> bytes:
         from skytemple_files.common.types.file_types import FileType
         serialized = FileType.DPC.serialize(data)
-        return FileType.AT4PX.serialize(
-            FileType.AT4PX.compress(serialized)
+        return FileType.COMMON_AT.serialize(
+            FileType.COMMON_AT.compress(serialized)
         )

--- a/skytemple_files/container/dungeon_bin/sub/at4px_dpci.py
+++ b/skytemple_files/container/dungeon_bin/sub/at4px_dpci.py
@@ -16,7 +16,7 @@
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 from skytemple_files.common.types.data_handler import DataHandler
 from skytemple_files.graphics.dpci.model import Dpci
-
+from skytemple_files.compression_container.common_at.handler import COMMON_AT_BEST_3
 
 class DbinAt4pxDpciHandler(DataHandler[Dpci]):
 
@@ -31,5 +31,5 @@ class DbinAt4pxDpciHandler(DataHandler[Dpci]):
         from skytemple_files.common.types.file_types import FileType
         serialized = FileType.DPCI.serialize(data)
         return FileType.COMMON_AT.serialize(
-            FileType.COMMON_AT.compress(serialized)
+            FileType.COMMON_AT.compress(serialized, COMMON_AT_BEST_3)
         )

--- a/skytemple_files/container/dungeon_bin/sub/at4px_dpci.py
+++ b/skytemple_files/container/dungeon_bin/sub/at4px_dpci.py
@@ -23,13 +23,13 @@ class DbinAt4pxDpciHandler(DataHandler[Dpci]):
     @classmethod
     def deserialize(cls, data: bytes, **kwargs) -> Dpci:
         from skytemple_files.common.types.file_types import FileType
-        at4px = FileType.AT4PX.deserialize(data)
-        return FileType.DPCI.deserialize(at4px.decompress())
+        at = FileType.COMMON_AT.deserialize(data)
+        return FileType.DPCI.deserialize(at.decompress())
 
     @classmethod
     def serialize(cls, data: Dpci, **kwargs) -> bytes:
         from skytemple_files.common.types.file_types import FileType
         serialized = FileType.DPCI.serialize(data)
-        return FileType.AT4PX.serialize(
-            FileType.AT4PX.compress(serialized)
+        return FileType.COMMON_AT.serialize(
+            FileType.COMMON_AT.compress(serialized)
         )

--- a/skytemple_files/container/dungeon_bin/sub/sir0_at4px.py
+++ b/skytemple_files/container/dungeon_bin/sub/sir0_at4px.py
@@ -17,14 +17,14 @@
 
 
 from skytemple_files.common.types.data_handler import DataHandler
-from skytemple_files.compression_container.at4px.model import At4px
+from skytemple_files.compression_container.common_at.model import CommonAt
+from skytemple_files.compression_container.common_at.handler import COMMON_AT_BEST_3
 
-
-class DbinSir0At4pxHandler(DataHandler[At4px]):
-    """A proxy data handler for At4px wrapped in Sir0."""
+class DbinSir0At4pxHandler(DataHandler[CommonAt]):
+    """A proxy data handler for At wrapped in Sir0."""
 
     @classmethod
-    def deserialize(cls, data: bytes, **kwargs) -> At4px:
+    def deserialize(cls, data: bytes, **kwargs) -> CommonAt:
         from skytemple_files.common.types.file_types import FileType
         sir0 = FileType.SIR0.deserialize(data)
         # We don't support more than the two default pointers, since we will also on serialize with those!
@@ -33,29 +33,29 @@ class DbinSir0At4pxHandler(DataHandler[At4px]):
         assert sir0.data_pointer == 0,  "The Sir0 contains a data pointer. That is not supported."
         # XXX: The developers messed up and somehow managed to include parts of
         # the sir0 "footer" in the compressed size.
-        return FileType.AT4PX.deserialize(sir0.content)
+        return FileType.COMMON_AT.deserialize(sir0.content)
 
     @classmethod
-    def serialize(cls, data: At4px, **kwargs) -> bytes:
+    def serialize(cls, data: CommonAt, **kwargs) -> bytes:
         from skytemple_files.common.types.file_types import FileType
-        sir0 = FileType.SIR0.wrap(FileType.AT4PX.serialize(data), [], None)
+        sir0 = FileType.SIR0.wrap(FileType.COMMON_AT.serialize(data), [], None)
         return FileType.SIR0.serialize(sir0)
 
     @classmethod
-    def compress(cls, data: bytes) -> At4px:
+    def compress(cls, data: bytes) -> CommonAt:
         from skytemple_files.common.types.file_types import FileType
-        return FileType.AT4PX.compress(data)
+        return FileType.COMMON_AT.compress(data, COMMON_AT_BEST_3)
 
     @classmethod
     def cont_size(cls, data: bytes, byte_offset=0):
         """Get the size of an AT4PX container starting at the given offset in data."""
         from skytemple_files.common.types.file_types import FileType
         sir0 = FileType.SIR0.deserialize(data)
-        return FileType.AT4PX.cont_size(sir0.content, byte_offset)
+        return FileType.COMMON_AT.cont_size(sir0.content, byte_offset)
 
     @classmethod
     def matches(cls, data: bytes, byte_offset=0):
-        """Check if the given data stream is a At4px container"""
+        """Check if the given data stream is an At container"""
         from skytemple_files.common.types.file_types import FileType
         sir0 = FileType.SIR0.deserialize(data)
-        return FileType.AT4PX.matches(sir0.content, byte_offset)
+        return FileType.COMMON_AT.matches(sir0.content, byte_offset)

--- a/skytemple_files/container/dungeon_bin/sub/sir0_at4px_dma.py
+++ b/skytemple_files/container/dungeon_bin/sub/sir0_at4px_dma.py
@@ -23,13 +23,13 @@ class DbinSir0At4pxDmaHandler(DataHandler[Dma]):
     @classmethod
     def deserialize(cls, data: bytes, **kwargs) -> Dma:
         from skytemple_files.common.types.file_types import FileType
-        at4px = FileType.DBIN_SIR0_AT4PX.deserialize(data)
-        return FileType.DMA.deserialize(at4px.decompress())
+        common_at = FileType.DBIN_SIR0_AT4PX.deserialize(data)
+        return FileType.DMA.deserialize(common_at.decompress())
 
     @classmethod
     def serialize(cls, data: Dma, **kwargs) -> bytes:
         from skytemple_files.common.types.file_types import FileType
         serialized = FileType.DMA.serialize(data)
         return FileType.DBIN_SIR0_AT4PX.serialize(
-            FileType.AT4PX.compress(serialized)
+            FileType.COMMON_AT.compress(serialized)
         )

--- a/skytemple_files/container/dungeon_bin/sub/sir0_pkdpx.py
+++ b/skytemple_files/container/dungeon_bin/sub/sir0_pkdpx.py
@@ -17,43 +17,43 @@
 
 
 from skytemple_files.common.types.data_handler import DataHandler
-from skytemple_files.compression_container.pkdpx.model import Pkdpx
+from skytemple_files.compression_container.common_at.model import CommonAt
+from skytemple_files.compression_container.common_at.handler import COMMON_AT_BEST_3
 
-
-class DbinSir0PkdpxHandler(DataHandler[Pkdpx]):
-    """A proxy data handler for Pkdpx wrapped in Sir0."""
+class DbinSir0PkdpxHandler(DataHandler[CommonAt]):
+    """A proxy data handler for AT container wrapped in Sir0."""
 
     @classmethod
-    def deserialize(cls, data: bytes, **kwargs) -> Pkdpx:
+    def deserialize(cls, data: bytes, **kwargs) -> CommonAt:
         from skytemple_files.common.types.file_types import FileType
         sir0 = FileType.SIR0.deserialize(data)
         # We don't support more than the two default pointers, since we will also on serialize with those!
         assert len(sir0.content_pointer_offsets) == 0, "The Sir0 contains an unexpected amount of pointers."
         # We don't support a data pointer, because we will also serialize without.
         assert sir0.data_pointer == 0,  "The Sir0 contains a data pointer. That is not supported."
-        return FileType.PKDPX.deserialize(sir0.content)
+        return FileType.COMMON_AT.deserialize(sir0.content)
 
     @classmethod
-    def serialize(cls, data: Pkdpx, **kwargs) -> bytes:
+    def serialize(cls, data: CommonAt, **kwargs) -> bytes:
         from skytemple_files.common.types.file_types import FileType
-        sir0 = FileType.SIR0.wrap(FileType.PKDPX.serialize(data), [], None)
+        sir0 = FileType.SIR0.wrap(FileType.COMMON_AT.serialize(data), [], None)
         return FileType.SIR0.serialize(sir0)
 
     @classmethod
-    def compress(cls, data: bytes) -> Pkdpx:
+    def compress(cls, data: bytes) -> CommonAt:
         from skytemple_files.common.types.file_types import FileType
-        return FileType.PKDPX.compress(data)
+        return FileType.COMMON_AT.compress(data, COMMON_AT_BEST_3)
 
     @classmethod
     def cont_size(cls, data: bytes, byte_offset=0):
-        """Get the size of an PKDPX container starting at the given offset in data."""
+        """Get the size of an AT container starting at the given offset in data."""
         from skytemple_files.common.types.file_types import FileType
         sir0 = FileType.SIR0.deserialize(data)
-        return FileType.PKDPX.cont_size(sir0.content, byte_offset)
+        return FileType.COMMON_AT.cont_size(sir0.content, byte_offset)
 
     @classmethod
     def matches(cls, data: bytes, byte_offset=0):
-        """Check if the given data stream is a Pkdpx container"""
+        """Check if the given data stream is an At container"""
         from skytemple_files.common.types.file_types import FileType
         sir0 = FileType.SIR0.deserialize(data)
-        return FileType.PKDPX.matches(sir0.content, byte_offset)
+        return FileType.COMMON_AT.matches(sir0.content, byte_offset)

--- a/skytemple_files/container/dungeon_bin/sub/sir0_pkdpx_dbg.py
+++ b/skytemple_files/container/dungeon_bin/sub/sir0_pkdpx_dbg.py
@@ -21,7 +21,7 @@ from skytemple_files.graphics.dbg.model import Dbg
 
 
 class DbinSir0PkdpxDbgHandler(DataHandler[Dbg]):
-    """A proxy data handler for Dbg compressed as Pkdpx wrapped in Sir0."""
+    """A proxy data handler for Dbg compressed as At container wrapped in Sir0."""
 
     @classmethod
     def deserialize(cls, data: bytes, **kwargs) -> Dbg:

--- a/skytemple_files/data/dbg/xml_export_test.py
+++ b/skytemple_files/data/dbg/xml_export_test.py
@@ -82,7 +82,7 @@ for md_base_index in range(0, NUM_ENTITIES):
     stat_id = md_base_index - 1
     if stat_id > -1 and stat_id < len(level_bin):
         stats = FileType.LEVEL_BIN_ENTRY.deserialize(
-            FileType.PKDPX.deserialize(FileType.SIR0.deserialize(level_bin[stat_id]).content).decompress()
+            FileType.COMMON_AT.deserialize(FileType.SIR0.deserialize(level_bin[stat_id]).content).decompress()
         )
 
     if stat_id > -1 and stat_id < kao.toc_len:
@@ -120,7 +120,7 @@ for lang_name, lang_model in languages.items():
 moveset = waza_p.learnsets[1]
 moveset2 = waza_p.learnsets[1]
 stats = FileType.LEVEL_BIN_ENTRY.deserialize(
-    FileType.PKDPX.deserialize(FileType.SIR0.deserialize(level_bin[0]).content).decompress()
+    FileType.COMMON_AT.deserialize(FileType.SIR0.deserialize(level_bin[0]).content).decompress()
 )
 portraits = []
 for kao_i in range(0, SUBENTRIES):

--- a/skytemple_files/data/level_bin_entry/dbg/export_import_test.py
+++ b/skytemple_files/data/level_bin_entry/dbg/export_import_test.py
@@ -32,7 +32,7 @@ all_level_ups_bin_decompressed = []
 # Collect all level up data
 for entry_bin in m_level:
     entry_bin_sir0 = FileType.SIR0.deserialize(entry_bin)
-    entry_bin_unpacked = FileType.PKDPX.deserialize(entry_bin_sir0.content)
+    entry_bin_unpacked = FileType.COMMON_AT.deserialize(entry_bin_sir0.content)
     entry_bin_decompressed = entry_bin_unpacked.decompress()
     all_level_ups_bin_decompressed.append(entry_bin_decompressed)
     entry = FileType.LEVEL_BIN_ENTRY.deserialize(entry_bin_decompressed)
@@ -44,8 +44,8 @@ for entry_bin in m_level:
 new_bytes_for_entries = []
 for i, entry in enumerate(all_level_ups):
     new_bytes_unpacked = FileType.LEVEL_BIN_ENTRY.serialize(entry)
-    new_bytes_pkdpx = FileType.PKDPX.serialize(FileType.PKDPX.compress(new_bytes_unpacked))
-    new_bytes = FileType.SIR0.wrap(new_bytes_pkdpx, [])
+    new_bytes_at = FileType.COMMON_AT.serialize(FileType.COMMON_AT.compress(new_bytes_unpacked))
+    new_bytes = FileType.SIR0.wrap(new_bytes_at, [])
     # Compare!
     new_bytes_for_entries.append(new_bytes)
     assert all_level_ups_bin_decompressed[i] == new_bytes_unpacked

--- a/skytemple_files/data/monster_xml.py
+++ b/skytemple_files/data/monster_xml.py
@@ -106,7 +106,7 @@ XML_STATS_GROWTH_LEVEL__DEFENSE = "Defense"
 XML_STATS_GROWTH_LEVEL__SP_DEFENSE = "SpDefense"
 XML_PORTRAITS = "Portraits"
 XML_PORTRAITS_PORTRAIT = "Portrait"
-XML_PORTRAITS_PORTRAIT__IMAGE = "At4pxImage"
+XML_PORTRAITS_PORTRAIT__IMAGE = "At4pxImage" #TODO: Change this to AtImage (could broke already exported xml data)
 XML_PORTRAITS_PORTRAIT__PALETTE = "Palette"
 
 XML_GENENT__MAP__SIMPLE = {

--- a/skytemple_files/dungeon_data/fixed_bin/dbg/draw_test.py
+++ b/skytemple_files/dungeon_data/fixed_bin/dbg/draw_test.py
@@ -57,7 +57,7 @@ def draw_monster_sprite(img: Image.Image, x: int, y: int, monster_id: int, direc
         return False
 
     sprite = FileType.WAN.deserialize(
-        FileType.PKDPX.deserialize(monster_bin[sprite_index]).decompress()
+        FileType.COMMON_AT.deserialize(monster_bin[sprite_index]).decompress()
     )
     ani_group = sprite.get_animations_for_group(sprite.anim_groups[0])
 

--- a/skytemple_files/export_maps.py
+++ b/skytemple_files/export_maps.py
@@ -14,7 +14,7 @@ This is also an example on how to use the following file handlers:
 - LSD
 - WAN, WAT
 - (BIN_PACK)
-- (AT4PX, PKDPX)
+- (COMMON_AT)
 - (Compressions)
 - (Hardcoded Lists)
 """
@@ -282,7 +282,7 @@ def draw_actor(img: Image.Image, draw, actor: SsaActor):
 
     try:
         sprite = FileType.WAN.deserialize(
-            FileType.PKDPX.deserialize(monster_bin_pack_file[actor_sprite_id]).decompress()
+            FileType.COMMON_AT.deserialize(monster_bin_pack_file[actor_sprite_id]).decompress()
         )
         ani_group = sprite.get_animations_for_group(sprite.anim_groups[0])
     except (ValueError, TypeError) as e:

--- a/skytemple_files/graphics/bgp/README.rst
+++ b/skytemple_files/graphics/bgp/README.rst
@@ -5,7 +5,7 @@ The BGP file format is used to store full-screen background images, most notably
 background of the main menu. Please note, that many background seen in the game are actually stored as level map
 backgrounds, see BMA_.
 
-The entire file is stored using AT4PX_ compression!
+The entire file is stored using AT_ compression!
 
 Usage
 -----
@@ -129,4 +129,4 @@ Based on following documentations:
 
 .. _BPC:                            https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/graphics/bpc
 .. _BMA:                            https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/graphics/bma
-.. _AT4PX:                          https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression_container/at4px
+.. _AT:                          https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression_container/common_at

--- a/skytemple_files/graphics/bgp/dbg/export_test.py
+++ b/skytemple_files/graphics/bgp/dbg/export_test.py
@@ -39,7 +39,7 @@ for filename in get_files_from_rom_with_extension(rom, 'bgp'):
     bin = rom.getFileByName(filename)
     with open(filename_h, 'wb') as f:
         tb = time()
-        d = FileType.AT4PX.deserialize(bin).decompress()
+        d = FileType.COMMON_AT.deserialize(bin).decompress()
         print(f"Decrompressing this takes {time() - tb}s.")
         f.write(d)
 

--- a/skytemple_files/graphics/bgp/dbg/import_image_test.py
+++ b/skytemple_files/graphics/bgp/dbg/import_image_test.py
@@ -23,7 +23,7 @@ from ndspy.rom import NintendoDSRom
 
 from skytemple_files.common.types.file_types import FileType
 from skytemple_files.common.util import get_files_from_rom_with_extension
-from skytemple_files.compression_container.at4px.handler import At4pxHandler
+from skytemple_files.compression_container.common_at.handler import CommonAtHandler
 from skytemple_files.graphics.bgp.handler import BgpHandler
 from skytemple_files.graphics.bgp.model import BGP_RES_WIDTH_IN_TILES
 

--- a/skytemple_files/graphics/bgp/dbg/import_test.py
+++ b/skytemple_files/graphics/bgp/dbg/import_test.py
@@ -23,7 +23,7 @@ from ndspy.rom import NintendoDSRom
 
 from skytemple_files.common.types.file_types import FileType
 from skytemple_files.common.util import get_files_from_rom_with_extension
-from skytemple_files.compression_container.at4px.handler import At4pxHandler
+from skytemple_files.compression_container.common_at.handler import CommonAtHandler
 from skytemple_files.graphics.bgp.handler import BgpHandler
 from skytemple_files.graphics.bgp.model import BGP_RES_WIDTH_IN_TILES
 
@@ -41,8 +41,8 @@ for filename in get_files_from_rom_with_extension(rom, 'bgp'):
 
     bin_after = BgpHandler.serialize(bgp)
 
-    bin_before_unpacked = At4pxHandler.deserialize(bin_before).decompress()
-    bin_after_unpacked = At4pxHandler.deserialize(bin_after).decompress()
+    bin_before_unpacked = CommonAtHandler.deserialize(bin_before).decompress()
+    bin_after_unpacked = CommonAtHandler.deserialize(bin_after).decompress()
 
     assert bin_before_unpacked == bin_after_unpacked
 

--- a/skytemple_files/graphics/bgp/handler.py
+++ b/skytemple_files/graphics/bgp/handler.py
@@ -18,7 +18,7 @@
 from skytemple_files.common.types.data_handler import DataHandler
 from skytemple_files.graphics.bgp.model import Bgp
 from skytemple_files.graphics.bgp.writer import BgpWriter
-from skytemple_files.compression_container.common_at.handler import COMMON_AT_BEST_4
+from skytemple_files.compression_container.common_at.handler import COMMON_AT_MUST_COMPRESS_4
 
 class BgpHandler(DataHandler[Bgp]):
     @classmethod
@@ -32,6 +32,6 @@ class BgpHandler(DataHandler[Bgp]):
         return FileType.COMMON_AT.serialize(
             FileType.COMMON_AT.compress(
                 BgpWriter(data).write(),
-                COMMON_AT_BEST_4
+                COMMON_AT_MUST_COMPRESS_4
             )
         )

--- a/skytemple_files/graphics/bgp/handler.py
+++ b/skytemple_files/graphics/bgp/handler.py
@@ -18,7 +18,7 @@
 from skytemple_files.common.types.data_handler import DataHandler
 from skytemple_files.graphics.bgp.model import Bgp
 from skytemple_files.graphics.bgp.writer import BgpWriter
-
+from skytemple_files.compression_container.common_at.handler import COMMON_AT_BEST_4
 
 class BgpHandler(DataHandler[Bgp]):
     @classmethod
@@ -31,6 +31,7 @@ class BgpHandler(DataHandler[Bgp]):
         from skytemple_files.common.types.file_types import FileType
         return FileType.COMMON_AT.serialize(
             FileType.COMMON_AT.compress(
-                BgpWriter(data).write()
+                BgpWriter(data).write(),
+                COMMON_AT_BEST_4
             )
         )

--- a/skytemple_files/graphics/dbg/README.rst
+++ b/skytemple_files/graphics/dbg/README.rst
@@ -11,7 +11,7 @@ right before these files in the dungeon.bin.
 
 The name is not official.
 
-The file can only be found SIR0 wrapped and PKDPX compressed in the dungeon.bin file.
+The file can only be found SIR0 wrapped and AT compressed in the dungeon.bin file.
 
 Usage
 -----
@@ -19,7 +19,7 @@ Use the class ``DbgHandler`` of the ``handler`` module, to open and save
 models from binary data. The model that the handler returns is in the
 module ``model``.
 
-To read/write the SIR0 wrapped and PKDPX compressed versions of this file instead,
+To read/write the SIR0 wrapped and AT compressed versions of this file instead,
 you can use the file handler in ``skytemple_files.container.dungeon_bin.sub.sir0_pkdpx_dbg``.
 
 File Format

--- a/skytemple_files/graphics/dma/README.rst
+++ b/skytemple_files/graphics/dma/README.rst
@@ -11,7 +11,7 @@ This file format is in it's purpose roughly the equivalent of `BMA`_ files but f
 
 The name is not official.
 
-The file can only be found SIR0 wrapped and AT4PX compressed in the dungeon.bin file.
+The file can only be found SIR0 wrapped and AT compressed in the dungeon.bin file.
 
 Usage
 -----
@@ -19,7 +19,7 @@ Use the class ``DmaHandler`` of the ``handler`` module, to open and save
 models from binary data. The model that the handler returns is in the
 module ``model``.
 
-To read/write the SIR0 wrapped & AT4PX compressed versions of this file instead, you can
+To read/write the SIR0 wrapped & AT compressed versions of this file instead, you can
 use the file handler in ``skytemple_files.container.dungeon_bin.sub.at4px_dpc``.
 
 The model further clusters the chunk types as specified below.

--- a/skytemple_files/graphics/dpc/README.rst
+++ b/skytemple_files/graphics/dpc/README.rst
@@ -12,7 +12,7 @@ This file format, used together with `DPCI`_ is the equivalent of `BPC`_ files b
 
 The name is not official.
 
-The file can only be found AT4PX compressed in the dungeon.bin file.
+The file can only be found AT compressed in the dungeon.bin file.
 
 Usage
 -----
@@ -20,7 +20,7 @@ Use the class ``DpciHandler`` of the ``handler`` module, to open and save
 models from binary data. The model that the handler returns is in the
 module ``model``.
 
-To read/write the AT4PX compressed versions of this file instead, you can
+To read/write the AT compressed versions of this file instead, you can
 use the file handler in ``skytemple_files.container.dungeon_bin.sub.at4px_dpc``.
 
 File Format

--- a/skytemple_files/graphics/dpci/README.rst
+++ b/skytemple_files/graphics/dpci/README.rst
@@ -6,7 +6,7 @@ This file format, used together with `DPC`_ is the equivalent of `BPC`_ files bu
 
 The name is not official.
 
-The file can only be found AT4PX compressed in the dungeon.bin file.
+The file can only be found in AT containers in the dungeon.bin file.
 
 Usage
 -----
@@ -14,7 +14,7 @@ Use the class ``DpciHandler`` of the ``handler`` module, to open and save
 models from binary data. The model that the handler returns is in the
 module ``model``.
 
-To read/write the AT4PX compressed versions of this file instead, you can
+To read/write the AT compressed versions of this file instead, you can
 use the file handler in ``skytemple_files.container.dungeon_bin.sub.at4px_dpci``.
 
 File Format

--- a/skytemple_files/graphics/fonts/abstract.py
+++ b/skytemple_files/graphics/fonts/abstract.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     from pil import Image
 
-class AbstractFontEntry(AutoString):
+class AbstractFontEntry(ABC, AutoString):
     @classmethod
     def get_class_properties(cls) -> List[str]:
         """Returns a list of the properties of this class"""

--- a/skytemple_files/graphics/kao/README.rst
+++ b/skytemple_files/graphics/kao/README.rst
@@ -64,7 +64,7 @@ All TOC entries have the following structure:
 
 Portrait Data
 ~~~~~~~~~~~~~
-Each portraits is made up of 2 things. A 16 color palette, followed immediately by a `AT4PX`_ compressed container
+Each portraits is made up of 2 things. A 16 color palette, followed immediately by a `AT`_ compressed container
 containing the actual image data for the portrait.
 
 The portraits do not carry any information about their formats. However, we do know that they're all 4 bits per
@@ -81,8 +81,8 @@ Structure of one portrait:
 | 0x00    | 48     |          | Color Palette       | 16 colors RGB color palette (3 bytes RGB). First color is   |
 |         |        |          |                     | transparent.                                                |
 +---------+--------+----------+---------------------+-------------------------------------------------------------+
-| 0x30    | Varies | AT4PX_   | Compressed Image    | This contains the actual image data for the portrait.       |
-|         |        |          |                     | Its a compressed AT4PX_ container that contains             |
+| 0x30    | Varies | AT_   | Compressed Image    | This contains the actual image data for the portrait.       |
+|         |        |          |                     | Its a compressed AT_ container that contains             |
 |         |        |          |                     | the raw pixels of the image. The image itself, once         |
 |         |        |          |                     | decompressed, is stored as an indexed 4 bits per            |
 |         |        |          |                     | pixels, 40x40, tiled image. Once decompressed each images   |
@@ -118,4 +118,4 @@ Based on following documentations:
 .. _psy_commando:                   https://github.com/PsyCommando/
 .. _Zhorken:                        https://github.com/Zhorken
 
-.. _AT4PX:                          https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression_container/at4px
+.. _AT:                             https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/compression_container/common_at

--- a/skytemple_files/graphics/kao/README.rst
+++ b/skytemple_files/graphics/kao/README.rst
@@ -81,8 +81,8 @@ Structure of one portrait:
 | 0x00    | 48     |          | Color Palette       | 16 colors RGB color palette (3 bytes RGB). First color is   |
 |         |        |          |                     | transparent.                                                |
 +---------+--------+----------+---------------------+-------------------------------------------------------------+
-| 0x30    | Varies | AT_   | Compressed Image    | This contains the actual image data for the portrait.       |
-|         |        |          |                     | Its a compressed AT_ container that contains             |
+| 0x30    | Varies | AT_      | Compressed Image    | This contains the actual image data for the portrait.       |
+|         |        |          |                     | Its a compressed AT_ container that contains                |
 |         |        |          |                     | the raw pixels of the image. The image itself, once         |
 |         |        |          |                     | decompressed, is stored as an indexed 4 bits per            |
 |         |        |          |                     | pixels, 40x40, tiled image. Once decompressed each images   |

--- a/skytemple_files/graphics/kao/dbg/export_test.py
+++ b/skytemple_files/graphics/kao/dbg/export_test.py
@@ -38,17 +38,17 @@ for idx, subidx, kao_image in kao:
     if kao_image:
         print(f"== {idx} - {subidx} ==")
         im = kao_image.get()
-        at4px_before = FileType.COMMON_AT.deserialize(kao_image.compressed_img_data)
-        print(f"Size before: {at4px_before.length_compressed}")
-        data_length_before += at4px_before.length_compressed
+        at_before = FileType.COMMON_AT.deserialize(kao_image.compressed_img_data)
+        print(f"Size before: {at_before.length_compressed}")
+        data_length_before += at_before.length_compressed
         # Test replacing the image (with the old one, so should be the same result)
         kao_image.set(im)
-        at4px_after = FileType.COMMON_AT.deserialize(kao_image.compressed_img_data)
+        at_after = FileType.COMMON_AT.deserialize(kao_image.compressed_img_data)
         im_after = kao_image.get()
         im_after.save(f'/tmp/{idx}_{subidx}.png')
         im.save(os.path.join(os.path.dirname(__file__), 'dbg_output', f'{idx}_{subidx}.png'))
-        data_length_after += at4px_after.length_compressed
-        print(f"Size after : {at4px_after.length_compressed}")
+        data_length_after += at_after.length_compressed
+        print(f"Size after : {at_after.length_compressed}")
 print(f"== WHOLE KAO ==")
 print(f"Size before: {data_length_before}")
 print(f"Size after : {data_length_after}")

--- a/skytemple_files/graphics/kao/dbg/export_test.py
+++ b/skytemple_files/graphics/kao/dbg/export_test.py
@@ -32,16 +32,23 @@ bin = rom.getFileByName('FONT/kaomado.kao')
 
 kao = KaoHandler.deserialize(bin)
 
+data_length_before = 0
+data_length_after = 0
 for idx, subidx, kao_image in kao:
     if kao_image:
+        print(f"== {idx} - {subidx} ==")
         im = kao_image.get()
-        at4px_before = FileType.AT4PX.deserialize(kao_image.compressed_img_data)
+        at4px_before = FileType.COMMON_AT.deserialize(kao_image.compressed_img_data)
+        print(f"Size before: {at4px_before.length_compressed}")
+        data_length_before += at4px_before.length_compressed
         # Test replacing the image (with the old one, so should be the same result)
         kao_image.set(im)
-        at4px_after = FileType.AT4PX.deserialize(kao_image.compressed_img_data)
+        at4px_after = FileType.COMMON_AT.deserialize(kao_image.compressed_img_data)
         im_after = kao_image.get()
         im_after.save(f'/tmp/{idx}_{subidx}.png')
         im.save(os.path.join(os.path.dirname(__file__), 'dbg_output', f'{idx}_{subidx}.png'))
-        print(f"== {idx} - {subidx} ==")
-        print(f"Size before: {at4px_before.length_compressed}")
+        data_length_after += at4px_after.length_compressed
         print(f"Size after : {at4px_after.length_compressed}")
+print(f"== WHOLE KAO ==")
+print(f"Size before: {data_length_before}")
+print(f"Size after : {data_length_after}")

--- a/skytemple_files/graphics/kao/model.py
+++ b/skytemple_files/graphics/kao/model.py
@@ -248,7 +248,9 @@ def pil_to_kao(pil: Image) -> Tuple[bytes, bytes]:
 
     new_img_compressed = FileType.COMMON_AT.serialize(FileType.COMMON_AT.compress(new_img, COMMON_AT_MUST_COMPRESS_3))
     if len(new_img_compressed)>800:
-        raise AttributeError(f"This portrait does not compress well, the result size is greater than 800 bytes ({len(new_img_compressed)} bytes total).")
+        raise AttributeError(f"This portrait does not compress well, the result size is greater than 800 bytes ({len(new_img_compressed)} bytes total).\n"
+                             f"If you haven't done already, try applying the 'ProvideATUPXSupport' to install an optimized compression algorithm, "
+                             f"which might be able to better compress this image.")
     # You can check if compression works, by uncompressing and checking the image again:
     # >>> unc = FileType.COMMON_AT.unserialize(new_img_compressed).decompress()
     # >>> uncompressed_kao_to_pil(new_palette, unc).show()

--- a/skytemple_files/graphics/kao/model.py
+++ b/skytemple_files/graphics/kao/model.py
@@ -26,6 +26,7 @@ except ImportError:
 from typing import Union, Tuple
 
 from skytemple_files.common.util import *
+from skytemple_files.compression_container.common_at.handler import COMMON_AT_MUST_COMPRESS_3
 
 SUBENTRIES = 40  # Subentries of one 80 byte TOC entry
 SUBENTRY_LEN = 4  # Length of the subentry pointers
@@ -245,7 +246,7 @@ def pil_to_kao(pil: Image) -> Tuple[bytes, bytes]:
     # correct image again:
     # >>> uncompressed_kao_to_pil(new_palette, new_img).show()
 
-    new_img_compressed = FileType.COMMON_AT.serialize(FileType.COMMON_AT.compress(new_img))
+    new_img_compressed = FileType.COMMON_AT.serialize(FileType.COMMON_AT.compress(new_img, COMMON_AT_MUST_COMPRESS_3))
     if len(new_img_compressed)>800:
         raise AttributeError(f"This portrait does not compress well, the result size is greater than 800 bytes ({len(new_img_compressed)} bytes total).")
     # You can check if compression works, by uncompressing and checking the image again:

--- a/skytemple_files/graphics/kao/model.py
+++ b/skytemple_files/graphics/kao/model.py
@@ -41,11 +41,11 @@ class KaoImage:
         if not isinstance(whole_kao_data, memoryview):
             whole_kao_data = memoryview(whole_kao_data)
 
-        """Construct a KaoImage using a raw image buffer (16 color palette, followed by AT4PX)"""
+        """Construct a KaoImage using a raw image buffer (16 color palette, followed by AT)"""
         from skytemple_files.common.types.file_types import FileType
 
-        cont_len = FileType.AT4PX.cont_size(whole_kao_data, start_pnt + KAO_IMG_PAL_B_SIZE)
-        # palette size + at4px container size
+        cont_len = FileType.COMMON_AT.cont_size(whole_kao_data, start_pnt + KAO_IMG_PAL_B_SIZE)
+        # palette size + at container size
         self.original_size = KAO_IMG_PAL_B_SIZE + cont_len
         self.pal_data = read_bytes(whole_kao_data, start_pnt, KAO_IMG_PAL_B_SIZE)
         self.compressed_img_data = read_bytes(whole_kao_data, start_pnt + KAO_IMG_PAL_B_SIZE, cont_len)
@@ -62,7 +62,7 @@ class KaoImage:
         return KAO_IMG_PAL_B_SIZE + len(self.compressed_img_data)
 
     def get_internal(self) -> bytes:
-        """Returns the portrait as 16 color palette followed by AT4PX compressed image data"""
+        """Returns the portrait as 16 color palette followed by AT compressed image data"""
         return bytes(self.pal_data) + bytes(self.compressed_img_data)
 
     def set(self, pil: Image) -> 'KaoImage':
@@ -169,7 +169,7 @@ def kao_to_pil(kao: KaoImage) -> Image:
     from skytemple_files.common.types.file_types import FileType
 
     # Generates an array where every three entries a new color begins (r, g, b, r, g, b...)
-    uncompressed_image_data = FileType.AT4PX.deserialize(kao.compressed_img_data).decompress()
+    uncompressed_image_data = FileType.COMMON_AT.deserialize(kao.compressed_img_data).decompress()
 
     return uncompressed_kao_to_pil(kao.pal_data, uncompressed_image_data)
 
@@ -205,7 +205,7 @@ def uncompressed_kao_to_pil(pal_data: bytes, uncompressed_image_data):
 
 
 def pil_to_kao(pil: Image) -> Tuple[bytes, bytes]:
-    """Converts a PIL image (with a 16 bit palette) to a kao palette and at4px compressed image data"""
+    """Converts a PIL image (with a 16 bit palette) to a kao palette and at compressed image data"""
     from skytemple_files.common.types.file_types import FileType
 
     img_dim = KAO_IMG_METAPIXELS_DIM * KAO_IMG_IMG_DIM
@@ -245,11 +245,11 @@ def pil_to_kao(pil: Image) -> Tuple[bytes, bytes]:
     # correct image again:
     # >>> uncompressed_kao_to_pil(new_palette, new_img).show()
 
-    new_img_compressed = FileType.AT4PX.serialize(FileType.AT4PX.compress(new_img))
+    new_img_compressed = FileType.COMMON_AT.serialize(FileType.COMMON_AT.compress(new_img))
     if len(new_img_compressed)>800:
         raise AttributeError(f"This portrait does not compress well, the result size is greater than 800 bytes ({len(new_img_compressed)} bytes total).")
     # You can check if compression works, by uncompressing and checking the image again:
-    # >>> unc = FileType.AT4PX.unserialize(new_img_compressed).decompress()
+    # >>> unc = FileType.COMMON_AT.unserialize(new_img_compressed).decompress()
     # >>> uncompressed_kao_to_pil(new_palette, unc).show()
 
     return new_palette[:KAO_IMG_PAL_B_SIZE], new_img_compressed

--- a/skytemple_files/graphics/kao/writer.py
+++ b/skytemple_files/graphics/kao/writer.py
@@ -110,7 +110,7 @@ class KaoWriter:
                         continue
                     image_data_bs = self.kao.original_data
                     image_data_start = pnt
-                    image_data_end = image_data_start + KAO_IMG_PAL_B_SIZE + FileType.AT4PX.cont_size(
+                    image_data_end = image_data_start + KAO_IMG_PAL_B_SIZE + FileType.COMMON_AT.cont_size(
                         image_data_bs, image_data_start + KAO_IMG_PAL_B_SIZE
                     )
                 # Update the TOC entry to point to the current image offset

--- a/skytemple_files/graphics/w16/model.py
+++ b/skytemple_files/graphics/w16/model.py
@@ -98,28 +98,15 @@ class W16Image(ABC):
         tiles_concat = bytes(itertools.chain.from_iterable(tiles))
         return pal[0], tiles_concat
 
-
-class W16At4pxImage(W16Image):
+class W16AtImage(W16Image):
     @classmethod
     def compress(cls, data: bytes) -> bytes:
         from skytemple_files.common.types.file_types import FileType
-        return FileType.AT4PX.serialize(FileType.AT4PX.compress(data))
+        return FileType.COMMON_AT.serialize(FileType.COMMON_AT.compress(data))
 
     def decompress(self) -> bytes:
         from skytemple_files.common.types.file_types import FileType
-        return FileType.AT4PX.deserialize(self.compressed_img_data).decompress()
-
-
-class W16At4pnImage(W16Image):
-    @classmethod
-    def compress(cls, data: bytes) -> bytes:
-        from skytemple_files.common.types.file_types import FileType
-        return FileType.AT4PN.serialize(FileType.AT4PN.new(data))
-
-    def decompress(self) -> bytes:
-        from skytemple_files.common.types.file_types import FileType
-        return FileType.AT4PN.deserialize(self.compressed_img_data).get()
-
+        return FileType.COMMON_AT.deserialize(self.compressed_img_data).decompress()
 
 class W16RawImage(W16Image):
     @classmethod
@@ -163,10 +150,8 @@ class W16:
             # Read image
             next_pointer = read_uintle(data, (i+1) * 8, 4)
             img_data = data[pointer + len_pal_bytes:next_pointer]
-            if FileType.AT4PX.matches(img_data):
-                self._files.append(W16At4pxImage(entry_data, img_data, pal))
-            elif FileType.AT4PN.matches(img_data):
-                self._files.append(W16At4pnImage(entry_data, img_data, pal))
+            if FileType.COMMON_AT.matches(img_data):
+                self._files.append(W16AtImage(entry_data, img_data, pal))
             else:
                 self._files.append(W16RawImage(entry_data, img_data, pal))
 

--- a/skytemple_files/graphics/wan_wat/dbg/dungeon_bg_sprites_test.py
+++ b/skytemple_files/graphics/wan_wat/dbg/dungeon_bg_sprites_test.py
@@ -112,7 +112,7 @@ for i, monster in enumerate(monster_md.entries):
         continue
     print(f"Monster {i} - Sprite {monster.sprite_index}")
     sprite = sprites[monster.sprite_index]
-    sprite_bin_decompressed = FileType.PKDPX.deserialize(sprite).decompress()
+    sprite_bin_decompressed = FileType.COMMON_AT.deserialize(sprite).decompress()
     wan_model = FileType.WAN.deserialize(sprite_bin_decompressed)
 
     img = Image.new('RGBA', (WIDTH, HEIGHT), (0, 0, 0, 0))

--- a/skytemple_files/graphics/wan_wat/dbg/export_sprites_test.py
+++ b/skytemple_files/graphics/wan_wat/dbg/export_sprites_test.py
@@ -59,7 +59,7 @@ pack_file = rom.getFileByName('MONSTER/monster.bin')
 bin_pack = FileType.BIN_PACK.deserialize(pack_file)
 for s_i, sprite in enumerate(bin_pack):
     print(f"Actor kind {s_i}")
-    sprite_bin_decompressed = FileType.PKDPX.deserialize(sprite).decompress()
+    sprite_bin_decompressed = FileType.COMMON_AT.deserialize(sprite).decompress()
     wan_model = FileType.WAN.deserialize(sprite_bin_decompressed)
     basename = f'actor_{s_i}'
 

--- a/skytemple_files/hardcoded/cart_removed.py
+++ b/skytemple_files/hardcoded/cart_removed.py
@@ -19,7 +19,7 @@ from typing import List
 
 from skytemple_files.common.util import *
 from skytemple_files.common.ppmdu_config.data import Pmd2Data
-from skytemple_files.compression_container.at4px.handler import At4pxHandler
+from skytemple_files.compression_container.common_at.handler import CommonAtHandler, CommonAtType
 
 try:
     from PIL import Image
@@ -37,7 +37,7 @@ class HardcodedCartRemoved:
         """
         block = config.binaries['arm9.bin'].blocks['CartRemovedImgData']
         data = arm9[block.begin:block.end]
-        img_data = At4pxHandler.deserialize(data).decompress()
+        img_data = CommonAtHandler.deserialize(data).decompress()
         raw_data = []
         for l, h in iter_bytes(img_data, 2):
             v = l+h*256
@@ -61,7 +61,7 @@ class HardcodedCartRemoved:
             v = (r//8) + ((g//8)<<5) + ((b//8)<<10)
             img_data.append(v%256)
             img_data.append(v//256)
-        data = At4pxHandler.serialize(At4pxHandler.compress(bytes(img_data)))
+        data = CommonAtHandler.serialize(CommonAtHandler.compress(bytes(img_data), [CommonAtType.AT3PX]))
         if len(data)>block.end-block.begin:
             raise AttributeError(f"This image must be compressed better to fit in the arm9 ({len(data)} > {block.end-block.begin}).")
         arm9[block.begin:block.end] = data + bytes((block.end-block.begin)-len(data))

--- a/skytemple_files/patch/handler/support_atupx.py
+++ b/skytemple_files/patch/handler/support_atupx.py
@@ -1,0 +1,83 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler
+
+
+NUM_PREVIOUS_ENTRIES = 600
+
+
+PATCH_CODE_START_US = 0xA48F8
+PATCH_CODE_END_US = 0x0A4ED8
+PATCH_CHECK_ADDR_APPLIED_US = 0x1F6B0
+PATCH_CHECK_INSTR_APPLIED_US = 0xEA0000D4
+PATCH_CODE_START_EU = 0xA4EF8
+PATCH_CODE_END_EU = 0xA54D8
+PATCH_CHECK_ADDR_APPLIED_EU = 0x1F74C
+PATCH_CHECK_INSTR_APPLIED_EU = 0xEA0000D4
+
+class AtupxSupportPatchHandler(AbstractPatchHandler):
+
+    @property
+    def name(self) -> str:
+        return 'ProvideATUPXSupport'
+
+    @property
+    def description(self) -> str:
+        return 'Provide support for ATUPX containers, which use a different algorithm than PX compression.\nRequires the ActorAndLevelLoader, as it frees the space needed to implement this.'
+
+    @property
+    def author(self) -> str:
+        return 'irdkwia'
+
+    @property
+    def version(self) -> str:
+        return '0.0.1'
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_US, 4)!=PATCH_CHECK_INSTR_APPLIED_US
+            if config.game_region == GAME_REGION_EU:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_EU, 4)!=PATCH_CHECK_INSTR_APPLIED_EU
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        if not self.is_applied(rom, config):
+            # Check if space is available
+            bincfg = config.binaries['arm9.bin']
+            binary = bytearray(get_binary_from_rom_ppmdu(rom, bincfg))
+            if config.game_version == GAME_VERSION_EOS:
+                if config.game_region == GAME_REGION_US:
+                    data = binary[PATCH_CODE_START_US:PATCH_CODE_END_US]
+                elif config.game_region == GAME_REGION_EU:
+                    data = binary[PATCH_CODE_START_EU:PATCH_CODE_END_EU]
+            for x in data:
+                if x!=0xff: #Check if every byte is 0xff
+                    raise RuntimeError("This patch can't be applied if ActorAndLevelLoader isn't applied.")
+        
+        try:
+            apply()
+        except RuntimeError as ex:
+            raise ex
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -36,6 +36,7 @@ from skytemple_files.patch.handler.disable_tips import DisableTipsPatch
 from skytemple_files.patch.handler.move_shortcuts import MoveShortcutsPatch
 from skytemple_files.patch.handler.same_type_partner import SameTypePartnerPatch
 from skytemple_files.patch.handler.unused_dungeon_chance import UnusedDungeonChancePatch
+from skytemple_files.patch.handler.support_atupx import AtupxSupportPatchHandler
 
 CORE_PATCHES_BASE_DIR = os.path.join(get_resources_dir(), 'patches')
 
@@ -46,6 +47,7 @@ class PatchType(Enum):
     MOVE_SHORTCUTS = MoveShortcutsPatch
     DISABLE_TIPS = DisableTipsPatch
     SAME_TYPE_PARTNER = SameTypePartnerPatch
+    SUPPORT_ATUPX = AtupxSupportPatchHandler
 
 
 class PatchPackageError(RuntimeError):

--- a/skytemple_files/script/ssa_sse_sss/dbg/export_draw_maps.py
+++ b/skytemple_files/script/ssa_sse_sss/dbg/export_draw_maps.py
@@ -110,7 +110,7 @@ def draw_actor(img: Image.Image, draw, actor: SsaActor):
     actor_sprite_id = monster_md[actor.actor.entid].sprite_index
 
     sprite = FileType.WAN.deserialize(
-        FileType.PKDPX.deserialize(monster_bin_pack_file[actor_sprite_id]).decompress()
+        FileType.COMMON_AT.deserialize(monster_bin_pack_file[actor_sprite_id]).decompress()
     )
     ani_group = sprite.get_animations_for_group(sprite.anim_groups[11])
     frame_id = actor.pos.direction.id - 1 if actor.pos.direction.id > 0 else 0


### PR DESCRIPTION
Some stuff about containers and compression used by the game.
- Fixed a bug with the PX compression which prevented it from using advanced control flags operations.
- Added support for the AT3PX container, natively supported by the game but never used.
- Added support for another compression algorithm, based on a compression algorithm used in 999. 
- Added support for a custom container (ATUPX) which uses this compression algorithm.
- Added a patch to make the game support the ATUPX container and the compression algorithm.
- All AT containers (AT3PX, AT4PX, PKDPX, AT4PN, ATUPX) can now be used in any place the game uses one of those, with the CommonAtHandler. The handler chooses the best container among the ones provided when compressing (if they are allowed).