### PR TITLE
CTC updated to 1.2.3

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsEU.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsEU.asm
@@ -21,7 +21,7 @@ ov_29 equ 022DCB80h
 .definelabel NA_022FE4BC, 022FEEDCh	;Function - executes the leader's action
 .definelabel NA_022FFF4C, 02300978h	;Function - used in turn verification algorithm
 .definelabel NA_02301D10, 0230273Ch	;Function - Checks a specific property of a pokemon, sometimes r12 is equal to this
-.definelabel NA_023023AC, 02302DD8h ;Operation - part which checks whether or not to display a pokemon's moves 
+.definelabel NA_023023AC, 02302DD8h	;Operation - part which checks whether or not to display a pokemon's moves
 .definelabel NA_02304FE0, 02305A0Ch	;Function - executes all moves in the movement buffer simultaneously
 .definelabel NA_0230506C, 02305A98h	;Operation - partner direction setter 2
 .definelabel NA_02305160, 02305B8Ch	;Operation - some line at the end of the partner direction setter
@@ -32,3 +32,4 @@ ov_29 equ 022DCB80h
 .definelabel NA_0235355C, 0235415Ch	;Variable - points to the current team leader
 ov_31 equ 02383420h
 .definelabel NA_02387530, 02388154h	;Operation - jump to team submenu option recorder
+.definelabel NA_023888A4, 023894C8h	;Operation - checks which option you selected in the rest menu

--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsUS.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsUS.asm
@@ -21,7 +21,7 @@ ov_29 equ 022DC240h
 .definelabel NA_022FE4BC, 022FE4BCh	;Function - executes the leader's action
 .definelabel NA_022FFF4C, 022FFF4Ch	;Function - used in turn verification algorithm
 .definelabel NA_02301D10, 02301D10h	;Function - Checks a specific property of a pokemon, sometimes r12 is equal to this
-.definelabel NA_023023AC, 023023ACh ;Operation - part which checks whether or not to display a pokemon's moves
+.definelabel NA_023023AC, 023023ACh	;Operation - part which checks whether or not to display a pokemon's moves
 .definelabel NA_02304FE0, 02304FE0h	;Function - executes all moves in the movement buffer simultaneously
 .definelabel NA_0230506C, 0230506Ch	;Operation - partner direction setter 2
 .definelabel NA_02305160, 02305160h	;Operation - some line at the end of the partner direction setter
@@ -32,3 +32,4 @@ ov_29 equ 022DC240h
 .definelabel NA_0235355C, 0235355Ch	;Variable - points to the current team leader
 ov_31 equ 02382820h
 .definelabel NA_02387530, 02387530h	;Operation - jump to team submenu option recorder
+.definelabel NA_023888A4, 023888A4h	;Operation - checks which option you selected in the rest menu

--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/completeteamcontrol.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/completeteamcontrol.asm
@@ -1,8 +1,8 @@
-; PMD EOS - Complete Team Control Code v1.2.2
+; PMD EOS - Complete Team Control Code v1.2.3
 ; Made by Cipnit
 ; https://www.pokecommunity.com/showthread.php?t=437108
 ; Build this file using armips: https://github.com/Kingcom/armips
-; Amount of space needed in the custom overlay: 420h bytes
+; Amount of space needed in the custom overlay: 470h bytes
 
 .nds
 .include "common/regionSelect.asm"
@@ -62,12 +62,14 @@
 .open "overlay_0031.bin", ov_31
 .org NA_02387530	;Jump to team submenu function
 	bl @paranoia_agent	;original: bl NA_022EB408
+.org NA_023888A4	;The part of the Rest menu function which checks what option you selected
+	bl @paranoia_agent_two	;original: ldr r0,[r1,8h]
 .close
 
 
 .open "overlay_0036.bin", ov_36
 .orga 0x10
-.area 430h -10h
+.area 480h -10h
 
 @ManualModeOn:
 	.byte 0h
@@ -190,6 +192,30 @@
 @@paranoiaagent_nvm:
 	pop r0
 	bl NA_022EB408	;this records the player's decision in the team submenu
+	pop r15
+.pool
+
+@paranoia_agent_two:	;Prevents the player from quicksaving while controling another partner in manual mode
+	push r14
+	ldr r0,[r1,8h]
+	cmp r0,1h
+	popne r15
+	ldr r0,=@ManualModeOn
+	ldrb r0,[r0]
+	cmp r0,1h
+	bne @paranoiaover
+	ldr r0,=NA_02353538
+	ldr r0,[r0]
+	add r0,r0,12000h
+	ldr r0,[r0,0B28h]
+	ldr r0,[r0,0B4h]
+	ldrb r0,[r0,7h]
+	cmp r0,1h
+	beq @paranoiaover
+	mov r0,0h
+	pop r15
+@paranoiaover:
+	ldr r0,[r1,8h]
 	pop r15
 .pool
 

--- a/skytemple_files/patch/handler/complete_team_control.py
+++ b/skytemple_files/patch/handler/complete_team_control.py
@@ -78,7 +78,7 @@ class CompleteTeamControl(AbstractPatchHandler, DependantPatch):
 
     @property
     def version(self) -> str:
-        return '1.2.2'
+        return '1.2.3'
 
     def depends_on(self) -> List[str]:
         return ['ExtraSpace']


### PR DESCRIPTION
This prevents players from selecting the quicksave option in the rest menu while they're controlling a partner, to prevent bugs. I can't believe I created CTC two years ago and didn't think about this until now.
@End45 the hack now needs 470h bytes