### PR TITLE
Add and Improve patches

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_dungeon_data/eu/patch_available_items.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_dungeon_data/eu/patch_available_items.asm
@@ -1,0 +1,106 @@
+; For use with ARMIPS
+; 2021/02/06
+; For Explorers of Sky EU Only
+; ------------------------------------------------------------------------------
+; Use filestreams instead of hardcoded lists 
+; ------------------------------------------------------------------------------
+
+.definelabel HookFunction1, 0x0200E094
+.definelabel HookFunction2, 0x020637D8
+.definelabel GetMaxReachedFloor, 0x0204D630
+.definelabel LoadItemTable, 0x02095130
+.definelabel BufferReadA, 0x020982B4
+.definelabel AItemsFName, 0x020982D4
+.definelabel AItemsFStream, 0x020982E8
+
+.org HookFunction1
+.area 0x48
+outer_loop:
+	mov r4, #0x0
+inner_loop:
+	add r0, r4, r3, lsl #0x5
+	bl GetMaxReachedFloor
+	cmp r0, #0x0
+	beq inner_loop_add
+	mov r0, #0x1
+	orr r5, r5, r0, lsl r4
+inner_loop_add:
+	add r4, r4, #0x1
+	cmp r4, 0x20
+	blt inner_loop
+end_inner_loop:
+	mov r0, r3
+	ldr r0, [r6, +r0]
+	ands r5, r0, r5
+	bne item_available
+	add r3, r3, #0x1
+	cmp r3, 0x8
+	blt outer_loop
+	b end_outer_loop
+.endarea
+
+.org HookFunction2
+.area 0x4C
+	stmdb  r13!,{r3,r4,r5,r6,r14}
+	b LoadItemTable
+end_load_item_table:
+	mov r3, #0x0
+	mov r5, #0x0
+	b outer_loop
+end_outer_loop: 
+	mov r0, #0x0
+	ldmia  r13!,{r3,r4,r5,r6,r15}
+item_available: 
+	mov r0, #0x1
+	ldmia  r13!,{r3,r4,r5,r6,r15}
+	.fill (HookFunction2 + 0x4C - .), 0xCC;
+.endarea
+
+.org LoadItemTable
+.area 0x3184
+	ldr r6,=BufferReadA
+	mov r4,r0
+	ldr r5,=AItemsFStream
+	bl FStreamAlloc
+	mov r0,r5
+	bl FStreamCtor
+	mov r0,r5
+	ldr r1,=AItemsFName
+	bl FStreamFOpen
+	
+	; Get the line in file
+	mov r0,r5
+	mov r1,r4,lsl #0x5
+	mov r2,#0x0
+	bl FStreamSeek
+	mov r0,r5
+	mov r1,r6
+	mov r2,#0x20
+	bl FStreamRead
+	
+	; Close the stream
+	mov r0,r5
+	bl FStreamClose
+	bl FStreamDealloc
+	
+	b end_load_item_table
+	
+	.pool
+	.fill (BufferReadA - .), 0xCC;
+.endarea
+
+.org BufferReadA
+.area 0x20
+	.fill 0x20, 0;
+.endarea
+
+.org AItemsFName
+.area 0x14
+	.ascii "BALANCE/a_items.bin"
+	dcb 0
+.endarea
+
+.org AItemsFStream
+.area 0x48
+	.fill 0x48, 0;
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_dungeon_data/eu/patch_floor_ranks.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_dungeon_data/eu/patch_floor_ranks.asm
@@ -1,0 +1,104 @@
+; For use with ARMIPS
+; 2021/02/06
+; For Explorers of Sky EU Only
+; ------------------------------------------------------------------------------
+; Use filestreams instead of hardcoded lists 
+; ------------------------------------------------------------------------------
+
+.definelabel BufferRead, 0x020A1188
+.definelabel RanksFName, 0x020A118C
+.definelabel RanksFStream, 0x020A11A0
+.definelabel LoadRank, 0x020A1058
+;LoadRank(r0: floor_id, r1: group_id)
+.definelabel FRankHook1, 0x0204FB28
+.definelabel FRankHook2, 0x0204FB94
+
+.org FRankHook1
+.area 0x24
+	ldrb r0,[r13, #+0x1]
+	mov r1,r2
+	bl LoadRank
+	nop
+	nop
+	nop
+	add  r13,r13,#0x4
+	ldmia  r13!,{r3,r4,r15}
+	nop
+.endarea
+
+.org FRankHook2
+.area 0x30
+	ldrb r0,[r13, #+0x1]
+	cmp r0,#0x1
+	mov r1,r2
+	movle  r0,#0x2
+	bl LoadRank
+	nop
+	nop
+	nop
+	nop
+	add  r13,r13,#0x4
+	ldmia  r13!,{r3,r4,r15}
+	nop
+.endarea
+
+.org LoadRank
+.area 0x130
+	stmdb  r13!,{r5,r6,r7,r8,r14}
+	mov r5,r0
+	mov r6,r1
+	ldr r7,=RanksFStream
+	ldr r8,=BufferRead
+	bl FStreamAlloc
+	mov r0,r7
+	bl FStreamCtor
+	mov r0,r7
+	ldr r1,=RanksFName
+	bl FStreamFOpen
+	
+	; Get the offset in file
+	mov r0,r7
+	mov r1,r6,lsl #0x2
+	mov r2,#0x0
+	bl FStreamSeek
+	mov r0,r7
+	mov r1,r8
+	mov r2,#0x4
+	bl FStreamRead
+	
+	; Get the mission floor byte
+	mov r0,r7
+	ldr r1,[r8, #+0x0]
+	add r1,r1,r5
+	mov r2,#0x0
+	bl FStreamSeek
+	mov r0,r7
+	mov r1,r8
+	mov r2,#0x1
+	bl FStreamRead
+	
+	; Close the stream
+	mov r0,r7
+	bl FStreamClose
+	bl FStreamDealloc
+	ldrb r0,[r8, #+0x0]
+	ldmia  r13!,{r5,r6,r7,r8,r15}
+	.pool
+	.fill (BufferRead - .), 0xCC;
+.endarea
+
+.org BufferRead
+.area 0x4
+	.fill 0x4, 0;
+.endarea
+
+.org RanksFName
+.area 0x14
+	.ascii "BALANCE/f_ranks.bin"
+	dcb 0
+.endarea
+
+.org RanksFStream
+.area 0x48
+	.fill 0x48, 0;
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_dungeon_data/eu/patch_forbidden_floors.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_dungeon_data/eu/patch_forbidden_floors.asm
@@ -1,0 +1,92 @@
+; For use with ARMIPS
+; 2021/02/06
+; For Explorers of Sky EU Only
+; ------------------------------------------------------------------------------
+; Use filestreams instead of hardcoded lists 
+; ------------------------------------------------------------------------------
+
+.definelabel ExternalFunctionCall, 0x0204F984
+
+.definelabel HookFunction, 0x020518A0
+.definelabel LoadForbid, 0x0209FC98
+.definelabel BufferReadF, 0x0209FD04
+.definelabel ForbidFName, 0x0209FD08
+.definelabel FStreamStruct, 0x0209FD1C
+
+.org HookFunction
+.area 0x5C
+	stmdb  r13!,{r3,r5,r6,r7,r8,r14}
+	mov  r1,r0
+	add  r0,r13,#0x0
+	bl ExternalFunctionCall
+	ldrb r6,[r13, #+0x0]
+	ldrb r5,[r13, #+0x1]
+	ldr r7,=RanksFStream
+	ldr r8,=BufferRead
+	
+	bl FStreamAlloc
+	mov r0,r7
+	bl FStreamCtor
+	mov r0,r7
+	ldr r1,=ForbidFName
+	bl FStreamFOpen
+	
+	b LoadForbid
+end_forbid:
+	ldmia  r13!,{r3,r5,r6,r7,r8,r15}
+	
+	.pool
+	.fill (HookFunction + 0x5C - .), 0xCC;
+.endarea
+
+.org LoadForbid
+.area 0x6C
+	
+	; Get the offset in file
+	mov r0,r7
+	mov r1,r6,lsl #0x2
+	mov r2,#0x0
+	bl FStreamSeek
+	mov r0,r7
+	mov r1,r8
+	mov r2,#0x4
+	bl FStreamRead
+	
+	; Get the mission floor byte
+	mov r0,r7
+	ldr r1,[r8, #+0x0]
+	add r1,r1,r5
+	mov r2,#0x0
+	bl FStreamSeek
+	mov r0,r7
+	mov r1,r8
+	mov r2,#0x1
+	bl FStreamRead
+	
+	; Close the stream
+	mov r0,r7
+	bl FStreamClose
+	bl FStreamDealloc
+	ldrb r0,[r8, #+0x0]
+	
+	b end_forbid
+	
+	.pool
+	.fill (BufferReadF - .), 0xCC;
+.endarea
+
+.org BufferReadF
+.area 0x4
+	.fill 0x4, 0;
+.endarea
+
+.org ForbidFName
+.area 0x14
+	.ascii "BALANCE/fforbid.bin"
+	dcb 0
+.endarea
+
+.org FStreamStruct
+.area 0x48
+	.fill 0x48, 0;
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_dungeon_data/na/patch_available_items.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_dungeon_data/na/patch_available_items.asm
@@ -1,0 +1,106 @@
+; For use with ARMIPS
+; 2021/02/06
+; For Explorers of Sky NA Only
+; ------------------------------------------------------------------------------
+; Use filestreams instead of hardcoded lists 
+; ------------------------------------------------------------------------------
+
+.definelabel HookFunction1, 0x0200E00C
+.definelabel HookFunction2, 0x0206345C
+.definelabel GetMaxReachedFloor, 0x0204D2F8
+.definelabel LoadItemTable, 0x02094D34
+.definelabel BufferReadA, 0x02097EB8
+.definelabel AItemsFName, 0x02097ED8
+.definelabel AItemsFStream, 0x02097EEC
+
+.org HookFunction1
+.area 0x48
+outer_loop:
+	mov r4, #0x0
+inner_loop:
+	add r0, r4, r3, lsl #0x5
+	bl GetMaxReachedFloor
+	cmp r0, #0x0
+	beq inner_loop_add
+	mov r0, #0x1
+	orr r5, r5, r0, lsl r4
+inner_loop_add:
+	add r4, r4, #0x1
+	cmp r4, 0x20
+	blt inner_loop
+end_inner_loop:
+	mov r0, r3
+	ldr r0, [r6, +r0]
+	ands r5, r0, r5
+	bne item_available
+	add r3, r3, #0x1
+	cmp r3, 0x8
+	blt outer_loop
+	b end_outer_loop
+.endarea
+
+.org HookFunction2
+.area 0x4C
+	stmdb  r13!,{r3,r4,r5,r6,r14}
+	b LoadItemTable
+end_load_item_table:
+	mov r3, #0x0
+	mov r5, #0x0
+	b outer_loop
+end_outer_loop: 
+	mov r0, #0x0
+	ldmia  r13!,{r3,r4,r5,r6,r15}
+item_available: 
+	mov r0, #0x1
+	ldmia  r13!,{r3,r4,r5,r6,r15}
+	.fill (HookFunction2 + 0x4C - .), 0xCC;
+.endarea
+
+.org LoadItemTable
+.area 0x3184
+	ldr r6,=BufferReadA
+	mov r4,r0
+	ldr r5,=AItemsFStream
+	bl FStreamAlloc
+	mov r0,r5
+	bl FStreamCtor
+	mov r0,r5
+	ldr r1,=AItemsFName
+	bl FStreamFOpen
+	
+	; Get the line in file
+	mov r0,r5
+	mov r1,r4,lsl #0x5
+	mov r2,#0x0
+	bl FStreamSeek
+	mov r0,r5
+	mov r1,r6
+	mov r2,#0x20
+	bl FStreamRead
+	
+	; Close the stream
+	mov r0,r5
+	bl FStreamClose
+	bl FStreamDealloc
+	
+	b end_load_item_table
+	
+	.pool
+	.fill (BufferReadA - .), 0xCC;
+.endarea
+
+.org BufferReadA
+.area 0x20
+	.fill 0x20, 0;
+.endarea
+
+.org AItemsFName
+.area 0x14
+	.ascii "BALANCE/a_items.bin"
+	dcb 0
+.endarea
+
+.org AItemsFStream
+.area 0x48
+	.fill 0x48, 0;
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_dungeon_data/na/patch_floor_ranks.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_dungeon_data/na/patch_floor_ranks.asm
@@ -1,0 +1,104 @@
+; For use with ARMIPS
+; 2021/01/30
+; For Explorers of Sky NA Only
+; ------------------------------------------------------------------------------
+; Use filestreams instead of hardcoded lists 
+; ------------------------------------------------------------------------------
+
+.definelabel BufferRead, 0x020A0C04
+.definelabel RanksFName, 0x020A0C08
+.definelabel RanksFStream, 0x020A0C1C
+.definelabel LoadRank, 0x020A0AD4
+;LoadRank(r0: floor_id, r1: group_id)
+.definelabel FRankHook1, 0x0204F7F0
+.definelabel FRankHook2, 0x0204F85C
+
+.org FRankHook1
+.area 0x24
+	ldrb r0,[r13, #+0x1]
+	mov r1,r2
+	bl LoadRank
+	nop
+	nop
+	nop
+	add  r13,r13,#0x4
+	ldmia  r13!,{r3,r4,r15}
+	nop
+.endarea
+
+.org FRankHook2
+.area 0x30
+	ldrb r0,[r13, #+0x1]
+	cmp r0,#0x1
+	mov r1,r2
+	movle  r0,#0x2
+	bl LoadRank
+	nop
+	nop
+	nop
+	nop
+	add  r13,r13,#0x4
+	ldmia  r13!,{r3,r4,r15}
+	nop
+.endarea
+
+.org LoadRank
+.area 0x130
+	stmdb  r13!,{r5,r6,r7,r8,r14}
+	mov r5,r0
+	mov r6,r1
+	ldr r7,=RanksFStream
+	ldr r8,=BufferRead
+	bl FStreamAlloc
+	mov r0,r7
+	bl FStreamCtor
+	mov r0,r7
+	ldr r1,=RanksFName
+	bl FStreamFOpen
+	
+	; Get the offset in file
+	mov r0,r7
+	mov r1,r6,lsl #0x2
+	mov r2,#0x0
+	bl FStreamSeek
+	mov r0,r7
+	mov r1,r8
+	mov r2,#0x4
+	bl FStreamRead
+	
+	; Get the mission floor byte
+	mov r0,r7
+	ldr r1,[r8, #+0x0]
+	add r1,r1,r5
+	mov r2,#0x0
+	bl FStreamSeek
+	mov r0,r7
+	mov r1,r8
+	mov r2,#0x1
+	bl FStreamRead
+	
+	; Close the stream
+	mov r0,r7
+	bl FStreamClose
+	bl FStreamDealloc
+	ldrb r0,[r8, #+0x0]
+	ldmia  r13!,{r5,r6,r7,r8,r15}
+	.pool
+	.fill (BufferRead - .), 0xCC;
+.endarea
+
+.org BufferRead
+.area 0x4
+	.fill 0x4, 0;
+.endarea
+
+.org RanksFName
+.area 0x14
+	.ascii "BALANCE/f_ranks.bin"
+	dcb 0
+.endarea
+
+.org RanksFStream
+.area 0x48
+	.fill 0x48, 0;
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_dungeon_data/na/patch_forbidden_floors.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_dungeon_data/na/patch_forbidden_floors.asm
@@ -1,0 +1,92 @@
+; For use with ARMIPS
+; 2021/01/31
+; For Explorers of Sky NA Only
+; ------------------------------------------------------------------------------
+; Use filestreams instead of hardcoded lists 
+; ------------------------------------------------------------------------------
+
+.definelabel ExternalFunctionCall, 0x0204F64C
+
+.definelabel HookFunction, 0x02051568
+.definelabel LoadForbid, 0x0209F714
+.definelabel BufferReadF, 0x0209F780
+.definelabel ForbidFName, 0x0209F784
+.definelabel FStreamStruct, 0x0209F798
+
+.org HookFunction
+.area 0x5C
+	stmdb  r13!,{r3,r5,r6,r7,r8,r14}
+	mov  r1,r0
+	add  r0,r13,#0x0
+	bl ExternalFunctionCall
+	ldrb r6,[r13, #+0x0]
+	ldrb r5,[r13, #+0x1]
+	ldr r7,=RanksFStream
+	ldr r8,=BufferRead
+	
+	bl FStreamAlloc
+	mov r0,r7
+	bl FStreamCtor
+	mov r0,r7
+	ldr r1,=ForbidFName
+	bl FStreamFOpen
+	
+	b LoadForbid
+end_forbid:
+	ldmia  r13!,{r3,r5,r6,r7,r8,r15}
+	
+	.pool
+	.fill (HookFunction + 0x5C - .), 0xCC;
+.endarea
+
+.org LoadForbid
+.area 0x6C
+	
+	; Get the offset in file
+	mov r0,r7
+	mov r1,r6,lsl #0x2
+	mov r2,#0x0
+	bl FStreamSeek
+	mov r0,r7
+	mov r1,r8
+	mov r2,#0x4
+	bl FStreamRead
+	
+	; Get the mission floor byte
+	mov r0,r7
+	ldr r1,[r8, #+0x0]
+	add r1,r1,r5
+	mov r2,#0x0
+	bl FStreamSeek
+	mov r0,r7
+	mov r1,r8
+	mov r2,#0x1
+	bl FStreamRead
+	
+	; Close the stream
+	mov r0,r7
+	bl FStreamClose
+	bl FStreamDealloc
+	ldrb r0,[r8, #+0x0]
+	
+	b end_forbid
+	
+	.pool
+	.fill (BufferReadF - .), 0xCC;
+.endarea
+
+.org BufferReadF
+.area 0x4
+	.fill 0x4, 0;
+.endarea
+
+.org ForbidFName
+.area 0x14
+	.ascii "BALANCE/fforbid.bin"
+	dcb 0
+.endarea
+
+.org FStreamStruct
+.area 0x48
+	.fill 0x48, 0;
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_dungeon_data/selector_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_dungeon_data/selector_arm9.asm
@@ -1,0 +1,21 @@
+; For use with ARMIPS
+; 2021/01/30
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/patch_floor_ranks.asm"
+	.include "na/patch_forbidden_floors.asm"
+	.include "na/patch_available_items.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/patch_floor_ranks.asm"
+	.include "eu/patch_forbidden_floors.asm"
+	.include "eu/patch_available_items.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_item_lists/eu/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_item_lists/eu/patch.asm
@@ -1,28 +1,116 @@
 ; For use with ARMIPS
-; 2021/01/27
+; 2021/01/30
 ; For Explorers of Sky EU Only
 ; ------------------------------------------------------------------------------
 ; Use filestreams instead of hardcoded lists 
 ; ------------------------------------------------------------------------------
 
-.org 0x0200E0DC
+.definelabel CacheHoldStruct, 0x0209F748
+.definelabel CacheUpdateStruct, 0x0209F750
+.definelabel CacheFunction, 0x0209FB18
+.definelabel CacheData, 0x209FE88
+.definelabel CacheSize, 0x11D0
+.definelabel CacheBlocks, 0x6
+.definelabel CacheLast, 0x5
+.definelabel ListSize, 0x2F8
+.definelabel FileNamesTable, 0x020B1264
+.definelabel FunctionHook1, 0x0200E0DC
+.definelabel FunctionHook2, 0x0200E260
+.definelabel FunctionHook3, 0x0200E274
+
+.org CacheHoldStruct
+.area CacheBlocks
+	.fill CacheBlocks, 0x00
+.endarea
+.org CacheUpdateStruct
+.area CacheBlocks
+	.fill CacheBlocks, 0x00
+.endarea
+
+.org CacheData
+.area CacheSize
+	.fill CacheSize, 0x00
+.endarea
+
+.org CacheFunction
+.area 0x180
+	mov r8,#0x0
+	mov r0,#0x0
+	mov r7,#0x0
+	mov r11,CacheBlocks
+	ldr r2,=CacheHoldStruct
+cache_find_loop:
+	; Il faut que je cache des trucs
+	ldrb r1, [r2, +r0]
+	cmp r1,r6
+	bne next_find_loop
+	ldr r7,=CacheData
+	mov r1,ListSize
+	mla r7,r1,r0,r7
+	mov r11,r0
+	mov r8,#0x1
+	b end_find_loop
+next_find_loop:
+	add r0,r0,#0x1
+	cmp r0,CacheBlocks
+	blt cache_find_loop
+end_find_loop:
+
+	mov r0,#0x0
+	ldr r2,=CacheUpdateStruct
+	cmp r8, #0x1
+	ldreqb r10, [r2, +r11]
+	movne r10, #0x0
+	
+cache_update_loop:
+	ldrb r1, [r2, +r0]
+	cmp r1,#0x0
+	cmpeq r8,#0x0
+	cmpeq r7,#0x0
+	bne skip_choice
+	ldr r7,=CacheHoldStruct
+	strb r6, [r7, +r0]
+	ldr r7,=CacheData
+	mov r9,ListSize
+	mla r7,r9,r0,r7
+	mov r11,r0
+skip_choice:
+	cmp r1,r10
+	subgt r1,r1,#0x1
+	cmp r0,r11
+	moveq r1,CacheLast
+	strb r1, [r2, +r0]
+	
+next_update_loop:
+	add r0,r0,#0x1
+	cmp r0,CacheBlocks
+	blt cache_update_loop
+end_update_loop:
+	cmp r8,#0x1
+	beq no_need_alloc
+	b need_alloc
+	.pool
+.endarea
+
+.org FunctionHook1
 .area 0xF4
 	stmdb  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r14}
 	mov  r6,r0
 	mov  r5,r1
-	mov  r0,#0x2F8
-	mov  r1,#0x0
 	mov  r4,r2
-	bl MemAlloc
-	mov  r7,r0
+	cmp r6,#0x0
+	moveq r6,#0x1
+	b CacheFunction
+	nop
+	nop
+	nop
+need_alloc: 
 	mov  r0,#0x48
 	mov  r1,#0x0
 	bl MemAlloc
 	mov r8,r0
-	cmp r6,#0x0
-	ldr r0,=0x020b1264
-	subne  r1,r6,#0x1
-	moveq r1,r6
+	ldr r0,=FileNamesTable
+	sub  r1,r6,#0x1
 	ldr r6,[r0,+r1, lsl #0x2]
 
 	; Open File Stream
@@ -86,16 +174,19 @@ end_loop:
 	nop
 	nop
 	nop
+no_need_alloc:
 .endarea
 
-; Remove the second block allocation
-.org 0x0200E268
-.area 0x8
+; Remove the blocks allocation
+.org FunctionHook2
+.area 0x10
+	nop
+	nop
 	nop
 	nop
 .endarea
 
-.org 0x0200E274
+.org FunctionHook3
 .area 0xC
 	ldmia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
 	.pool

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_item_lists/na/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_item_lists/na/patch.asm
@@ -1,28 +1,116 @@
 ; For use with ARMIPS
-; 2021/01/27
+; 2021/01/30
 ; For Explorers of Sky NA Only
 ; ------------------------------------------------------------------------------
 ; Use filestreams instead of hardcoded lists 
 ; ------------------------------------------------------------------------------
 
-.org 0x0200E054
+.definelabel CacheHoldStruct, 0x0209F1C4
+.definelabel CacheUpdateStruct, 0x0209F1CC
+.definelabel CacheFunction, 0x0209F594
+.definelabel CacheData, 0x0209F904
+.definelabel CacheSize, 0x11D0
+.definelabel CacheBlocks, 0x6
+.definelabel CacheLast, 0x5
+.definelabel ListSize, 0x2F8
+.definelabel FileNamesTable, 0x020B0948
+.definelabel FunctionHook1, 0x0200E054
+.definelabel FunctionHook2, 0x0200E1D8
+.definelabel FunctionHook3, 0x0200E1EC
+
+.org CacheHoldStruct
+.area CacheBlocks
+	.fill CacheBlocks, 0x00
+.endarea
+.org CacheUpdateStruct
+.area CacheBlocks
+	.fill CacheBlocks, 0x00
+.endarea
+
+.org CacheData
+.area CacheSize
+	.fill CacheSize, 0x00
+.endarea
+
+.org CacheFunction
+.area 0x180
+	mov r8,#0x0
+	mov r0,#0x0
+	mov r7,#0x0
+	mov r11,CacheBlocks
+	ldr r2,=CacheHoldStruct
+cache_find_loop:
+	; Il faut que je cache des trucs
+	ldrb r1, [r2, +r0]
+	cmp r1,r6
+	bne next_find_loop
+	ldr r7,=CacheData
+	mov r1,ListSize
+	mla r7,r1,r0,r7
+	mov r11,r0
+	mov r8,#0x1
+	b end_find_loop
+next_find_loop:
+	add r0,r0,#0x1
+	cmp r0,CacheBlocks
+	blt cache_find_loop
+end_find_loop:
+
+	mov r0,#0x0
+	ldr r2,=CacheUpdateStruct
+	cmp r8, #0x1
+	ldreqb r10, [r2, +r11]
+	movne r10, #0x0
+	
+cache_update_loop:
+	ldrb r1, [r2, +r0]
+	cmp r1,#0x0
+	cmpeq r8,#0x0
+	cmpeq r7,#0x0
+	bne skip_choice
+	ldr r7,=CacheHoldStruct
+	strb r6, [r7, +r0]
+	ldr r7,=CacheData
+	mov r9,ListSize
+	mla r7,r9,r0,r7
+	mov r11,r0
+skip_choice:
+	cmp r1,r10
+	subgt r1,r1,#0x1
+	cmp r0,r11
+	moveq r1,CacheLast
+	strb r1, [r2, +r0]
+	
+next_update_loop:
+	add r0,r0,#0x1
+	cmp r0,CacheBlocks
+	blt cache_update_loop
+end_update_loop:
+	cmp r8,#0x1
+	beq no_need_alloc
+	b need_alloc
+	.pool
+.endarea
+
+.org FunctionHook1
 .area 0xF4
 	stmdb  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r14}
 	mov  r6,r0
 	mov  r5,r1
-	mov  r0,#0x2F8
-	mov  r1,#0x0
 	mov  r4,r2
-	bl MemAlloc
-	mov  r7,r0
+	cmp r6,#0x0
+	moveq r6,#0x1
+	b CacheFunction
+	nop
+	nop
+	nop
+need_alloc: 
 	mov  r0,#0x48
 	mov  r1,#0x0
 	bl MemAlloc
 	mov r8,r0
-	cmp r6,#0x0
-	ldr r0,=0x020b0948
-	subne  r1,r6,#0x1
-	moveq r1,r6
+	ldr r0,=FileNamesTable
+	sub  r1,r6,#0x1
 	ldr r6,[r0,+r1, lsl #0x2]
 
 	; Open File Stream
@@ -86,16 +174,19 @@ end_loop:
 	nop
 	nop
 	nop
+no_need_alloc:
 .endarea
 
-; Remove the second block allocation
-.org 0x0200E1E0
-.area 0x8
+; Remove the blocks allocation
+.org FunctionHook2
+.area 0x10
+	nop
+	nop
 	nop
 	nop
 .endarea
 
-.org 0x0200E1EC
+.org FunctionHook3
 .area 0xC
 	ldmia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
 	.pool

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -880,6 +880,13 @@
 	  </OpenBin>
         </Patch>
         
+        <!-- A patch to extract dungeon data -->
+        <Patch id="ExtractDungeonData" >
+          <OpenBin filepath="arm9.bin">
+	  	<Include filename ="irdkwia_asm_mods/extract_dungeon_data/selector_arm9.asm"/>
+	  </OpenBin>
+        </Patch>
+        
         <!-- A patch that fixes the unused dungeon chance -->
         <Patch id="UnusedDungeonChancePatch" >
           <OpenBin filepath="overlay/overlay_0029.bin">

--- a/skytemple_files/dungeon_data/floor_attribute/__init__.py
+++ b/skytemple_files/dungeon_data/floor_attribute/__init__.py
@@ -1,0 +1,16 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.

--- a/skytemple_files/dungeon_data/floor_attribute/handler.py
+++ b/skytemple_files/dungeon_data/floor_attribute/handler.py
@@ -1,0 +1,31 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from skytemple_files.common.types.data_handler import DataHandler
+from skytemple_files.common.util import read_bytes
+from skytemple_files.dungeon_data.floor_attribute.model import FloorAttribute
+from skytemple_files.dungeon_data.floor_attribute.writer import FloorAttributeWriter
+
+
+class FloorAttributeHandler(DataHandler[FloorAttribute]):
+    @classmethod
+    def deserialize(cls, data: bytes, **kwargs) -> FloorAttribute:
+        return FloorAttribute(data)
+
+    @classmethod
+    def serialize(cls, data: FloorAttribute, **kwargs) -> bytes:
+        return FloorAttributeWriter(data).write()

--- a/skytemple_files/dungeon_data/floor_attribute/model.py
+++ b/skytemple_files/dungeon_data/floor_attribute/model.py
@@ -1,0 +1,73 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Optional, List, Tuple
+from skytemple_files.dungeon_data.floor_attribute import *
+from skytemple_files.common.util import *
+
+class FloorAttribute:
+    def __init__(self, data: bytes):
+        if not isinstance(data, memoryview):
+            data = memoryview(data)
+        self.attrs = []
+        last_ptr = read_uintle(data, 0, 4)
+        nbgroups = last_ptr//4
+        for g in range(nbgroups):
+            start = read_uintle(data, g*4, 4)
+            if g==nbgroups-1:
+                end = len(data)
+            else:
+                end = read_uintle(data, g*4+4, 4)
+            g_list = list(data[start:end])
+            self.attrs.append(g_list)
+
+    def extend_nb_floors(self, group_id: int, start_floor: int, nb_floors: int, rank: int = 0):
+        if nb_floors>0:
+            self.attrs[group_id] = self.attrs[group_id][:start_floor]+([rank]*nb_floors)+self.attrs[group_id][start_floor:]
+        elif nb_floors<0:
+            self.attrs[group_id] = self.attrs[group_id][:start_floor+nb_floors]+self.attrs[group_id][start_floor:]
+
+    def reorder_floors(self, reorder_list: List[List[Tuple[int,Optional[int],Optional[int]]]]):
+        new_attrs = []
+        for new_groups in reorder_list:
+            new_attrs.append([0])
+            for t_switch in new_groups:
+                group_id = t_switch[0]
+                start = t_switch[1]
+                end = t_switch[2]
+                if start==None:
+                    start = 0
+                start += 1
+                if end==None:
+                    end = len(self.attrs[group_id])
+                end += 1
+                new_attrs[-1].extend(self.attrs[group_id][start:end])
+        self.attrs = new_attrs
+                
+    def adjust_nb_floors(self, group_id: int, nb_floors: int):
+        while group_id>=len(self.attrs):
+            self.attrs.append([0])
+        if len(self.attrs[group_id])>nb_floors:
+            self.attrs[group_id] = self.attrs[group_id][:nb_floors]
+        else:
+            self.attrs[group_id].extend([0]*(nb_floors-len(self.attrs[group_id])))
+
+    def set_floor_attr(self, group_id: int, floor_id: int, attr: int):
+        self.attrs[group_id][floor_id] = attr
+
+    def get_floor_attr(self, group_id: int, floor_id: int):
+        return self.attrs[group_id][floor_id]

--- a/skytemple_files/dungeon_data/floor_attribute/writer.py
+++ b/skytemple_files/dungeon_data/floor_attribute/writer.py
@@ -1,4 +1,4 @@
-"""Converts Md models back into the binary format used by the game"""
+"""Converts FloorAttribute models back into the binary format used by the game"""
 #  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
 #
 #  This file is part of SkyTemple.

--- a/skytemple_files/dungeon_data/floor_attribute/writer.py
+++ b/skytemple_files/dungeon_data/floor_attribute/writer.py
@@ -1,0 +1,38 @@
+"""Converts Md models back into the binary format used by the game"""
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from skytemple_files.common.util import *
+from skytemple_files.dungeon_data.floor_attribute import *
+from skytemple_files.dungeon_data.floor_attribute.model import FloorAttribute
+
+
+class FloorAttributeWriter:
+    def __init__(self, model: FloorAttribute):
+        self.model = model
+
+    def write(self) -> bytes:
+        header = bytearray(len(self.model.attrs)*4)
+        data = bytearray(0)
+        for i, g_list in enumerate(self.model.attrs):
+            current_ptr = len(header)+len(data)
+            d_list = bytearray(g_list)
+            if len(d_list)%4!=0:
+                d_list += bytearray(4-(len(d_list)%4))
+            write_uintle(header, current_ptr, i*4, 4)
+            data += d_list
+        data = header+data
+        return bytes(data)

--- a/skytemple_files/patch/handler/extract_dungeon_data.py
+++ b/skytemple_files/patch/handler/extract_dungeon_data.py
@@ -1,0 +1,137 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler
+from skytemple_files.hardcoded.dungeons import HardcodedDungeons
+PATCH_CHECK_ADDR_APPLIED_US = 0x4F7F8
+PATCH_CHECK_INSTR_APPLIED_US = 0x359F1010
+PATCH_CHECK_ADDR_APPLIED_EU = 0x4FB30
+PATCH_CHECK_INSTR_APPLIED_EU = 0x359F1010
+
+FLOOR_FORBID_TABLE_US = 0x9F714
+ITEM_AVAILABLE_TABLE_US = 0x94D34
+FLOOR_RANKS_TABLE_US = 0xA0AD4
+FLOOR_FORBID_TABLE_EU = 0x9FC98
+ITEM_AVAILABLE_TABLE_EU = 0x95130
+FLOOR_RANKS_TABLE_EU = 0xA1058
+NB_ITEMS_TABLE = 100
+AVAILABLE_ITEMS_NB = 1024
+ARM9_START = 0x02000000
+
+FLOOR_FORBID_PATH = "BALANCE/fforbid.bin"
+FLOOR_RANKS_PATH = "BALANCE/f_ranks.bin"
+AVAILABLE_ITEMS_PATH = "BALANCE/a_items.bin"
+# TODO: move this somewhere else
+FLOORS_NB = [3, 5, 6, 10, 8, 12, 9, 5, 14, 5, 11, 5, 16, 20, 15, 21, 11, 14, 8, 15, 15, 8, 12, 20, 15, 24, 24, 14, 25, 25, 20, 18, 50, 20, 23, 30, 18, 30, 20, 8, 13, 20, 10, 15, 20, 20, 30, 6, 5, 10, 5, 50, 20, 99, 30, 19, 19, 17, 25, 75, 40, 40, 99, 1, 50, 99, 10, 5, 15, 20, 25, 30, 40, 17, 7, 10, 15, 11, 16, 20, 8, 10, 15, 10, 18, 10, 11, 5, 5, 11, 19, 16, 5, 6, 7, 6, 5, 5, 5, 5]
+
+class ExtractDungeonDataPatchHandler(AbstractPatchHandler):
+
+    @property
+    def name(self) -> str:
+        return 'ExtractDungeonData'
+
+    @property
+    def description(self) -> str:
+        return 'Extracts the floor ranks, forbidden mission floors, items available in dungeon tables and put them in files. Provides support for reading them from the rom file system.'
+
+    @property
+    def author(self) -> str:
+        return 'irdkwia'
+
+    @property
+    def version(self) -> str:
+        return '0.0.1'
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_US, 4)!=PATCH_CHECK_INSTR_APPLIED_US
+            if config.game_region == GAME_REGION_EU:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_EU, 4)!=PATCH_CHECK_INSTR_APPLIED_EU
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        if not self.is_applied(rom, config):
+            if config.game_version == GAME_VERSION_EOS:
+                if config.game_region == GAME_REGION_US:
+                    rank_table = FLOOR_RANKS_TABLE_US
+                    item_table = ITEM_AVAILABLE_TABLE_US
+                    forbid_table = FLOOR_FORBID_TABLE_US
+                if config.game_region == GAME_REGION_EU:
+                    rank_table = FLOOR_RANKS_TABLE_EU
+                    item_table = ITEM_AVAILABLE_TABLE_EU
+                    forbid_table = FLOOR_FORBID_TABLE_EU
+
+            header = bytearray(NB_ITEMS_TABLE*4)
+            rank_data = bytearray(0)
+            forbid_data = bytearray(0)
+            current_ptr = len(header)
+            for i in range(NB_ITEMS_TABLE):
+                start = read_uintle(rom.arm9, rank_table+i*4, 4)-ARM9_START
+                end = start+1+FLOORS_NB[i]
+                if end%4!=0:
+                    end += 4-(end%4)
+                rdata = rom.arm9[start:end]
+                fdata = bytearray(len(rdata))
+                x = forbid_table
+                while rom.arm9[x]!=0x64:
+                    if rom.arm9[x]==i:
+                        fdata[rom.arm9[x+1]] = 1
+                    x += 2
+                rom.arm9 = rom.arm9[:start]+bytes([0xCC]*(end-start))+rom.arm9[end:]
+                write_uintle(header, current_ptr, i*4, 4)
+                rank_data += bytearray(rdata)
+                forbid_data += bytearray(fdata)
+                
+                current_ptr += end-start
+            file_data = header + rank_data
+            if FLOOR_RANKS_PATH not in rom.filenames:
+                create_file_in_rom(rom, FLOOR_RANKS_PATH, file_data)
+            else:
+                rom.setFileByName(FLOOR_RANKS_PATH, file_data)
+            file_data = header + forbid_data
+            if FLOOR_FORBID_PATH not in rom.filenames:
+                create_file_in_rom(rom, FLOOR_FORBID_PATH, file_data)
+            else:
+                rom.setFileByName(FLOOR_FORBID_PATH, file_data)
+
+            dungeon_list = HardcodedDungeons.get_dungeon_list(rom.arm9, config)
+            groups = [d.mappa_index for d in dungeon_list]
+            print(hex(len(groups)))
+            list_available = []
+            for x in range(AVAILABLE_ITEMS_NB):
+                list_available.append(bytearray(0x100//8))
+                for i, g in enumerate(groups):
+                    off = item_table + g * (AVAILABLE_ITEMS_NB//8) + (x//8)
+                    if rom.arm9[off]&(1<<(x%8)):
+                        list_available[-1][i//8] |= 1<<(i%8)
+            file_data = bytearray().join(list_available)
+            if AVAILABLE_ITEMS_PATH not in rom.filenames:
+                create_file_in_rom(rom, AVAILABLE_ITEMS_PATH, file_data)
+            else:
+                rom.setFileByName(AVAILABLE_ITEMS_PATH, file_data)
+        try:
+            apply()
+        except RuntimeError as ex:
+            raise ex
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/handler/extract_item_lists.py
+++ b/skytemple_files/patch/handler/extract_item_lists.py
@@ -50,7 +50,7 @@ class ExtractItemListsPatchHandler(AbstractPatchHandler):
 
     @property
     def version(self) -> str:
-        return '0.0.1'
+        return '0.0.2'
 
     def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
         if config.game_version == GAME_VERSION_EOS:

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -38,6 +38,7 @@ from skytemple_files.patch.handler.same_type_partner import SameTypePartnerPatch
 from skytemple_files.patch.handler.unused_dungeon_chance import UnusedDungeonChancePatch
 from skytemple_files.patch.handler.support_atupx import AtupxSupportPatchHandler
 from skytemple_files.patch.handler.extract_item_lists import ExtractItemListsPatchHandler
+from skytemple_files.patch.handler.extract_dungeon_data import ExtractDungeonDataPatchHandler
 
 CORE_PATCHES_BASE_DIR = os.path.join(get_resources_dir(), 'patches')
 
@@ -50,6 +51,7 @@ class PatchType(Enum):
     SAME_TYPE_PARTNER = SameTypePartnerPatch
     SUPPORT_ATUPX = AtupxSupportPatchHandler
     EXTRACT_ITEM_LISTS = ExtractItemListsPatchHandler
+    EXTRACT_DUNGEON_DATA = ExtractDungeonDataPatchHandler
 
 
 class PatchPackageError(RuntimeError):


### PR DESCRIPTION
- Improve 'ExtractHardcodedItemLists' patch. 
- Add a patch to extract and edit rank and no mission floor attributes.
Note: there is also a 3rd data structure I extracted, but I was too lazy to add models for it; it is important though, as it breaks consistency with the dungeon floor data.