### PR TITLE
Add patches to implement Fairy type and Fairy gummies.

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/eu/patch_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/eu/patch_arm9.asm
@@ -1,0 +1,19 @@
+; For use with ARMIPS
+; 2021/03/09
+; For Explorers of Sky EU Only
+; ------------------------------------------------------------------------------
+; Edit Type Table Access
+; ------------------------------------------------------------------------------
+
+; For Gummies
+
+.org 0x020119D4
+.area 0x4
+	mov  r2,#0x19 ; Now it's 25x25
+.endarea
+.org 0x020119E0
+.area 0xC
+	ldrb r2,[r10, r3]
+	ldrb r0,[r10, r1]
+	nop
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/eu/patch_overlay13.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/eu/patch_overlay13.asm
@@ -1,0 +1,13 @@
+; For use with ARMIPS
+; 2021/03/12
+; For Explorers of Sky EU Only
+; ------------------------------------------------------------------------------
+; Edit Type Table Access
+; ------------------------------------------------------------------------------
+
+; Fix Fairy type's mask, in the original game, it also removes Electric types.
+
+.org 0x0238CC80
+.area 0x4
+	.word 0x00020000
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/eu/patch_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/eu/patch_overlay29.asm
@@ -1,0 +1,43 @@
+; For use with ARMIPS
+; 2021/03/09
+; For Explorers of Sky EU Only
+; ------------------------------------------------------------------------------
+; Edit Type Table Access
+; ------------------------------------------------------------------------------
+
+; For Gummies
+
+.org 0x0231DB78
+.area 0x4
+	mov  r0,#0x19 ; Now it's 25x25
+.endarea
+.org 0x0231DB8C
+.area 0x4
+	mov  r0,r2
+.endarea
+.org 0x0231DB94
+.area 0x8
+	ldrb r12,[r0, r12]
+	ldrb r0,[r0, r11]
+.endarea
+.org 0x0231DBAC
+.area 0x4
+	mov  r0,r2
+.endarea
+.org 0x0231DBB8
+.area 0x8
+	ldrb r2,[r0, r2]
+	ldrb r0,[r0, r1]
+.endarea
+
+;For Matchups
+
+.org 0x0230B758
+.area 0x4
+	mov  r0,#0x19 ; Now it's 25x25
+.endarea
+.org 0x0230B768
+.area 0x8
+	ldrb r0,[r1, +r0]
+	nop
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/jp/patch_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/jp/patch_arm9.asm
@@ -1,0 +1,19 @@
+; For use with ARMIPS
+; 2021/03/09
+; For Explorers of Sky JP Only
+; ------------------------------------------------------------------------------
+; Edit Type Table Access
+; ------------------------------------------------------------------------------
+
+; For Gummies
+
+.org 0x020118FC
+.area 0x4
+	mov  r2,#0x19 ; Now it's 25x25
+.endarea
+.org 0x02011908
+.area 0xC
+	ldrb r2,[r10, r3]
+	ldrb r0,[r10, r1]
+	nop
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/jp/patch_overlay13.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/jp/patch_overlay13.asm
@@ -1,0 +1,13 @@
+; For use with ARMIPS
+; 2021/03/12
+; For Explorers of Sky NA Only
+; ------------------------------------------------------------------------------
+; Edit Type Table Access
+; ------------------------------------------------------------------------------
+
+; Fix Fairy type's mask, in the original game, it also removes Electric types.
+
+.org 0x0238D6A8
+.area 0x4
+	.word 0x00020000
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/jp/patch_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/jp/patch_overlay29.asm
@@ -1,0 +1,43 @@
+; For use with ARMIPS
+; 2021/03/09
+; For Explorers of Sky JP Only
+; ------------------------------------------------------------------------------
+; Edit Type Table Access
+; ------------------------------------------------------------------------------
+
+; For Gummies
+
+.org 0x0231E5D8
+.area 0x4
+	mov  r0,#0x19 ; Now it's 25x25
+.endarea
+.org 0x0231E5EC
+.area 0x4
+	mov  r0,r2
+.endarea
+.org 0x0231E5F4
+.area 0x8
+	ldrb r12,[r0, r12]
+	ldrb r0,[r0, r11]
+.endarea
+.org 0x0231E60C
+.area 0x4
+	mov  r0,r2
+.endarea
+.org 0x0231E618
+.area 0x8
+	ldrb r2,[r0, r2]
+	ldrb r0,[r0, r1]
+.endarea
+
+;For Matchups
+
+.org 0x0230C25C
+.area 0x4
+	mov  r0,#0x19 ; Now it's 25x25
+.endarea
+.org 0x0230C26C
+.area 0x8
+	ldrb r0,[r1, +r0]
+	nop
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/na/patch_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/na/patch_arm9.asm
@@ -1,0 +1,19 @@
+; For use with ARMIPS
+; 2021/03/09
+; For Explorers of Sky NA Only
+; ------------------------------------------------------------------------------
+; Edit Type Table Access
+; ------------------------------------------------------------------------------
+
+; For Gummies
+
+.org 0x0201192C
+.area 0x4
+	mov  r2,#0x19 ; Now it's 25x25
+.endarea
+.org 0x02011938
+.area 0xC
+	ldrb r2,[r10, r3]
+	ldrb r0,[r10, r1]
+	nop
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/na/patch_overlay13.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/na/patch_overlay13.asm
@@ -1,0 +1,13 @@
+; For use with ARMIPS
+; 2021/03/12
+; For Explorers of Sky NA Only
+; ------------------------------------------------------------------------------
+; Edit Type Table Access
+; ------------------------------------------------------------------------------
+
+; Fix Fairy type's mask, in the original game, it also removes Electric types.
+
+.org 0x0238C140
+.area 0x4
+	.word 0x00020000
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/na/patch_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/na/patch_overlay29.asm
@@ -1,0 +1,43 @@
+; For use with ARMIPS
+; 2021/03/09
+; For Explorers of Sky NA Only
+; ------------------------------------------------------------------------------
+; Edit Type Table Access
+; ------------------------------------------------------------------------------
+
+; For Gummies
+
+.org 0x0231D110
+.area 0x4
+	mov  r0,#0x19 ; Now it's 25x25
+.endarea
+.org 0x0231D124
+.area 0x4
+	mov  r0,r2
+.endarea
+.org 0x0231D12C
+.area 0x8
+	ldrb r12,[r0, r12]
+	ldrb r0,[r0, r11]
+.endarea
+.org 0x0231D144
+.area 0x4
+	mov  r0,r2
+.endarea
+.org 0x0231D150
+.area 0x8
+	ldrb r2,[r0, r2]
+	ldrb r0,[r0, r1]
+.endarea
+
+;For Matchups
+
+.org 0x0230ACE4
+.area 0x4
+	mov  r0,#0x19 ; Now it's 25x25
+.endarea
+.org 0x0230ACF4
+.area 0x8
+	ldrb r0,[r1, r0]
+	nop
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/selector_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/selector_arm9.asm
@@ -1,0 +1,19 @@
+; For use with ARMIPS
+; 2021/01/30
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/patch_arm9.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/patch_arm9.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/patch_arm9.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/selector_overlay13.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/selector_overlay13.asm
@@ -1,0 +1,19 @@
+; For use with ARMIPS
+; 2021/03/09
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/patch_overlay13.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/patch_overlay13.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/patch_overlay13.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/selector_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/add_type/selector_overlay29.asm
@@ -1,0 +1,19 @@
+; For use with ARMIPS
+; 2021/03/09
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/patch_overlay29.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/patch_overlay29.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/patch_overlay29.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_bar_list/eu/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_bar_list/eu/patch.asm
@@ -1,0 +1,164 @@
+; For use with ARMIPS
+; 2021/03/11
+; For Explorers of Sky EU Only
+; ------------------------------------------------------------------------------
+; Use filestreams to load bar item list
+; ------------------------------------------------------------------------------
+
+.definelabel FullLoad1, 0x0238ACEC
+.definelabel CheckOnly1, 0x0238B1F8
+.definelabel CheckOnly2, 0x0238D130
+.definelabel FullLoad2, 0x0238DC60
+
+.definelabel BarGetListFunc, 0x0238AC80
+.definelabel BarListFunc, 0x0238E700
+.definelabel BarFStream, BarListFunc+0x5AC - 0x48
+.definelabel BarFName, BarFStream - 0x14
+.definelabel BufferRead, BarFName - 0x16
+.definelabel PageCache, BufferRead - 0x2
+.definelabel PageData, PageCache - 0x400
+
+.org BarGetListFunc
+.area 0x40
+	stmdb  r13!,{r14}
+	bl BarListFunc
+	ldmia  r13!,{r15}
+check_only:
+	stmdb  r13!,{r14}
+	mov r1,#0
+	bl BarGetListFunc
+	ldmia  r13!,{r15}
+full_load:
+	stmdb  r13!,{r14}
+	mov r1,#1
+	bl BarGetListFunc
+	ldmia  r13!,{r15}
+	.fill BarGetListFunc + 0x40 - ., 0xCC
+.endarea
+
+.org FullLoad1
+.area 0x4
+	bl full_load
+.endarea
+.org CheckOnly1
+.area 0x4
+	bl check_only
+.endarea
+.org CheckOnly2
+.area 0x4
+	bl check_only
+.endarea
+.org FullLoad2
+.area 0x4
+	bl full_load
+.endarea
+
+.org BarListFunc
+.area PageData-BarListFunc
+	stmdb  r13!,{r5,r6,r7,r8,r9,r10,r14}
+	mov r5,r1
+	mov r6,r0
+	mov r9, #0
+	
+	ldr r8,=PageCache
+	mov r7, r6, lsr 0x9
+	ldrh r8,[r8]
+	subs r10,r8,r7
+	cmpeq r5,#0
+	beq no_read
+	
+	mov r9, #1
+	ldr r7,=BarFStream
+	ldr r8,=BufferRead
+	bl FStreamAlloc
+	mov r0,r7
+	bl FStreamCtor
+	mov r0,r7
+	ldr r1,=BarFName
+	bl FStreamFOpen
+	
+	movs r10,r10
+	beq no_read
+	
+	mov r0,r7
+	mov r1,r8
+	mov r2,#0x4
+	bl FStreamRead
+	
+	; Get the offset in file
+	mov r0,r7
+	mov r1, r6, lsr 0x9
+	mov r1, r1, lsl #0x9
+	mov r2,#0x1 ; Relative seek
+	bl FStreamSeek
+	mov r0,r7
+	ldr r1,=PageData
+	mov r2,#0x400
+	bl FStreamRead
+	
+	ldr r1,=PageCache
+	mov r0, r6, lsr 0x9
+	strh r0,[r1]
+no_read:
+	ldr r1,=0x1FF
+	and r0,r6,r1
+	ldr r1,=PageData
+	mov r0,r0,lsl 0x1
+	ldrsh r1,[r1, r0]
+	mvn r0, #0
+	cmp r0,r1
+	moveq r6,#0
+	beq end
+	cmp r5,#0
+	moveq r6,#1
+	beq end
+	
+	ldr r0,[r8, #+0x0]
+	mov r2,#0x14
+	mla r1,r1,r2,r0
+	mov r0,r7
+	mov r2,#0x0
+	bl FStreamSeek
+	mov r0,r7
+	add r1,r8,#0x2
+	mov r2,#0x14
+	bl FStreamRead
+	mov r6,r8
+end:
+	; Close the stream
+	cmp r9,#0
+	beq no_close
+	mov r0,r7
+	bl FStreamClose
+	bl FStreamDealloc
+no_close:
+	mov r0,r6
+	ldmia  r13!,{r5,r6,r7,r8,r9,r10,r15}
+	.pool
+	.fill PageData - ., 0xCC
+.endarea
+
+.org PageData
+.area 0x400
+	.fill 0x400, 0
+.endarea
+.org PageCache
+.area 0x2
+	.fill 0x2, 0xFF
+.endarea
+
+.org BufferRead
+.area 0x16
+	.fill 0x16, 0
+.endarea
+
+.org BarFName
+.area 0x14
+	.ascii "BALANCE/itembar.bin"
+	dcb 0
+.endarea
+
+.org BarFStream
+.area 0x48
+	.fill 0x48, 0
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_bar_list/jp/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_bar_list/jp/patch.asm
@@ -1,0 +1,164 @@
+; For use with ARMIPS
+; 2021/03/11
+; For Explorers of Sky JP Only
+; ------------------------------------------------------------------------------
+; Use filestreams to load bar item list
+; ------------------------------------------------------------------------------
+
+.definelabel FullLoad1, 0x0238B70C
+.definelabel CheckOnly1, 0x0238BC18
+.definelabel CheckOnly2, 0x0238DB54
+.definelabel FullLoad2, 0x0238E684
+
+.definelabel BarGetListFunc, 0x0238B6A0
+.definelabel BarListFunc, 0x0238F124
+.definelabel BarFStream, BarListFunc+0x5AC - 0x48
+.definelabel BarFName, BarFStream - 0x14
+.definelabel BufferRead, BarFName - 0x16
+.definelabel PageCache, BufferRead - 0x2
+.definelabel PageData, PageCache - 0x400
+
+.org BarGetListFunc
+.area 0x40
+	stmdb  r13!,{r14}
+	bl BarListFunc
+	ldmia  r13!,{r15}
+check_only:
+	stmdb  r13!,{r14}
+	mov r1,#0
+	bl BarGetListFunc
+	ldmia  r13!,{r15}
+full_load:
+	stmdb  r13!,{r14}
+	mov r1,#1
+	bl BarGetListFunc
+	ldmia  r13!,{r15}
+	.fill BarGetListFunc + 0x40 - ., 0xCC
+.endarea
+
+.org FullLoad1
+.area 0x4
+	bl full_load
+.endarea
+.org CheckOnly1
+.area 0x4
+	bl check_only
+.endarea
+.org CheckOnly2
+.area 0x4
+	bl check_only
+.endarea
+.org FullLoad2
+.area 0x4
+	bl full_load
+.endarea
+
+.org BarListFunc
+.area PageData-BarListFunc
+	stmdb  r13!,{r5,r6,r7,r8,r9,r10,r14}
+	mov r5,r1
+	mov r6,r0
+	mov r9, #0
+	
+	ldr r8,=PageCache
+	mov r7, r6, lsr 0x9
+	ldrh r8,[r8]
+	subs r10,r8,r7
+	cmpeq r5,#0
+	beq no_read
+	
+	mov r9, #1
+	ldr r7,=BarFStream
+	ldr r8,=BufferRead
+	bl FStreamAlloc
+	mov r0,r7
+	bl FStreamCtor
+	mov r0,r7
+	ldr r1,=BarFName
+	bl FStreamFOpen
+	
+	movs r10,r10
+	beq no_read
+	
+	mov r0,r7
+	mov r1,r8
+	mov r2,#0x4
+	bl FStreamRead
+	
+	; Get the offset in file
+	mov r0,r7
+	mov r1, r6, lsr 0x9
+	mov r1, r1, lsl #0x9
+	mov r2,#0x1 ; Relative seek
+	bl FStreamSeek
+	mov r0,r7
+	ldr r1,=PageData
+	mov r2,#0x400
+	bl FStreamRead
+	
+	ldr r1,=PageCache
+	mov r0, r6, lsr 0x9
+	strh r0,[r1]
+no_read:
+	ldr r1,=0x1FF
+	and r0,r6,r1
+	ldr r1,=PageData
+	mov r0,r0,lsl 0x1
+	ldrsh r1,[r1, r0]
+	mvn r0, #0
+	cmp r0,r1
+	moveq r6,#0
+	beq end
+	cmp r5,#0
+	moveq r6,#1
+	beq end
+	
+	ldr r0,[r8, #+0x0]
+	mov r2,#0x14
+	mla r1,r1,r2,r0
+	mov r0,r7
+	mov r2,#0x0
+	bl FStreamSeek
+	mov r0,r7
+	add r1,r8,#0x2
+	mov r2,#0x14
+	bl FStreamRead
+	mov r6,r8
+end:
+	; Close the stream
+	cmp r9,#0
+	beq no_close
+	mov r0,r7
+	bl FStreamClose
+	bl FStreamDealloc
+no_close:
+	mov r0,r6
+	ldmia  r13!,{r5,r6,r7,r8,r9,r10,r15}
+	.pool
+	.fill PageData - ., 0xCC
+.endarea
+
+.org PageData
+.area 0x400
+	.fill 0x400, 0
+.endarea
+.org PageCache
+.area 0x2
+	.fill 0x2, 0xFF
+.endarea
+
+.org BufferRead
+.area 0x16
+	.fill 0x16, 0
+.endarea
+
+.org BarFName
+.area 0x14
+	.ascii "BALANCE/itembar.bin"
+	dcb 0
+.endarea
+
+.org BarFStream
+.area 0x48
+	.fill 0x48, 0
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_bar_list/na/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_bar_list/na/patch.asm
@@ -1,0 +1,164 @@
+; For use with ARMIPS
+; 2021/03/11
+; For Explorers of Sky NA Only
+; ------------------------------------------------------------------------------
+; Use filestreams to load bar item list
+; ------------------------------------------------------------------------------
+
+.definelabel FullLoad1, 0x0238A1AC
+.definelabel CheckOnly1, 0x0238A6B8
+.definelabel CheckOnly2, 0x0238C5FC
+.definelabel FullLoad2, 0x0238D12C
+
+.definelabel BarGetListFunc, 0x0238A140
+.definelabel BarListFunc, 0x0238DBCC
+.definelabel BarFStream, BarListFunc+0x5AC - 0x48
+.definelabel BarFName, BarFStream - 0x14
+.definelabel BufferRead, BarFName - 0x16
+.definelabel PageCache, BufferRead - 0x2
+.definelabel PageData, PageCache - 0x400
+
+.org BarGetListFunc
+.area 0x40
+	stmdb  r13!,{r14}
+	bl BarListFunc
+	ldmia  r13!,{r15}
+check_only:
+	stmdb  r13!,{r14}
+	mov r1,#0
+	bl BarGetListFunc
+	ldmia  r13!,{r15}
+full_load:
+	stmdb  r13!,{r14}
+	mov r1,#1
+	bl BarGetListFunc
+	ldmia  r13!,{r15}
+	.fill BarGetListFunc + 0x40 - ., 0xCC
+.endarea
+
+.org FullLoad1
+.area 0x4
+	bl full_load
+.endarea
+.org CheckOnly1
+.area 0x4
+	bl check_only
+.endarea
+.org CheckOnly2
+.area 0x4
+	bl check_only
+.endarea
+.org FullLoad2
+.area 0x4
+	bl full_load
+.endarea
+
+.org BarListFunc
+.area PageData-BarListFunc
+	stmdb  r13!,{r5,r6,r7,r8,r9,r10,r14}
+	mov r5,r1
+	mov r6,r0
+	mov r9, #0
+	
+	ldr r8,=PageCache
+	mov r7, r6, lsr 0x9
+	ldrh r8,[r8]
+	subs r10,r8,r7
+	cmpeq r5,#0
+	beq no_read
+	
+	mov r9, #1
+	ldr r7,=BarFStream
+	ldr r8,=BufferRead
+	bl FStreamAlloc
+	mov r0,r7
+	bl FStreamCtor
+	mov r0,r7
+	ldr r1,=BarFName
+	bl FStreamFOpen
+	
+	movs r10,r10
+	beq no_read
+	
+	mov r0,r7
+	mov r1,r8
+	mov r2,#0x4
+	bl FStreamRead
+	
+	; Get the offset in file
+	mov r0,r7
+	mov r1, r6, lsr 0x9
+	mov r1, r1, lsl #0x9
+	mov r2,#0x1 ; Relative seek
+	bl FStreamSeek
+	mov r0,r7
+	ldr r1,=PageData
+	mov r2,#0x400
+	bl FStreamRead
+	
+	ldr r1,=PageCache
+	mov r0, r6, lsr 0x9
+	strh r0,[r1]
+no_read:
+	ldr r1,=0x1FF
+	and r0,r6,r1
+	ldr r1,=PageData
+	mov r0,r0,lsl 0x1
+	ldrsh r1,[r1, r0]
+	mvn r0, #0
+	cmp r0,r1
+	moveq r6,#0
+	beq end
+	cmp r5,#0
+	moveq r6,#1
+	beq end
+	
+	ldr r0,[r8, #+0x0]
+	mov r2,#0x14
+	mla r1,r1,r2,r0
+	mov r0,r7
+	mov r2,#0x0
+	bl FStreamSeek
+	mov r0,r7
+	add r1,r8,#0x2
+	mov r2,#0x14
+	bl FStreamRead
+	mov r6,r8
+end:
+	; Close the stream
+	cmp r9,#0
+	beq no_close
+	mov r0,r7
+	bl FStreamClose
+	bl FStreamDealloc
+no_close:
+	mov r0,r6
+	ldmia  r13!,{r5,r6,r7,r8,r9,r10,r15}
+	.pool
+	.fill PageData - ., 0xCC
+.endarea
+
+.org PageData
+.area 0x400
+	.fill 0x400, 0
+.endarea
+.org PageCache
+.area 0x2
+	.fill 0x2, 0xFF
+.endarea
+
+.org BufferRead
+.area 0x16
+	.fill 0x16, 0
+.endarea
+
+.org BarFName
+.area 0x14
+	.ascii "BALANCE/itembar.bin"
+	dcb 0
+.endarea
+
+.org BarFStream
+.area 0x48
+	.fill 0x48, 0
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_bar_list/selector_overlay19.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/extract_bar_list/selector_overlay19.asm
@@ -1,0 +1,19 @@
+; For use with ARMIPS
+; 2021/01/30
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/patch.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/patch.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/patch.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/implement_fairy_gummies/eu/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/implement_fairy_gummies/eu/patch.asm
@@ -1,0 +1,76 @@
+; For use with ARMIPS
+; 2021/03/12
+; For Explorers of Sky EU Only
+; ------------------------------------------------------------------------------
+; Implement Fairy-type gummies
+; ------------------------------------------------------------------------------
+
+.definelabel IsGummi, 0x0200CC7C
+.definelabel GummiStatUp, 0x0201196C
+.definelabel GetType, 0x02052D3C
+.definelabel WonderGummiIQBoost, 0x020A1E14
+.definelabel WonderGummiStatBoost, 0x020A1E34
+.definelabel GummiStatBoost, 0x020A1E0C
+.definelabel GummiIQBoostTable, 0x020A2834
+.definelabel GummiStatUpPool, 0x02011B48
+
+
+; Edit IsGummi
+
+.org IsGummi
+.area 0x20
+	cmp r0,#0x77
+	movlt  r0,#0x7F000000
+	cmp r0,#0x88
+	movle  r0,#0x8A
+	cmp r0,#0x8A
+	moveq  r0,#0x1
+	movne  r0,#0x0
+	bx r14
+.endarea
+
+.org GummiStatUp
+.area 0x8C
+	sub  r11,r0,#0x76
+	strh r4,[r6, #+0x2]
+	bl IsGummi
+	cmp r0,#0x0
+	ldmeqia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
+	ldrsh r0,[r13, #+0x28]
+	cmp r0,#0x8A
+	moveq r11,#0x12
+	cmp r0,#0x88
+	bne no_wonder_gummi
+	ldr r1,=WonderGummiIQBoost
+	ldr r0,=WonderGummiStatBoost
+	ldrsh r1,[r1, #+0x0]
+	ldrsh r5,[r0, #+0x0]
+	add  r4,r4,r1
+	b end_iq_inc
+no_wonder_gummi:
+	ldrsh r0,[r10, #+0x0]
+	ldr r2,=GummiStatBoost
+	mov  r1,r4
+	ldrsh r5,[r2, #+0x0]
+	bl GetType
+	str r0,[r13, #+0x0]
+	ldrsh r0,[r10, #+0x0]
+	mov  r1,#0x1
+	bl GetType
+	ldr r10,=GummiIQBoostTable
+	ldr r1,[r13, #+0x0]
+	mov  r2,#0x19
+	mla  r3,r1,r2,r10
+	mla  r1,r0,r2,r10
+	ldrb r2,[r11, r3]
+	ldrb r0,[r11, r1]
+	cmp r2,r0
+	addgt  r4,r4,r2
+	addle  r4,r4,r0
+end_iq_inc:
+.endarea
+
+.org GummiStatUpPool
+.area 0x10
+	.pool
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/implement_fairy_gummies/jp/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/implement_fairy_gummies/jp/patch.asm
@@ -1,0 +1,76 @@
+; For use with ARMIPS
+; 2021/03/12
+; For Explorers of Sky JP Only
+; ------------------------------------------------------------------------------
+; Implement Fairy-type gummies
+; ------------------------------------------------------------------------------
+
+.definelabel IsGummi, 0x0200CBF4
+.definelabel GummiStatUp, 0x02011894
+.definelabel GetType, 0x02052D3C
+.definelabel WonderGummiIQBoost, 0x020A2C64
+.definelabel WonderGummiStatBoost, 0x020A2C84
+.definelabel GummiStatBoost, 0x020A2C5C
+.definelabel GummiIQBoostTable, 0x020A3684
+.definelabel GummiStatUpPool, 0x02011A70
+
+
+; Edit IsGummi
+
+.org IsGummi
+.area 0x20
+	cmp r0,#0x77
+	movlt  r0,#0x7F000000
+	cmp r0,#0x88
+	movle  r0,#0x8A
+	cmp r0,#0x8A
+	moveq  r0,#0x1
+	movne  r0,#0x0
+	bx r14
+.endarea
+
+.org GummiStatUp
+.area 0x8C
+	sub  r11,r0,#0x76
+	strh r4,[r6, #+0x2]
+	bl IsGummi
+	cmp r0,#0x0
+	ldmeqia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
+	ldrsh r0,[r13, #+0x28]
+	cmp r0,#0x8A
+	moveq r11,#0x12
+	cmp r0,#0x88
+	bne no_wonder_gummi
+	ldr r1,=WonderGummiIQBoost
+	ldr r0,=WonderGummiStatBoost
+	ldrsh r1,[r1, #+0x0]
+	ldrsh r5,[r0, #+0x0]
+	add  r4,r4,r1
+	b end_iq_inc
+no_wonder_gummi:
+	ldrsh r0,[r10, #+0x0]
+	ldr r2,=GummiStatBoost
+	mov  r1,r4
+	ldrsh r5,[r2, #+0x0]
+	bl GetType
+	str r0,[r13, #+0x0]
+	ldrsh r0,[r10, #+0x0]
+	mov  r1,#0x1
+	bl GetType
+	ldr r10,=GummiIQBoostTable
+	ldr r1,[r13, #+0x0]
+	mov  r2,#0x19
+	mla  r3,r1,r2,r10
+	mla  r1,r0,r2,r10
+	ldrb r2,[r11, r3]
+	ldrb r0,[r11, r1]
+	cmp r2,r0
+	addgt  r4,r4,r2
+	addle  r4,r4,r0
+end_iq_inc:
+.endarea
+
+.org GummiStatUpPool
+.area 0x10
+	.pool
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/implement_fairy_gummies/na/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/implement_fairy_gummies/na/patch.asm
@@ -1,0 +1,76 @@
+; For use with ARMIPS
+; 2021/02/21
+; For Explorers of Sky NA Only
+; ------------------------------------------------------------------------------
+; Implement Fairy-type gummies
+; ------------------------------------------------------------------------------
+
+.definelabel IsGummi, 0x0200CBF4
+.definelabel GummiStatUp, 0x020118C4
+.definelabel GetType, 0x02052A04
+.definelabel WonderGummiIQBoost, 0x020A1890
+.definelabel WonderGummiStatBoost, 0x020A18B0
+.definelabel GummiStatBoost, 0x020A1888
+.definelabel GummiIQBoostTable, 0x020A22B0
+.definelabel GummiStatUpPool, 0x02011AA0
+
+
+; Edit IsGummi
+
+.org IsGummi
+.area 0x20
+	cmp r0,#0x77
+	movlt  r0,#0x7F000000
+	cmp r0,#0x88
+	movle  r0,#0x8A
+	cmp r0,#0x8A
+	moveq  r0,#0x1
+	movne  r0,#0x0
+	bx r14
+.endarea
+
+.org GummiStatUp
+.area 0x8C
+	sub  r11,r0,#0x76
+	strh r4,[r6, #+0x2]
+	bl IsGummi
+	cmp r0,#0x0
+	ldmeqia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
+	ldrsh r0,[r13, #+0x28]
+	cmp r0,#0x8A
+	moveq r11,#0x12
+	cmp r0,#0x88
+	bne no_wonder_gummi
+	ldr r1,=WonderGummiIQBoost
+	ldr r0,=WonderGummiStatBoost
+	ldrsh r1,[r1, #+0x0]
+	ldrsh r5,[r0, #+0x0]
+	add  r4,r4,r1
+	b end_iq_inc
+no_wonder_gummi:
+	ldrsh r0,[r10, #+0x0]
+	ldr r2,=GummiStatBoost
+	mov  r1,r4
+	ldrsh r5,[r2, #+0x0]
+	bl GetType
+	str r0,[r13, #+0x0]
+	ldrsh r0,[r10, #+0x0]
+	mov  r1,#0x1
+	bl GetType
+	ldr r10,=GummiIQBoostTable
+	ldr r1,[r13, #+0x0]
+	mov  r2,#0x19
+	mla  r3,r1,r2,r10
+	mla  r1,r0,r2,r10
+	ldrb r2,[r11, r3]
+	ldrb r0,[r11, r1]
+	cmp r2,r0
+	addgt  r4,r4,r2
+	addle  r4,r4,r0
+end_iq_inc:
+.endarea
+
+.org GummiStatUpPool
+.area 0x10
+	.pool
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/implement_fairy_gummies/selector_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/implement_fairy_gummies/selector_arm9.asm
@@ -1,0 +1,19 @@
+; For use with ARMIPS
+; 2021/01/30
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/patch.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/patch.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/patch.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -904,6 +904,33 @@
 	  </OpenBin>
         </Patch>
         
+        <!-- A patch to add types to the type table -->
+        <Patch id="AddTypes" >
+          <OpenBin filepath="arm9.bin">
+	  	<Include filename ="irdkwia_asm_mods/add_type/selector_arm9.asm"/>
+	  </OpenBin>
+          <OpenBin filepath="overlay/overlay_0013.bin">
+	  	<Include filename ="irdkwia_asm_mods/add_type/selector_overlay13.asm"/>
+	  </OpenBin>
+          <OpenBin filepath="overlay/overlay_0029.bin">
+	  	<Include filename ="irdkwia_asm_mods/add_type/selector_overlay29.asm"/>
+	  </OpenBin>
+        </Patch>
+        
+        <!-- A patch to implement Fairy-type gummies -->
+        <Patch id="ImplementFairyGummies" >
+          <OpenBin filepath="arm9.bin">
+	  	<Include filename ="irdkwia_asm_mods/implement_fairy_gummies/selector_arm9.asm"/>
+	  </OpenBin>
+        </Patch>
+        
+        <!-- A patch to extract spinda bar's item list-->
+        <Patch id="ExtractBarItemList" >
+          <OpenBin filepath="overlay/overlay_0019.bin">
+	  	<Include filename ="irdkwia_asm_mods/extract_bar_list/selector_overlay19.asm"/>
+	  </OpenBin>
+        </Patch>
+        
         <!-- A patch to extract hardcoded item lists -->
         <Patch id="ExtractHardcodedItemLists" >
           <OpenBin filepath="arm9.bin">

--- a/skytemple_files/common/types/file_types.py
+++ b/skytemple_files/common/types/file_types.py
@@ -37,6 +37,7 @@ from skytemple_files.data.level_bin_entry.handler import LevelBinEntryHandler
 from skytemple_files.data.md.handler import MdHandler
 from skytemple_files.data.str.handler import StrHandler
 from skytemple_files.data.waza_p.handler import WazaPHandler
+from skytemple_files.data.item_p.handler import ItemPHandler
 from skytemple_files.data.tbl_talk.handler import TblTalkHandler
 from skytemple_files.dungeon_data.fixed_bin.handler import FixedBinHandler
 from skytemple_files.dungeon_data.mappa_bin.handler import MappaBinHandler
@@ -151,6 +152,7 @@ class FileType:
     MD = MdHandler
     LEVEL_BIN_ENTRY = LevelBinEntryHandler
     WAZA_P = WazaPHandler
+    ITEM_P = ItemPHandler
     TBL_TALK = TblTalkHandler
 
     # These handlers assume the content to be Sir0 wrapped by default:

--- a/skytemple_files/data/data_st/__init__.py
+++ b/skytemple_files/data/data_st/__init__.py
@@ -1,0 +1,17 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+

--- a/skytemple_files/data/data_st/handler.py
+++ b/skytemple_files/data/data_st/handler.py
@@ -1,0 +1,31 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from skytemple_files.common.types.data_handler import DataHandler
+from skytemple_files.data.data_st.model import DataST
+from skytemple_files.data.data_st.writer import DataSTWriter
+
+
+class DataSTHandler(DataHandler[DataST]):
+    @classmethod
+    def deserialize(cls, data: bytes, **kwargs) -> 'DataST':
+        return DataST(data)
+
+    @classmethod
+    def serialize(cls, data: 'DataST', **kwargs) -> bytes:
+        return DataSTWriter(data).write()
+

--- a/skytemple_files/data/data_st/model.py
+++ b/skytemple_files/data/data_st/model.py
@@ -1,0 +1,57 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from skytemple_files.common.util import *
+from skytemple_files.common.i18n_util import _
+from skytemple_files.data.data_cd.armips_importer import ArmipsImporter
+
+
+class DataST(AutoString):
+    def __init__(self, data: bytes):
+        if not isinstance(data, memoryview):
+            data = memoryview(data)
+        limit = read_uintle(data, 0, 4)
+        self.struct_ids = []
+        for x in range(4, limit, 2):
+            self.struct_ids.append(read_sintle(data, x, 2))
+        self.struct_data = bytes(data[limit:])
+
+    def nb_struct_ids(self) -> int:
+        return len(self.struct_ids)
+
+    def get_item_struct_id(self, item_id: int) -> int:
+        return self.struct_ids[item_id]
+
+    def set_item_struct_id(self, item_id: int, struct_id: int):
+        self.struct_ids[item_id] = struct_id
+        
+    def add_item_struct_id(self, struct_id: int):
+        self.struct_ids.append(struct_id)
+        
+    def get_all_of(self, struct_id: int) -> List[int]:
+        ids = []
+        for i, x in enumerate(self.struct_ids):
+            if x==struct_id:
+                ids.append(i)
+        return ids
+    
+    
+    def __eq__(self, other):
+        if not isinstance(other, DataST):
+            return False
+        return self.struct_ids == other.struct_ids and \
+               self.struct_data == other.struct_data

--- a/skytemple_files/data/data_st/writer.py
+++ b/skytemple_files/data/data_st/writer.py
@@ -1,0 +1,38 @@
+"""Converts DataST models back into the binary format used by the game"""
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Optional, Dict
+
+from skytemple_files.common.util import *
+from skytemple_files.data.data_st.model import DataST
+
+
+class DataSTWriter:
+    def __init__(self, model: DataST):
+        self.model = model
+
+    def write(self) -> bytes:
+        nb_items = len(self.model.struct_ids)
+        
+        header = bytearray(4+2*nb_items)
+        write_uintle(header, 4+2*nb_items, 0, 4)
+        
+        for i, x in enumerate(self.model.struct_ids):
+            write_sintle(header, x, 4+2*i, 2)
+        
+        file_data = header + self.model.struct_data
+        return bytes(file_data)

--- a/skytemple_files/data/item_p/__init__.py
+++ b/skytemple_files/data/item_p/__init__.py
@@ -1,0 +1,18 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+ITEM_P_ENTRY_SIZE = 16

--- a/skytemple_files/data/item_p/dbg/__init__.py
+++ b/skytemple_files/data/item_p/dbg/__init__.py
@@ -1,0 +1,17 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+

--- a/skytemple_files/data/item_p/dbg/export_import_test.py
+++ b/skytemple_files/data/item_p/dbg/export_import_test.py
@@ -1,0 +1,41 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+import os
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.types.file_types import FileType
+from skytemple_files.data.item_p.writer import ItemPWriter
+
+base_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', '..')
+
+rom = NintendoDSRom.fromFile(os.path.join(base_dir, 'skyworkcopy.nds'))
+item_p_bin = rom.getFileByName('BALANCE/item_p.bin')
+item_p = FileType.ITEM_P.deserialize(item_p_bin)
+sir0_pointers_before = FileType.SIR0.deserialize(item_p_bin).content_pointer_offsets
+
+sir0_pointers_after = ItemPWriter(item_p).write()[1]
+bin_after = FileType.ITEM_P.serialize(item_p)
+
+with open('/tmp/before.bin', 'wb') as f:
+    f.write(item_p_bin)
+
+with open('/tmp/after.bin', 'wb') as f:
+    f.write(bin_after)
+
+assert sir0_pointers_before == sir0_pointers_after
+assert FileType.ITEM_P.deserialize(bin_after) == item_p

--- a/skytemple_files/data/item_p/handler.py
+++ b/skytemple_files/data/item_p/handler.py
@@ -1,0 +1,44 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from skytemple_files.common.types.data_handler import DataHandler
+from skytemple_files.data.item_p.model import ItemP
+from skytemple_files.data.item_p.writer import ItemPWriter
+
+
+class ItemPHandler(DataHandler[ItemP]):
+    """
+    Deals with Sir0 wrapped models by default (assumes they are Sir0 wrapped).
+    Use the deserialize_raw / serialize_raw methods to work with the unwrapped models instead.
+    """
+    @classmethod
+    def deserialize(cls, data: bytes, **kwargs) -> 'ItemP':
+        from skytemple_files.common.types.file_types import FileType
+        return FileType.SIR0.unwrap_obj(FileType.SIR0.deserialize(data), ItemP)
+
+    @classmethod
+    def serialize(cls, data: 'ItemP', **kwargs) -> bytes:
+        from skytemple_files.common.types.file_types import FileType
+        return FileType.SIR0.serialize(FileType.SIR0.wrap_obj(data))
+
+    @classmethod
+    def deserialize_raw(cls, data: bytes, **kwargs) -> 'ItemP':
+        return ItemP(data)
+
+    @classmethod
+    def serialize_raw(cls, data: 'ItemP', **kwargs) -> bytes:
+        return ItemPWriter(data).write()[0]

--- a/skytemple_files/data/item_p/model.py
+++ b/skytemple_files/data/item_p/model.py
@@ -1,0 +1,116 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Optional
+
+from skytemple_files.common.util import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data
+from skytemple_files.container.sir0.sir0_serializable import Sir0Serializable
+from skytemple_files.container.sir0.sir0_util import decode_sir0_pointer_offsets
+from skytemple_files.data.item_p import *
+
+
+
+class ItemPEntry(AutoString):
+    def __init__(self, data: bytes):
+        self.buy_price = read_uintle(data, 0, 2) # Buy Price in Kecleon Shops
+        self.sell_price = read_uintle(data, 2, 2) # Sell Price in Kecleon Shops
+        self.category = read_uintle(data, 4, 1) # Category
+        self.sprite = read_uintle(data, 5, 1) # Sprite ID associated to that item
+        self.item_id = read_uintle(data, 6, 2) # Item ID
+        self.move_id = read_uintle(data, 8, 2) # Move ID associated to that item
+        self.range_min = read_uintle(data, 10, 1) # For stackable, indicates the minimum amount you can get for 1 instance of that item
+        self.range_max = read_uintle(data, 11, 1) # For stackable, indicates the maximum amount you can get for 1 instance of that item
+        self.palette = read_uintle(data, 12, 1) # Palette ID associated to that item
+        self.action_name = read_uintle(data, 13, 1) # Action name displayed in dungeon menus (Use, Eat, Ingest, Equip...)
+        bitfield = read_uintle(data, 14, 1)
+        self.is_valid = (bitfield&0x1)!=0 # Is Valid
+        self.is_in_td = (bitfield&0x2)!=0 # Is in Time/Darkness
+        self.ai_flag_1 = (bitfield&0x20)!=0 # Flag 1 for the AI?
+        self.ai_flag_2 = (bitfield&0x40)!=0 # Flag 2 for the AI?
+        self.ai_flag_3 = (bitfield&0x80)!=0 # Flag 3 for the AI?
+    
+    def to_bytes(self) -> bytes:
+        data = bytearray(ITEM_P_ENTRY_SIZE)
+        write_uintle(data, self.buy_price, 0, 2)
+        write_uintle(data, self.sell_price, 2, 2)
+        write_uintle(data, self.category, 4, 1)
+        write_uintle(data, self.sprite, 5, 1)
+        write_uintle(data, self.item_id, 6, 2)
+        write_uintle(data, self.move_id, 8, 2)
+        write_uintle(data, self.range_min, 10, 1)
+        write_uintle(data, self.range_max, 11, 1)
+        write_uintle(data, self.palette, 12, 1)
+        write_uintle(data, self.action_name, 13, 1)
+        bitfield = 0
+        if self.is_valid:
+            bitfield|=0x1
+        if self.is_in_td:
+            bitfield|=0x2
+        if self.ai_flag_1:
+            bitfield|=0x20
+        if self.ai_flag_2:
+            bitfield|=0x40
+        if self.ai_flag_3:
+            bitfield|=0x80
+        write_uintle(data, bitfield, 14, 1)
+        return bytes(data)
+    
+    def __eq__(self, other):
+        if not isinstance(other, ItemPEntry):
+            return False
+        return self.buy_price == other.buy_price and \
+               self.sell_price == other.sell_price and \
+               self.category == other.category and \
+               self.sprite == other.sprite and \
+               self.item_id == other.item_id and \
+               self.move_id == other.move_id and \
+               self.range_min == other.range_min and \
+               self.range_max == other.range_max and \
+               self.palette == other.palette and \
+               self.action_name == other.action_name and \
+               self.is_valid == other.is_valid and \
+               self.is_in_td == other.is_in_td and \
+               self.ai_flag_1 == other.ai_flag_1 and \
+               self.ai_flag_2 == other.ai_flag_2 and \
+               self.ai_flag_3 == other.ai_flag_3
+               
+        
+class ItemP(Sir0Serializable, AutoString):
+    def __init__(self, data: bytes, header_pointer: int):
+        if not isinstance(data, memoryview):
+            data = memoryview(data)
+        self.item_list = []
+        for x in range(0, len(data), ITEM_P_ENTRY_SIZE):
+            self.item_list.append(ItemPEntry(data[x:x+ITEM_P_ENTRY_SIZE]))
+
+    @classmethod
+    def sir0_unwrap(cls, content_data: bytes, data_pointer: int,
+                    static_data: Optional[Pmd2Data] = None) -> 'Sir0Serializable':
+        return cls(content_data, data_pointer)
+
+    def sir0_serialize_parts(self) -> Tuple[bytes, List[int], Optional[int]]:
+        from skytemple_files.data.item_p.writer import ItemPWriter
+        return ItemPWriter(self).write()
+
+    def __eq__(self, other):
+        if not isinstance(other, ItemP):
+            return False
+        return self.item_list == other.item_list
+
+    @staticmethod
+    def _decode_ints(data: bytes, pnt_start: int) -> List[int]:
+        return decode_sir0_pointer_offsets(data, pnt_start, False)

--- a/skytemple_files/data/item_p/writer.py
+++ b/skytemple_files/data/item_p/writer.py
@@ -1,0 +1,35 @@
+"""Converts ItemP models back into the binary format used by the game"""
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Optional, Dict
+
+from skytemple_files.common.util import *
+from skytemple_files.container.sir0.sir0_util import encode_sir0_pointer_offsets
+from skytemple_files.data.item_p.model import ItemP
+from skytemple_files.data.item_p import *
+
+class ItemPWriter:
+    def __init__(self, model: ItemP):
+        self.model = model
+
+    def write(self) -> Tuple[bytes, List[int], Optional[int]]:
+        pointer_offsets: List[int] = []
+        header_offset = 0
+        data = bytearray(0)
+        for i in self.model.item_list:
+            data += i.to_bytes()
+        return bytes(data), pointer_offsets, header_offset

--- a/skytemple_files/dungeon_data/mappa_bin/item_list.py
+++ b/skytemple_files/dungeon_data/mappa_bin/item_list.py
@@ -41,7 +41,7 @@ class MappaItemCategory(Enum):
     THROWN_PIERCE = 0, 1, 6, [], [9]
     THROWN_ROCK = 1, 7, 4, [9], []
     BERRIES_SEEDS_VITAMINS = 2, 69, 40, [], [116, 117, 118]
-    FOODS_GUMMIES = 3, 109, 29, [116, 117, 118], []
+    FOODS_GUMMIES = 3, 109, 30, [116, 117, 118], []
     HOLD = 4, 13, 56, [], []
     TMS = 5, 188, 105, [], []
     POKE = 6, 183, 1, [], []

--- a/skytemple_files/patch/handler/add_type.py
+++ b/skytemple_files/patch/handler/add_type.py
@@ -1,0 +1,181 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable, Dict, List, Set
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU, GAME_REGION_JP
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler
+from skytemple_files.data.str.handler import StrHandler
+from skytemple_files.patch.asm_tools import AsmFunction
+from skytemple_files.common.i18n_util import _
+
+PATCH_CHECK_ADDR_APPLIED_US = 0x2EAA4
+PATCH_CHECK_ADDR_APPLIED_EU = 0x2EBD8
+PATCH_CHECK_ADDR_APPLIED_JP = 0x2E97C
+PATCH_CHECK_INSTR_APPLIED = 0xE3A00024
+
+
+TYPE_TABLE_US = 0x8C30
+TYPE_TABLE_EU = 0x8C48
+TYPE_TABLE_JP = 0x8B78
+
+GUMMI_IQ_TABLE_US = 0xA22B0
+GUMMI_IQ_TABLE_EU = 0xA2834
+GUMMI_IQ_TABLE_JP = 0xA3684
+
+GUMMI_BELLY_TABLE_US = 0xA2538
+GUMMI_BELLY_TABLE_EU = 0xA2ABC
+GUMMI_BELLY_TABLE_JP = 0xA390C
+
+TABLE_LEN = 648
+
+NEW_TYPES = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 0, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 1, 1, 3, 2, 3, 2, 2, 2, 2, 2, 3, 1, 2, 1, 2, 3, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 3, 1, 1, 2, 2, 2, 2, 3, 2, 2, 2, 3, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 1, 3, 1, 2, 2, 2, 1, 3, 1, 2, 1, 3, 2, 1, 2, 1, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 2, 3, 1, 1, 2, 2, 2, 0, 3, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 1, 1, 3, 2, 1, 2, 2, 3, 3, 2, 2, 2, 2, 3, 2, 1, 2, 2, 2, 2, 2, 2, 2,
+             2, 3, 2, 2, 2, 2, 3, 2, 1, 2, 1, 1, 1, 3, 0, 2, 3, 3, 1, 2, 2, 2, 2, 2, 2,
+             2, 2, 2, 2, 3, 2, 2, 2, 1, 1, 2, 2, 2, 1, 1, 2, 2, 0, 3, 2, 2, 2, 2, 2, 2,
+             2, 2, 3, 2, 1, 3, 2, 2, 3, 2, 0, 2, 1, 3, 2, 2, 2, 3, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 2, 2, 3, 1, 2, 3, 2, 2, 2, 2, 3, 1, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 2, 2, 2, 2, 2, 3, 3, 2, 2, 1, 2, 2, 2, 2, 0, 1, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 1, 2, 3, 2, 2, 1, 1, 2, 1, 3, 2, 2, 1, 2, 3, 1, 1, 2, 2, 2, 2, 2, 2,
+             2, 2, 3, 2, 2, 2, 3, 1, 2, 1, 3, 2, 3, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2,
+             2, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 2, 2, 3, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 2, 1, 0, 2, 2, 2, 2, 2, 2,
+             2, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 3, 2, 2, 3, 2, 1, 2, 1, 2, 2, 2, 2, 2, 2,
+             2, 2, 1, 1, 2, 1, 3, 2, 2, 2, 2, 2, 2, 3, 2, 2, 2, 1, 3, 2, 2, 2, 2, 2, 2,
+             2, 2, 1, 2, 2, 2, 2, 3, 1, 2, 2, 2, 2, 2, 2, 3, 3, 1, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] # Leftovers
+
+NEW_IQ_GUMMI = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 5, 3, 3, 3, 3, 3, 4, 3, 3, 3, 3, 3, 3, 1, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0,
+                0, 3, 5, 4, 2, 3, 2, 3, 3, 4, 3, 3, 2, 4, 3, 3, 3, 2, 2, 0, 0, 0, 0, 0, 0,
+                0, 3, 2, 5, 4, 4, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 3, 0, 0, 0, 0, 0, 0,
+                0, 3, 4, 2, 5, 2, 4, 3, 4, 2, 4, 3, 4, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0,
+                0, 3, 3, 3, 3, 5, 3, 3, 3, 4, 2, 3, 3, 3, 3, 3, 3, 2, 3, 0, 0, 0, 0, 0, 0,
+                0, 3, 4, 3, 3, 3, 5, 4, 3, 3, 3, 3, 3, 4, 3, 3, 3, 4, 3, 0, 0, 0, 0, 0, 0,
+                0, 3, 3, 3, 3, 3, 3, 5, 3, 3, 4, 4, 2, 2, 3, 3, 2, 3, 4, 0, 0, 0, 0, 0, 0,
+                0, 3, 3, 3, 2, 3, 3, 2, 5, 4, 3, 4, 2, 3, 3, 3, 3, 3, 2, 0, 0, 0, 0, 0, 0,
+                0, 3, 3, 4, 4, 1, 4, 3, 2, 5, 3, 3, 3, 2, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0,
+                0, 3, 3, 3, 2, 4, 4, 2, 3, 1, 5, 3, 2, 4, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0,
+                0, 3, 3, 3, 3, 3, 3, 2, 3, 3, 3, 5, 4, 3, 4, 3, 4, 3, 3, 0, 0, 0, 0, 0, 0,
+                0, 3, 4, 3, 2, 3, 3, 2, 3, 2, 4, 3, 5, 4, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0,
+                0, 2, 2, 4, 4, 3, 3, 4, 2, 4, 2, 3, 3, 5, 3, 3, 3, 4, 3, 0, 0, 0, 0, 0, 0,
+                0, 1, 3, 3, 3, 3, 3, 1, 2, 3, 3, 3, 2, 3, 5, 3, 4, 3, 3, 0, 0, 0, 0, 0, 0,
+                0, 3, 2, 2, 2, 2, 4, 3, 3, 3, 3, 3, 3, 3, 3, 5, 3, 3, 4, 0, 0, 0, 0, 0, 0,
+                0, 3, 3, 3, 3, 3, 3, 4, 3, 3, 3, 1, 4, 3, 2, 3, 5, 3, 4, 0, 0, 0, 0, 0, 0,
+                0, 2, 4, 3, 2, 3, 2, 4, 1, 4, 2, 2, 2, 2, 3, 2, 3, 5, 2, 0, 0, 0, 0, 0, 0,
+                0, 3, 3, 3, 3, 3, 3, 2, 4, 3, 3, 3, 2, 3, 3, 1, 2, 4, 5, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+NEW_BELLY_GUMMI = [30 if x==5 else x*5 for x in NEW_IQ_GUMMI]
+
+TYPE_LIST = {"MESSAGE/text_e.str": "Fairy",
+             "MESSAGE/text_f.str": "Fée",
+             "MESSAGE/text_g.str": "Fee",
+             "MESSAGE/text_i.str": "Folletto",
+             "MESSAGE/text_s.str": "Hada",
+             "MESSAGE/text_j.str": "フェアリー"}
+
+class AddTypePatchHandler(AbstractPatchHandler):
+
+    @property
+    def name(self) -> str:
+        return 'AddTypes'
+
+    @property
+    def description(self) -> str:
+        return _('Add types to the type matchup table. This will replace the old matchup table by the 6th+ Gen type table, Fairy type being added to the end.')
+
+    @property
+    def author(self) -> str:
+        return 'irdkwia'
+
+    @property
+    def version(self) -> str:
+        return '0.0.1'
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_uintle(rom.loadArm9Overlays([29])[29].data, PATCH_CHECK_ADDR_APPLIED_US, 4)!=PATCH_CHECK_INSTR_APPLIED
+            if config.game_region == GAME_REGION_EU:
+                return read_uintle(rom.loadArm9Overlays([29])[29].data, PATCH_CHECK_ADDR_APPLIED_EU, 4)!=PATCH_CHECK_INSTR_APPLIED
+            if config.game_region == GAME_REGION_JP:
+                return read_uintle(rom.loadArm9Overlays([29])[29].data, PATCH_CHECK_ADDR_APPLIED_JP, 4)!=PATCH_CHECK_INSTR_APPLIED
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                type_table = TYPE_TABLE_US
+                gummi_iq_table = GUMMI_IQ_TABLE_US
+                gummi_belly_table = GUMMI_BELLY_TABLE_US
+            if config.game_region == GAME_REGION_EU:
+                type_table = TYPE_TABLE_EU
+                gummi_iq_table = GUMMI_IQ_TABLE_EU
+                gummi_belly_table = GUMMI_BELLY_TABLE_EU
+            if config.game_region == GAME_REGION_JP:
+                type_table = TYPE_TABLE_JP
+                gummi_iq_table = GUMMI_IQ_TABLE_JP
+                gummi_belly_table = GUMMI_BELLY_TABLE_JP
+        
+        bincfg = config.binaries['overlay/overlay_0010.bin']
+        data = bytearray(get_binary_from_rom_ppmdu(rom, bincfg))
+        data[type_table:type_table+TABLE_LEN] = bytearray(NEW_TYPES)
+        set_binary_in_rom_ppmdu(rom, bincfg, bytes(data))
+
+        # Change Fairy's type name
+        for filename in get_files_from_rom_with_extension(rom, 'str'):
+            bin_before = rom.getFileByName(filename)
+            strings = StrHandler.deserialize(bin_before)
+            block = config.string_index_data.string_blocks['Type Names']
+            strings.strings[block.begin+18] = TYPE_LIST[filename]
+            bin_after = StrHandler.serialize(strings)
+            rom.setFileByName(filename, bin_after)
+        
+        bincfg = config.binaries['arm9.bin']
+        data = bytearray(get_binary_from_rom_ppmdu(rom, bincfg))
+        data[gummi_iq_table:gummi_iq_table+TABLE_LEN] = bytearray(NEW_IQ_GUMMI)
+        data[gummi_belly_table:gummi_belly_table+TABLE_LEN] = bytearray(NEW_BELLY_GUMMI)
+        set_binary_in_rom_ppmdu(rom, bincfg, bytes(data))
+
+        try:
+            apply()
+        except RuntimeError as ex:
+            raise ex
+
+    
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/handler/extract_bar_list.py
+++ b/skytemple_files/patch/handler/extract_bar_list.py
@@ -1,0 +1,107 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable, Dict, List, Set
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU, GAME_REGION_JP
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler
+from skytemple_files.common.i18n_util import _
+
+PATCH_CHECK_ADDR_APPLIED_US = 0x0
+PATCH_CHECK_ADDR_APPLIED_EU = 0x0
+PATCH_CHECK_ADDR_APPLIED_JP = 0x0
+PATCH_CHECK_INSTR_APPLIED = 0xE92D4008
+
+BAR_LIST_US = 0x3A8C
+BAR_LIST_EU = 0x3A80
+BAR_LIST_JP = 0x3A84
+
+BAR_LIST_ENTRY_SIZE = 0x16
+BAR_LIST_SIZE = 0x5AC
+
+NB_ITEMS = 1400
+
+ITEM_LIST_PATH = "BALANCE/itembar.bin"
+
+
+class ExtractBarItemListPatchHandler(AbstractPatchHandler):
+
+    @property
+    def name(self) -> str:
+        return 'ExtractBarItemList'
+
+    @property
+    def description(self) -> str:
+        return _('Extracts Spinda bar\'s item list.')
+
+    @property
+    def author(self) -> str:
+        return 'irdkwia'
+
+    @property
+    def version(self) -> str:
+        return '0.0.1'
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_uintle(rom.loadArm9Overlays([19])[19].data, PATCH_CHECK_ADDR_APPLIED_US, 4)!=PATCH_CHECK_INSTR_APPLIED
+            if config.game_region == GAME_REGION_EU:
+                return read_uintle(rom.loadArm9Overlays([19])[19].data, PATCH_CHECK_ADDR_APPLIED_EU, 4)!=PATCH_CHECK_INSTR_APPLIED
+            if config.game_region == GAME_REGION_JP:
+                return read_uintle(rom.loadArm9Overlays([19])[19].data, PATCH_CHECK_ADDR_APPLIED_JP, 4)!=PATCH_CHECK_INSTR_APPLIED
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        if not self.is_applied(rom, config):
+            if config.game_version == GAME_VERSION_EOS:
+                if config.game_region == GAME_REGION_US:
+                    bar_list = BAR_LIST_US
+                if config.game_region == GAME_REGION_EU:
+                    bar_list = BAR_LIST_EU
+                if config.game_region == GAME_REGION_JP:
+                    bar_list = BAR_LIST_JP
+
+            data = rom.loadArm9Overlays([19])[19].data
+            
+            header = bytearray([0xFF]*(4+2*NB_ITEMS))
+            write_uintle(header, 4+2*NB_ITEMS, 0, 4)
+            list_data = []
+            for x in range(bar_list, bar_list+BAR_LIST_SIZE, BAR_LIST_ENTRY_SIZE):
+                item_id = read_uintle(data, x, 2)
+                cdata = bytes(data[x+2:x+BAR_LIST_ENTRY_SIZE])
+                if cdata in list_data:
+                    index = list_data.index(cdata)
+                else:
+                    index = len(list_data)
+                    list_data.append(cdata)
+                write_uintle(header, index, 4+2*item_id, 2)
+            file_data = header + b''.join(list_data)
+            if ITEM_LIST_PATH not in rom.filenames:
+                create_file_in_rom(rom, ITEM_LIST_PATH, file_data)
+            else:
+                rom.setFileByName(ITEM_LIST_PATH, file_data)
+        try:
+            apply()
+        except RuntimeError as ex:
+            raise ex
+
+    
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/handler/fairy_gummies.py
+++ b/skytemple_files/patch/handler/fairy_gummies.py
@@ -1,0 +1,184 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable, Dict, List, Set
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU, GAME_REGION_JP
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+from skytemple_files.patch.asm_tools import AsmFunction
+from skytemple_files.common.i18n_util import _
+from skytemple_files.data.item_p.handler import ItemPHandler
+from skytemple_files.data.data_st.handler import DataSTHandler
+from skytemple_files.data.data_cd.handler import DataCDHandler
+from skytemple_files.data.str.handler import StrHandler
+
+PATCH_CHECK_ADDR_APPLIED_US = 0xCBF8
+PATCH_CHECK_ADDR_APPLIED_EU = 0xCC80
+PATCH_CHECK_ADDR_APPLIED_JP = 0xCBF8
+PATCH_CHECK_INSTR_APPLIED = 0xB3A00000
+
+# Too lazy to put that in an actual file
+ITEM_EFFECT_US = b'\x08\x00\xa0\xe1\x010\xa0\xe3\x07\x10\xa0\xe1\x12 \xa0\xe3\x96\x04\x00\xeb*\x03\x00\xea'
+ITEM_EFFECT_EU = b'\x08\x00\xa0\xe1\x010\xa0\xe3\x07\x10\xa0\xe1\x12 \xa0\xe3\x98\x04\x00\xeb*\x03\x00\xea'
+ITEM_EFFECT_JP = None #TODO
+
+GUMMI_ITEM_ID = 138
+OTHER_GUMMI_ID = 136
+
+# TODO; support other languages
+NAME_LIST = {"MESSAGE/text_e.str": "Fairy Gummi",
+             "MESSAGE/text_f.str": "Gelée Féerique",
+             "MESSAGE/text_g.str": "Feegummi",
+             "MESSAGE/text_i.str": "Gommafolletto",
+             "MESSAGE/text_s.str": "Gomi Hada",
+             "MESSAGE/text_j.str": "---"}
+
+# TODO; support other languages
+SDES_LIST = {"MESSAGE/text_e.str": "Raises IQ.",
+             "MESSAGE/text_f.str": "Augmente le Q.I.",
+             "MESSAGE/text_g.str": "Erhöht den IQ.",
+             "MESSAGE/text_i.str": "Aumenta il QI.",
+             "MESSAGE/text_s.str": "Sube el CI.",
+             "MESSAGE/text_j.str": "---"}
+
+# TODO; support other languages
+LDES_LIST = {"MESSAGE/text_e.str": """A food item that permanently
+raises the [CS:E]IQ[CR] of a team member.
+Fairy-type Pokémon like it most.
+It also somewhat fills the Pokémon's
+[CS:E]Belly[CR].""",
+             "MESSAGE/text_f.str": """Aliment augmentant de façon
+permanente le [CS:E]Q.I.[CR] du Pokémon
+qui le mange. Plaît particulièrement
+aux Pokémon de type Fée.
+Remplit un peu l'[CS:E]Estomac[CR]
+du Pokémon.""",
+             "MESSAGE/text_g.str": """Nahrungsmittel, das den [CS:E]IQ[CR] eines
+Team-Mitglieds dauerhaft erhöht.
+Fee-Pokémon mögen es besonders.
+Füllt den [CS:E]Magen[CR] des
+Pokémon ein wenig.""",
+             "MESSAGE/text_i.str": """Un cibo che riempie un po' la [CS:E]pancia[CR] e fa
+crescere permanentemente il [CS:E]QI[CR] di un
+membro della squadra. È la preferita
+dei Pokémon di tipo Folletto.""",
+             "MESSAGE/text_s.str": """Alimento que eleva de manera
+permanente el [CS:E]CI[CR] del Pokémon.
+Los de tipo Hada las adoran.
+También llena ligeramente su
+[CS:E]Tripa[CR].""",
+             "MESSAGE/text_j.str": "---"}
+class ImplementFairyGummiesPatchHandler(AbstractPatchHandler, DependantPatch):
+
+    @property
+    def name(self) -> str:
+        return 'ImplementFairyGummies'
+
+    @property
+    def description(self) -> str:
+        return _("""Implements Fairy-type specialized gummies. Uses unused item 138.
+Needs ExtractItemCode, ExtractBarItemList and AddTypes patches to be applied for this patch to work.
+Also, you'll need to reapply this if you apply AddTypes again. """)
+
+    @property
+    def author(self) -> str:
+        return 'irdkwia'
+
+    @property
+    def version(self) -> str:
+        return '0.0.1'
+    
+    def depends_on(self) -> List[str]:
+        return ['ExtractItemCode', 'ExtractBarItemList', 'AddTypes']
+    
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_US, 4)!=PATCH_CHECK_INSTR_APPLIED
+            if config.game_region == GAME_REGION_EU:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_EU, 4)!=PATCH_CHECK_INSTR_APPLIED
+            if config.game_region == GAME_REGION_JP:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_JP, 4)!=PATCH_CHECK_INSTR_APPLIED
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                item_effect = ITEM_EFFECT_US
+            if config.game_region == GAME_REGION_EU:
+                item_effect = ITEM_EFFECT_EU
+            if config.game_region == GAME_REGION_JP:
+                item_effect = ITEM_EFFECT_JP
+
+        # Apply Gummi item properties
+        item_p_bin = rom.getFileByName('BALANCE/item_p.bin')
+        item_p_model = ItemPHandler.deserialize(item_p_bin)
+        gummi = item_p_model.item_list[GUMMI_ITEM_ID]
+        gummi.buy_price = 800
+        gummi.sell_price = 50
+        gummi.category = 3
+        gummi.sprite = 17
+        gummi.item_id = GUMMI_ITEM_ID
+        gummi.move_id = 0
+        gummi.range_min = 0
+        gummi.range_max = 0
+        gummi.palette = 14
+        gummi.action_name = 4
+        gummi.is_valid = True
+        gummi.is_in_td = False
+        gummi.ai_flag_1 = False
+        gummi.ai_flag_2 = True
+        gummi.ai_flag_3 = False
+        rom.setFileByName('BALANCE/item_p.bin', ItemPHandler.serialize(item_p_model))
+        
+        # Apply Gummi item dungeon effect
+        item_cd_bin = rom.getFileByName('BALANCE/item_cd.bin')
+        item_cd_model = DataCDHandler.deserialize(item_cd_bin)
+        effect_id = item_cd_model.nb_effects()
+        item_cd_model.add_effect_code(item_effect)
+        item_cd_model.set_item_effect_id(GUMMI_ITEM_ID, effect_id)
+        rom.setFileByName('BALANCE/item_cd.bin', DataCDHandler.serialize(item_cd_model))
+        
+        # Change item's text attributes
+        for filename in get_files_from_rom_with_extension(rom, 'str'):
+            bin_before = rom.getFileByName(filename)
+            strings = StrHandler.deserialize(bin_before)
+            block = config.string_index_data.string_blocks['Item Names']
+            strings.strings[block.begin+GUMMI_ITEM_ID] = NAME_LIST[filename]
+            block = config.string_index_data.string_blocks['Item Short Descriptions']
+            strings.strings[block.begin+GUMMI_ITEM_ID] = SDES_LIST[filename]
+            block = config.string_index_data.string_blocks['Item Long Descriptions']
+            strings.strings[block.begin+GUMMI_ITEM_ID] = LDES_LIST[filename]
+            bin_after = StrHandler.serialize(strings)
+            rom.setFileByName(filename, bin_after)
+        
+        bar_bin = rom.getFileByName('BALANCE/itembar.bin')
+        bar_model = DataSTHandler.deserialize(bar_bin)
+        gummi_id = bar_model.get_item_struct_id(OTHER_GUMMI_ID)
+        bar_model.set_item_struct_id(GUMMI_ITEM_ID, gummi_id)
+        rom.setFileByName('BALANCE/itembar.bin', DataSTHandler.serialize(bar_model))
+
+        try:
+            apply()
+        except RuntimeError as ex:
+            raise ex
+
+    
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -41,6 +41,9 @@ from skytemple_files.patch.handler.support_atupx import AtupxSupportPatchHandler
 from skytemple_files.patch.handler.extract_item_lists import ExtractItemListsPatchHandler
 from skytemple_files.patch.handler.extract_dungeon_data import ExtractDungeonDataPatchHandler
 from skytemple_files.patch.handler.fix_evolution import FixEvolutionPatchHandler
+from skytemple_files.patch.handler.add_type import AddTypePatchHandler
+from skytemple_files.patch.handler.fairy_gummies import ImplementFairyGummiesPatchHandler
+from skytemple_files.patch.handler.extract_bar_list import ExtractBarItemListPatchHandler
 from skytemple_files.patch.handler.exp_share import ExpSharePatchHandler
 from skytemple_files.patch.handler.complete_team_control import CompleteTeamControl
 from skytemple_files.patch.handler.far_off_pal_overdrive import FarOffPalOverdrive
@@ -71,6 +74,9 @@ class PatchType(Enum):
     EXTRA_SPACE = ExtraSpacePatch
     EXTRACT_MOVE_CODE = ExtractMoveCodePatchHandler
     EXTRACT_ITEM_CODE = ExtractItemCodePatchHandler
+    ADD_TYPES = AddTypePatchHandler
+    IMPLEMENT_FAIRY_GUMMIES = ImplementFairyGummiesPatchHandler
+    EXTRACT_BAR_LIST = ExtractBarItemListPatchHandler
 
 
 class PatchPackageError(RuntimeError):


### PR DESCRIPTION
Add patches to implement the Fairy type: 
- A patch to change the type match-up table implementation and add Fairy type as the "Neutral" (this replaces the old table with the 6th+ gens table) and all tables related to Gummi effects by type (IQ boosts/Belly recover).
- A patch to transform unused item 138 into a Fairy-type Gummi.

To create those patches, some new files have been created: 
- Handler/Model/Writer for file "BALANCE/item_p.bin".
- A patch to extract Spinda bar's item list.
- Handler/Model/Writer for file "BALANCE/itembar.bin" (the file created by the patch mentioned in the previous point).