### PR TITLE
updated CTC to 1.2.2

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsEU.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsEU.asm
@@ -21,6 +21,7 @@ ov_29 equ 022DCB80h
 .definelabel NA_022FE4BC, 022FEEDCh	;Function - executes the leader's action
 .definelabel NA_022FFF4C, 02300978h	;Function - used in turn verification algorithm
 .definelabel NA_02301D10, 0230273Ch	;Function - Checks a specific property of a pokemon, sometimes r12 is equal to this
+.definelabel NA_023023AC, 02302DD8h ;Operation - part which checks whether or not to display a pokemon's moves
 .definelabel NA_02304FE0, 02305A0Ch	;Function - executes all moves in the movement buffer simultaneously
 .definelabel NA_0230506C, 02305A98h	;Operation - partner direction setter 2
 .definelabel NA_02305160, 02305B8Ch	;Operation - some line at the end of the partner direction setter

--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsEU.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsEU.asm
@@ -21,7 +21,7 @@ ov_29 equ 022DCB80h
 .definelabel NA_022FE4BC, 022FEEDCh	;Function - executes the leader's action
 .definelabel NA_022FFF4C, 02300978h	;Function - used in turn verification algorithm
 .definelabel NA_02301D10, 0230273Ch	;Function - Checks a specific property of a pokemon, sometimes r12 is equal to this
-.definelabel NA_023023AC, 02302DD8h ;Operation - part which checks whether or not to display a pokemon's moves
+.definelabel NA_023023AC, 02302DD8h ;Operation - part which checks whether or not to display a pokemon's moves 
 .definelabel NA_02304FE0, 02305A0Ch	;Function - executes all moves in the movement buffer simultaneously
 .definelabel NA_0230506C, 02305A98h	;Operation - partner direction setter 2
 .definelabel NA_02305160, 02305B8Ch	;Operation - some line at the end of the partner direction setter

--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsUS.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsUS.asm
@@ -21,6 +21,7 @@ ov_29 equ 022DC240h
 .definelabel NA_022FE4BC, 022FE4BCh	;Function - executes the leader's action
 .definelabel NA_022FFF4C, 022FFF4Ch	;Function - used in turn verification algorithm
 .definelabel NA_02301D10, 02301D10h	;Function - Checks a specific property of a pokemon, sometimes r12 is equal to this
+.definelabel NA_023023AC, 023023ACh ;Operation - part which checks whether or not to display a pokemon's moves
 .definelabel NA_02304FE0, 02304FE0h	;Function - executes all moves in the movement buffer simultaneously
 .definelabel NA_0230506C, 0230506Ch	;Operation - partner direction setter 2
 .definelabel NA_02305160, 02305160h	;Operation - some line at the end of the partner direction setter

--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/completeteamcontrol.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/completeteamcontrol.asm
@@ -1,4 +1,4 @@
-; PMD EOS - Complete Team Control Code v1.2.1
+; PMD EOS - Complete Team Control Code v1.2.2
 ; Made by Cipnit
 ; https://www.pokecommunity.com/showthread.php?t=437108
 ; Build this file using armips: https://github.com/Kingcom/armips
@@ -51,7 +51,13 @@
 .org NA_022EBD50	;Spot where the game originally calls a function which decreases the gusting wind counter.
 	bl @RoundCounterCounter	;original: bl NA_022ECB48
 
+.org NA_023023AC	;Spot where the game checks if you have a temporary party member - in the original game, you're not allowed to see a temporary party member's moves, but with team control, it's possible to see them while you're controling them - however, bugs would occur if you looked at their info. This fixes it so temp party members are treated like regular party members when it comes to moves.
+	nop
+	mov r0,1h
+	pop r4,r15
+
 .close
+
 
 .open "overlay_0031.bin", ov_31
 .org NA_02387530	;Jump to team submenu function

--- a/skytemple_files/patch/handler/complete_team_control.py
+++ b/skytemple_files/patch/handler/complete_team_control.py
@@ -78,7 +78,7 @@ class CompleteTeamControl(AbstractPatchHandler, DependantPatch):
 
     @property
     def version(self) -> str:
-        return '1.2.1'
+        return '1.2.2'
 
     def depends_on(self) -> List[str]:
         return ['ExtraSpace']


### PR DESCRIPTION
Fixed a bug with looking at a temporary party member's moves. You can now look at a temporary party member's moves as if it was a permanent party member. 