### PR TITLE
complete team control update to 1.2.1

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsEU.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsEU.asm
@@ -4,12 +4,14 @@ ov_36 equ 023A7080h	;CHANGE THIS IF END45'S OVERLAY IS CHANGED
 ov_29 equ 022DCB80h
 .definelabel NA_022EB408, 022EBDB8h	;Function - team submenu option recorder
 .definelabel NA_022EBD10, 022EC6C0h	;Operation - the round function's third operation
+.definelabel NA_022EBD50, 022EC700h	;Operation - calls the function which lowers the gusting wind counter
 .definelabel NA_022EBD78, 022EC728h	;Operation - the moment the turns of partners start in the round function
 .definelabel NA_022EC094, 022ECA44h	;Operation - the moment the turns of enemies start
 .definelabel NA_022EC350, 022ECD00h	;Operation - the end of the leader's turn verification algorithm
 .definelabel NA_022EC488, 022ECE38h	;Operation - the jump to the function which executes the leader's action
 .definelabel NA_022EC4C0, 022ECE70h	;Operation - leader's wait bit setter
 .definelabel NA_022EC5F0, 022ECFA0h	;Operation - resets the round counter when you get a speed boost
+.definelabel NA_022ECB48, 022ED4F8h	;Function - lowers the gusting wind counter
 .definelabel NA_022F1178, 022F1B2Ch	;Operation - partner direction setter 1
 .definelabel NA_022F1EE0, 022F2894h	;Operation - checks if you're holding Y or start on your turn
 .definelabel NA_022F488C, 022F5248h	;Operation - skips partner's turn when it gets an item

--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsUS.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsUS.asm
@@ -4,12 +4,14 @@ ov_36 equ 023A7080h	;CHANGE THIS IF END45'S OVERLAY IS CHANGED
 ov_29 equ 022DC240h
 .definelabel NA_022EB408, 022EB408h	;Function - team submenu option recorder
 .definelabel NA_022EBD10, 022EBD10h	;Operation - the round function's third operation
+.definelabel NA_022EBD50, 022EBD50h	;Operation - calls the function which lowers the gusting wind counter
 .definelabel NA_022EBD78, 022EBD78h	;Operation - the moment the turns of partners start in the round function
 .definelabel NA_022EC094, 022EC094h	;Operation - the moment the turns of enemies start
 .definelabel NA_022EC350, 022EC350h	;Operation - the end of the leader's turn verification algorithm
 .definelabel NA_022EC488, 022EC488h	;Operation - the jump to the function which executes the leader's action
 .definelabel NA_022EC4C0, 022EC4C0h	;Operation - leader's wait bit setter
 .definelabel NA_022EC5F0, 022EC5F0h	;Operation - resets the round counter when you get a speed boost
+.definelabel NA_022ECB48, 022ED4F8h	;Function - lowers the gusting wind counter
 .definelabel NA_022F1178, 022F1178h	;Operation - partner direction setter 1
 .definelabel NA_022F1EE0, 022F1EE0h	;Operation - checks if you're holding Y or start on your turn
 .definelabel NA_022F488C, 022F488Ch	;Operation - skips partner's turn when it gets an item

--- a/skytemple_files/patch/handler/complete_team_control.py
+++ b/skytemple_files/patch/handler/complete_team_control.py
@@ -78,7 +78,7 @@ class CompleteTeamControl(AbstractPatchHandler, DependantPatch):
 
     @property
     def version(self) -> str:
-        return '1.2'
+        return '1.2.1'
 
     def depends_on(self) -> List[str]:
         return ['ExtraSpace']


### PR DESCRIPTION
Bugfix: the gusting wind counter would lower whenever you moved a partner in manual mode. Fixed it so it only lowers once per round as it's supposed to. Thanks to End and FireFox6 for finding it.
Also @End45 - the hack takes 0x420 bytes in the extra overlay now I swear I didn't make a weed joke on purpose