### PR TITLE
Make HP regeneration unsigned

### DIFF
--- a/skytemple_files/data/md/model.py
+++ b/skytemple_files/data/md/model.py
@@ -353,7 +353,7 @@ class Md:
                 'unk18': rs(0x2D, 1),
                 'shadow_size': ShadowSize(rs(0x2E, 1)),
                 'chance_spawn_asleep': rs(0x2F, 1),
-                'hp_regeneration': rs(0x30, 1),
+                'hp_regeneration': ru(0x30, 1),
                 'unk21_h': rs(0x31, 1),
                 'base_form_index': rs(0x32),
                 'exclusive_item1': rs(0x34),

--- a/skytemple_files/data/md/writer.py
+++ b/skytemple_files/data/md/writer.py
@@ -67,7 +67,7 @@ class MdWriter:
             self._write_data(entry.unk18, 1, signed=True)
             self._write_data(entry.shadow_size.value, 1, signed=True)
             self._write_data(entry.chance_spawn_asleep, 1, signed=True)
-            self._write_data(entry.hp_regeneration, 1, signed=True)
+            self._write_data(entry.hp_regeneration, 1)
             self._write_data(entry.unk21_h, 1, signed=True)
             self._write_data(entry.base_form_index, signed=True)
             self._write_data(entry.exclusive_item1, signed=True)


### PR DESCRIPTION
The HP regeneration value inside monster data should be unsigned, since the max value is 250.