### PR TITLE
Add a patch to not entirely load the waza_p file in RAM

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/fs_waza_p/common/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/fs_waza_p/common/patch.asm
@@ -145,14 +145,11 @@ TrueOpenWaza:
 	mov r4,r0
 	mov r5,r1
 	mov r6,r2
-	;ldr r1,=string
-	;ldr r2,=0x020AF364
-	;ldr r2,[r2]
-	;bl 0x0200C240
 	ldr r0,=ReadMoveBuffer
-	ldrh r0,[r0]
+	ldrh r0,[r1]
 	cmp r4,r0
 	beq no_read_move
+	strh r4,[r1]
 	bl FStreamAlloc
 	ldr r3,=CurrentWazaInfo
 	ldr r1,=WazaFileInfo
@@ -197,10 +194,6 @@ actual_data:
 	stmdb  r13!,{r4,r5,r6,r14}
 	mov r4,r0
 	mov r5,r1
-	;ldr r1,=string
-	;ldr r2,=0x020AF364
-	;ldr r2,[r2]
-	;bl 0x0200C240
 	bl FStreamAlloc
 	ldr r3,=CurrentWazaInfo
 	ldr r1,=WazaFileInfo

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/fs_waza_p/common/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/fs_waza_p/common/patch.asm
@@ -1,0 +1,628 @@
+; For use with ARMIPS
+; 2021/04/07
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Use filestreams to access waza_p/waza_p2 instead of loading it entirely
+; Useless in itself
+; ------------------------------------------------------------------------------
+
+; ///////////////////////////////////////////////////// WazaP load functions
+
+
+.org UnloadCurrentWazaP
+.area 0x40
+	b TrueUnloadCurrentWazaP
+	.fill 0x3C, 0xCC
+.endarea
+
+.org LoadWazaP
+.area 0x28
+	stmdb  r13!,{r3,r14}
+	ldr r1,=CurrentWazaInfo
+	mov  r0,#0x0
+	str r0,[r1, #+0x4]
+	bl OpenWaza
+	ldr r0,=CurrentWazaInfo
+	ldr r0,[r0, #+0x4]
+	bl SelectWaza
+	ldmia  r13!,{r3,r15}
+	.pool
+.endarea
+
+.org LoadWazaP2
+.area 0x28
+	stmdb  r13!,{r3,r14}
+	ldr r1,=CurrentWazaInfo
+	mov  r0,#0x1
+	str r0,[r1, #+0x4]
+	bl OpenWaza
+	ldr r0,=CurrentWazaInfo
+	ldr r0,[r0, #+0x4]
+	bl SelectWaza
+	ldmia  r13!,{r3,r15}
+	.pool
+.endarea
+
+
+; TODO: Change Position
+.org OpenWaza
+.area 0x68
+	b TrueOpenWaza
+string:
+	.ascii "TransferMode: %08X"
+	dcb 0
+	.fill 0x40, 0xCC
+.endarea
+
+.org SelectWaza
+.area 0x2C
+	ldr r1,=MoveInfoTableAddr
+	ldr r2,=MovesetTableAddr
+	ldr r3,[r1,+r0, lsl #0x2]
+	ldr r1,=CurrentWazaInfo
+	ldr r0,[r2,+r0, lsl #0x2]
+	str r3,[r1, #+0x8]
+	str r0,[r1, #+0x0]
+	bx r14
+	.pool
+.endarea
+
+
+; ///////////////////////////////////////////////////// WazaP read functions
+
+.org TrueUnloadCurrentWazaP
+.area 0x140
+	stmdb  r13!,{r4,r14}
+	bl FStreamAlloc
+	ldr r0,=CurrentWazaInfo
+	ldr r1,=WazaFileInfo
+	ldr r0,[r0, #+0x4]
+	add  r4,r1,r0,lsl #0x3
+	mov  r0,r4
+	bl FStreamClose
+	bl FStreamDealloc
+	mov  r0,r4
+	bl MemFree
+	mov  r0,r4
+	bl FillWithZeros8Bytes
+	ldr r1,=CurrentWazaInfo
+	mov  r0,#0x0
+	str r0,[r1, #+0x4]
+	bl SelectWaza
+	ldmia  r13!,{r4,r15}
+	.pool
+TrueOpenWaza:
+	stmdb  r13!,{r3,r4,r5,r14}
+	sub  r13,r13,#0x4
+	mov  r4,r0
+	mov  r0,#0x48 ;TODO: Change if we need more size
+	mov  r1,#0x0
+	bl MemAlloc
+	ldr r1,=WazaFileInfo
+	mov r5,r0
+	str r5,[r1,+r4, lsl #0x3]
+	
+	bl FStreamAlloc
+	mov r0,r5
+	bl FStreamCtor
+	mov r0,r5
+	ldr r1,=WazaFileNamesPtr
+	ldr r1,[r1,+r4, lsl #0x2]
+	add r1,r1,#6
+	bl FStreamFOpen
+	mov r0,r5
+	mov r1,#4
+	mov r2,#0
+	bl FStreamSeek
+	mov r0,r5
+	mov r1,r13
+	mov r2,#4
+	bl FStreamRead
+	mov r0,r5
+	ldr r1,[r13]
+	mov r2,#0
+	bl FStreamSeek
+	
+	ldr r1,=MoveInfoTableAddr
+	mov r0,r5
+	add r1,r1,r4,lsl #0x2
+	mov r2,#4
+	bl FStreamRead
+	ldr r1,=MovesetTableAddr
+	mov r0,r5
+	add r1,r1,r4,lsl #0x2
+	mov r2,#4
+	bl FStreamRead
+	bl FStreamDealloc
+	add  r13,r13,#0x4
+	ldmia  r13!,{r3,r4,r5,r15}
+	.pool
+	.fill (TrueUnloadCurrentWazaP+0x140-.), 0xCC
+.endarea
+.org ReadMoveValue
+.area 0xA0
+	stmdb  r13!,{r4,r5,r6,r7,r14}
+	mov r4,r0
+	mov r5,r1
+	mov r6,r2
+	;ldr r1,=string
+	;ldr r2,=0x020AF364
+	;ldr r2,[r2]
+	;bl 0x0200C240
+	ldr r0,=ReadMoveBuffer
+	ldrh r0,[r0]
+	cmp r4,r0
+	beq no_read_move
+	bl FStreamAlloc
+	ldr r3,=CurrentWazaInfo
+	ldr r1,=WazaFileInfo
+	ldr r2,[r3, #+0x4]
+	ldr r7,[r1,+r2, lsl #0x3]
+	ldr r3,[r3, #+0x8] ;r3 contains the start table address
+	mov  r0,#0x1A
+	mla  r1,r4,r0,r3 ;r1 contains the move offset
+	mov r0,r7
+	mov r2,#0
+	bl FStreamSeek
+	mov r0,r7
+	ldr r1,=actual_data
+	mov r2,#0x1A
+	bl FStreamRead
+	bl FStreamDealloc
+no_read_move:
+	ldr r1,=actual_data
+	cmp r6,#0
+	moveq r0,r1
+	beq end_read
+	cmp r6,#1
+	ldreqb r0,[r1,r5]
+	beq end_read
+	ldrsh r0,[r1,r5]
+end_read:
+	ldmia  r13!,{r4,r5,r6,r7,r15}
+	.pool
+	.fill (ReadMoveValue+0xA0-.), 0xCC
+.endarea
+
+.org ReadMoveBuffer
+.area 0x1C
+	.fill 0x2, 0xFF
+actual_data:
+	.fill 0x1A, 0x0
+.endarea
+
+; r0: result = ReadMoveset(r0: pkmn_id, r1: moveset_id)
+.org ReadMoveset
+.area 0xA0
+	stmdb  r13!,{r4,r5,r6,r14}
+	mov r4,r0
+	mov r5,r1
+	;ldr r1,=string
+	;ldr r2,=0x020AF364
+	;ldr r2,[r2]
+	;bl 0x0200C240
+	bl FStreamAlloc
+	ldr r3,=CurrentWazaInfo
+	ldr r1,=WazaFileInfo
+	ldr r2,[r3, #+0x4]
+	ldr r6,[r1,+r2, lsl #0x3]
+	ldr r3,[r3, #+0x0] ;r3 contains the start table address
+	mov  r0,#0xC
+	mla  r1,r4,r0,r3 ;r1 contains the move offset
+	add r1,r1,r5,lsl #0x2
+	mov r0,r6
+	mov r2,#0
+	bl FStreamSeek
+	mov r0,r6
+	ldr r1,=ReadMovesetBuffer
+	mov r2,#0x4
+	bl FStreamRead
+	mov r0,r6
+	ldr r1,[ReadMovesetBuffer]
+	mov r2,#0
+	bl FStreamSeek
+	mov r0,r6
+	ldr r1,=ReadMovesetBuffer
+	mov r2,#0x800
+	bl FStreamRead
+	bl FStreamDealloc
+	ldr r0,=ReadMovesetBuffer
+	ldmia  r13!,{r4,r5,r6,r15}
+	.pool
+	.fill (ReadMoveset+0xA0-.), 0xCC
+.endarea
+
+.org ReadMovesetBuffer
+.area 0x800
+	.fill 0x800, 0x0
+.endarea
+
+; ///////////////////////////////////////////////////// WazaP access functions
+
+
+
+.org GetMoveFlags
+.area 0x24
+	stmdb  r13!,{r14}
+	ldrh r0,[r0, #+0x4]
+	mov  r1,r1,lsl #0x1
+	add  r1,r1,#4
+	mov  r2,#2
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org GetMoveType
+.area 0x20
+	stmdb  r13!,{r14}
+	ldrh r0,[r0, #+0x4]
+	mov  r1,#2
+	mov  r2,#1
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org GetMovesetLevelUpPtr
+.area 0x48
+	stmdb  r13!,{r4,r14}
+	mov  r4,r0
+	cmp r4,#0x258
+	subge  r0,r4,#0x258
+	movge  r0,r0,lsl #0x10
+	movge  r4,r0,asr #0x10
+	mov  r0,r4
+	bl IsInvalidMoveset
+	cmp r0,#0x0
+	ldrne r0,=NullMoveset
+	mov r0,r4
+	mov r1,#0
+	bl ReadMoveset
+	ldmia  r13!,{r4,r15}
+	.pool
+.endarea
+
+.org IsInvalidMoveset
+.area 0x28
+	cmp r0,#0x0
+	ble below_lower_bound
+	ldr r1,=0x00000229
+	cmp r0,r1
+	blt below_upper_bound
+below_lower_bound:
+	mov  r0,#0x1
+	bx r14
+below_upper_bound:
+	mov  r0,#0x0
+	bx r14
+	.pool
+.endarea
+
+.org GetMovesetHMTMPtr
+.area 0x4C
+	stmdb  r13!,{r4,r14}
+	mov  r4,r0
+	cmp r4,#0x258
+	subge  r0,r4,#0x258
+	movge  r0,r0,lsl #0x10
+	movge  r4,r0,asr #0x10
+	mov  r0,r4
+	bl IsInvalidMoveset
+	cmp r0,#0x0
+	ldrne r0,=NullMoveset
+	ldmneia  r13!,{r4,r15}
+	mov r0,r4
+	mov r1,#1
+	bl ReadMoveset
+	ldmia  r13!,{r4,r15}
+	.pool
+.endarea
+
+.org GetMovesetEggPtr
+.area 0x4C
+	stmdb  r13!,{r4,r14}
+	mov  r4,r0
+	cmp r4,#0x258
+	subge  r0,r4,#0x258
+	movge  r0,r0,lsl #0x10
+	movge  r4,r0,asr #0x10
+	mov  r0,r4
+	bl IsInvalidMoveset
+	cmp r0,#0x0
+	ldrne r0,=NullMoveset
+	ldmneia  r13!,{r4,r15}
+	mov r0,r4
+	mov r1,#2
+	bl ReadMoveset
+	ldmia  r13!,{r4,r15}
+	.pool
+.endarea
+
+.org GetMoveUnk09
+.area 0x20
+	stmdb  r13!,{r14}
+	ldrh r0,[r0, #+0x4]
+	mov  r1,#0x9
+	mov  r2,#1
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org GetMoveNbHits
+.area 0x20
+	stmdb  r13!,{r14}
+	ldrh r0,[r0, #+0x4]
+	mov  r1,#0xD
+	mov  r2,#1
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org GetMoveBasePower
+.area 0x20
+	stmdb  r13!,{r14}
+	ldrh r0,[r0, #+0x4]
+	mov  r1,#0x0
+	mov  r2,#2
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org GetMoveBasePowerOverworld
+.area 0x20
+	stmdb  r13!,{r14}
+	ldrh r0,[r0, #+0x2]
+	mov  r1,#0x0
+	mov  r2,#2
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org GetMoveAccuracy
+.area 0x24
+	stmdb  r13!,{r14}
+	ldrh r0,[r0, #+0x4]
+	add  r1,r1,#0xA
+	mov  r2,#1
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org GetMoveBasePP
+.area 0x20
+	stmdb  r13!,{r14}
+	ldrh r0,[r0, #+0x4]
+	mov  r1,#0x8
+	mov  r2,#1
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org GetMovePPWithBonus
+.area 0x80
+	stmdb  r13!,{r4,r14}
+	mov r4,r0
+	ldrh r0,[r0, #+0x4]
+	mov  r1,#0x8
+	mov  r2,#1
+	bl ReadMoveValue
+	ldrh r2,[r4, #+0x2]
+	tst r2,#0x100
+	ldrne r1,=IQSkillPPUp
+	ldrnesh r1,[r1, #+0x0]
+	addne  r0,r0,r1
+	movne  r0,r0,lsl #0x10
+	movne  r0,r0,asr #0x10
+	tst r2,#0x200
+	ldrne r1,=ExclusiveItemPPUp2
+	ldrnesh r1,[r1, #+0x0]
+	addne  r0,r0,r1
+	movne  r0,r0,lsl #0x10
+	movne  r0,r0,asr #0x10
+	tst r2,#0x400
+	ldrne r1,=ExclusiveItemPPUp4
+	ldrnesh r1,[r1, #+0x0]
+	addne  r0,r0,r1
+	movne  r0,r0,lsl #0x10
+	movne  r0,r0,asr #0x10
+	cmp r0,#0x63
+	movgt  r0,#0x63
+	ldmia  r13!,{r4,r15}
+	.pool
+.endarea
+
+.org GetMoveMaxGinsengBoost
+.area 0x20
+	stmdb  r13!,{r14}
+	ldrh r0,[r0, #+0x4]
+	mov  r1,#0xE
+	mov  r2,#1
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org GetMoveMaxGinsengBoostOverworld
+.area 0x20
+	stmdb  r13!,{r14}
+	ldrh r0,[r0, #+0x2]
+	mov  r1,#0xE
+	mov  r2,#1
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org GetMoveCriticalRate
+.area 0x20
+	stmdb  r13!,{r14}
+	ldrh r0,[r0, #+0x4]
+	mov  r1,#0xF
+	mov  r2,#1
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org IsIceBreaker
+.area 0x20
+	stmdb  r13!,{r14}
+	ldrh r0,[r0, #+0x4]
+	mov  r1,#0x13
+	mov  r2,#1
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org IsAffectedByTaunt
+.area 0x20
+	stmdb  r13!,{r14}
+	ldrh r0,[r0, #+0x4]
+	mov  r1,#0x14
+	mov  r2,#1
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org GetMoveRangeID
+.area 0x20
+	stmdb  r13!,{r14}
+	ldrh r0,[r0, #+0x4]
+	mov  r1,#0x15
+	mov  r2,#1
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org GetMoveActualAccuracy
+.area 0x58
+	stmdb  r13!,{r3,r14}
+	mov  r1,#0
+	mov  r2,#0
+	bl ReadMoveValue
+	mov r1,r0
+	ldrb r0,[r1, #+0xe]
+	cmp r0,#0x0
+	ldreqb r0,[r1, #+0xa]
+	ldmeqia  r13!,{r3,r15}
+	cmp r0,#0x63
+	bne status_move
+	ldrb r2,[r1, #+0xa]
+	ldrb r0,[r1, #+0xb]
+	cmp r2,#0x7D
+	ldmeqia  r13!,{r3,r15}
+	mul  r0,r2,r0
+	mov  r1,#0x64
+	bl EuclidianDivision
+	ldmia  r13!,{r3,r15}
+status_move:
+	mov  r0,#0x0
+	ldmia  r13!,{r3,r15}
+.endarea
+
+.org GetMoveBasePowerWithID
+.area 0x1C
+	stmdb  r13!,{r14}
+	mov  r1,#0x0
+	mov  r2,#1
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org IsMoveRangeID13
+.area 0x2C
+	stmdb  r13!,{r14}
+	ldrh r0,[r0, #+0x4]
+	mov  r1,#0x15
+	mov  r2,#1
+	bl ReadMoveValue
+	cmp r0,#0x13
+	moveq  r0,#0x1
+	movne  r0,#0x0
+	ldmia  r13!,{r15}
+.endarea
+
+.org GetMoveMessageID
+.area 0x34
+	stmdb  r13!,{r14}
+	mov  r1,#0x18
+	mov  r2,#2
+	bl ReadMoveValue
+	add  r0,r0,#0x314
+	add  r0,r0,#0xC00
+	mov  r0,r0,lsl #0x10
+	mov  r0,r0,lsr #0x10
+	bl UnkGetString
+	ldmia  r13!,{r15}
+.endarea
+
+.org IsAffectedByMagicCoat
+.area 0x1C
+	stmdb  r13!,{r14}
+	mov  r1,#0x10
+	mov  r2,#1
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org IsSnatchable
+.area 0x1C
+	stmdb  r13!,{r14}
+	mov  r1,#0x11
+	mov  r2,#1
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+.org IsMouthMove
+.area 0x1C
+	stmdb  r13!,{r14}
+	mov  r1,#0x12
+	mov  r2,#1
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea
+
+
+
+.org ConvertOverwoldToDungeonMoveset
+.area 0x94
+	stmdb  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r14}
+	mov  r6,r0
+	mov  r8,r1
+	mov  r4,#0x0
+	mov  r5,#0x6
+	mov  r9,#0x0
+loop_process_moveset:
+	mul  r2,r4,r5
+	ldrb r2,[r8, +r2]
+	tst r2,#0x1
+	streqb r9,[r6,+r4, lsl #0x3]
+	beq end_loop_process_moveset
+	strb r2,[r6,+r4, lsl #0x3]
+	mla  r7,r4,r5,r8
+	ldrh r0,[r7, #+0x2]
+	mov  r1,#0x8
+	mov  r2,#1
+	bl ReadMoveValue
+	add  r2,r6,r4,lsl #0x3
+	strb r0,[r2, #+0x6]
+	ldrh r10,[r7, #+0x2]
+	strh r10,[r2, #+0x4]
+	ldrb r7,[r7, #+0x4]
+	strb r7,[r2, #+0x7]
+end_loop_process_moveset:
+	add  r4,r4,#0x1
+	cmp r4,#0x4
+	blt loop_process_moveset
+	mov  r1,#0x0
+	strb r1,[r6, #+0x20]
+	mov r0,r6
+	ldmia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
+	.pool
+.endarea
+
+.org GetMoveCategory
+.area 0x1C
+	stmdb  r13!,{r14}
+	mov  r1,#3
+	mov  r2,#1
+	bl ReadMoveValue
+	ldmia  r13!,{r15}
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/fs_waza_p/common/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/fs_waza_p/common/patch.asm
@@ -145,7 +145,7 @@ TrueOpenWaza:
 	mov r4,r0
 	mov r5,r1
 	mov r6,r2
-	ldr r0,=ReadMoveBuffer
+	ldr r1,=ReadMoveBuffer
 	ldrh r0,[r1]
 	cmp r4,r0
 	beq no_read_move

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/fs_waza_p/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/fs_waza_p/eu/offsets.asm
@@ -1,0 +1,75 @@
+; For use with ARMIPS
+; 2021/04/07
+; For Explorers of Sky EU Only
+; ------------------------------------------------------------------------------
+; Use filestreams to access waza_p/waza_p2 instead of loading it entirely
+; ------------------------------------------------------------------------------
+
+
+.relativeinclude on
+.nds
+.arm
+
+.definelabel FillWithZeros8Bytes, 0x02003228
+
+.definelabel LoadWazaP, 0x0201346C
+.definelabel LoadWazaP2, 0x02013494
+.definelabel UnloadCurrentWazaP, 0x020134BC
+
+.definelabel GetMoveFlags, 0x020138E8
+.definelabel GetMoveType, 0x0201390C
+.definelabel GetMovesetLevelUpPtr, 0x0201392C
+.definelabel IsInvalidMoveset, 0x02013974
+.definelabel GetMovesetHMTMPtr, 0x0201399C
+.definelabel GetMovesetEggPtr, 0x020139E8
+.definelabel GetMoveUnk09, 0x02013A34
+.definelabel GetMoveNbHits, 0x02013A54
+.definelabel GetMoveBasePower, 0x02013A74
+.definelabel GetMoveBasePowerOverworld, 0x02013A94
+.definelabel GetMoveAccuracy, 0x02013AB4
+.definelabel GetMoveBasePP, 0x02013AD8
+.definelabel GetMovePPWithBonus, 0x02013AF8
+.definelabel GetMoveMaxGinsengBoost, 0x02013B78
+.definelabel GetMoveMaxGinsengBoostOverworld, 0x02013B98
+.definelabel GetMoveCriticalRate, 0x02013BB8
+.definelabel IsIceBreaker, 0x02013BD8
+.definelabel IsAffectedByTaunt, 0x02013BF8
+.definelabel GetMoveRangeID, 0x02013C18
+.definelabel GetMoveActualAccuracy, 0x02013C38
+.definelabel GetMoveBasePowerWithID, 0x02013C90
+.definelabel IsMoveRangeID13, 0x02013CAC
+.definelabel GetMoveMessageID, 0x02013CD8
+
+.definelabel IsAffectedByMagicCoat, 0x02013DB0
+.definelabel IsSnatchable, 0x02013DCC
+.definelabel IsMouthMove, 0x02013DE8
+
+.definelabel ConvertOverwoldToDungeonMoveset, 0x0201478C
+
+.definelabel GetMoveCategory, 0x02015270
+
+.definelabel OpenWaza, 0x0201533C
+.definelabel SelectWaza, 0x020153A4
+
+.definelabel UnkGetString, 0x02025B90
+
+.definelabel EuclidianDivision, 0x0209023C
+
+.definelabel NullMoveset, 0x020991A8
+
+.definelabel IQSkillPPUp, 0x020A1E24
+.definelabel ExclusiveItemPPUp2, 0x020A1E4C
+.definelabel ExclusiveItemPPUp4, 0x020A1DF8
+
+.definelabel TrueUnloadCurrentWazaP, 0x020A66C0
+.definelabel ReadMoveValue, TrueUnloadCurrentWazaP+0x140
+.definelabel ReadMoveBuffer, ReadMoveValue+0xA0
+.definelabel ReadMoveset, ReadMoveBuffer+0x1C
+.definelabel ReadMovesetBuffer, ReadMoveset+0xA0
+; r0: result = ReadMoveValue(r0: move_id, r1: value_offset, r2: value_size)
+
+.definelabel CurrentWazaInfo, 0x020AFFA8 ;{0x4: MovesetTableAddr, 0x4: WazaID, 0x4: MoveInfoTableAddr}
+.definelabel WazaFileNamesPtr, 0x020AFFB4 ;{0x4: WazaP, 0x4: WazaP2}
+.definelabel MovesetTableAddr, 0x020AFFBC ;{0x4: WazaP, 0x4: WazaP2}
+.definelabel MoveInfoTableAddr, 0x020AFFC4 ;{0x4: WazaP, 0x4: WazaP2}
+.definelabel WazaFileInfo, 0x020AFFCC ;{0x8: WazaP, 0x8: WazaP2}

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/fs_waza_p/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/fs_waza_p/jp/offsets.asm
@@ -1,0 +1,75 @@
+; For use with ARMIPS
+; 2021/04/07
+; For Explorers of Sky JP Only
+; ------------------------------------------------------------------------------
+; Use filestreams to access waza_p/waza_p2 instead of loading it entirely
+; ------------------------------------------------------------------------------
+
+
+.relativeinclude on
+.nds
+.arm
+
+.definelabel FillWithZeros8Bytes, 0x02003228
+
+.definelabel LoadWazaP, 0x02013394
+.definelabel LoadWazaP2, 0x020133BC
+.definelabel UnloadCurrentWazaP, 0x020133E4
+
+.definelabel GetMoveFlags, 0x02013810
+.definelabel GetMoveType, 0x02013834
+.definelabel GetMovesetLevelUpPtr, 0x02013854
+.definelabel IsInvalidMoveset, 0x0201389C
+.definelabel GetMovesetHMTMPtr, 0x020138C4
+.definelabel GetMovesetEggPtr, 0x02013910
+.definelabel GetMoveUnk09, 0x0201395C
+.definelabel GetMoveNbHits, 0x0201397C
+.definelabel GetMoveBasePower, 0x0201399C
+.definelabel GetMoveBasePowerOverworld, 0x020139BC
+.definelabel GetMoveAccuracy, 0x020139DC
+.definelabel GetMoveBasePP, 0x02013A00
+.definelabel GetMovePPWithBonus, 0x02013A20
+.definelabel GetMoveMaxGinsengBoost, 0x02013AA0
+.definelabel GetMoveMaxGinsengBoostOverworld, 0x02013AC0
+.definelabel GetMoveCriticalRate, 0x02013AE0
+.definelabel IsIceBreaker, 0x02013B00
+.definelabel IsAffectedByTaunt, 0x02013B20
+.definelabel GetMoveRangeID, 0x02013B40
+.definelabel GetMoveActualAccuracy, 0x02013B60
+.definelabel GetMoveBasePowerWithID, 0x02013BB8
+.definelabel IsMoveRangeID13, 0x02013BD4
+.definelabel GetMoveMessageID, 0x02013C00
+
+.definelabel IsAffectedByMagicCoat, 0x02013CD8
+.definelabel IsSnatchable, 0x02013CF4
+.definelabel IsMouthMove, 0x02013D10
+
+.definelabel ConvertOverwoldToDungeonMoveset, 0x020146B4
+
+.definelabel GetMoveCategory, 0x02015198
+
+.definelabel OpenWaza, 0x02015264
+.definelabel SelectWaza, 0x020152CC
+
+.definelabel UnkGetString, 0x020258A4
+
+.definelabel EuclidianDivision, 0x0209018C
+
+.definelabel NullMoveset, 0x02099058
+
+.definelabel IQSkillPPUp, 0x020A2C74
+.definelabel ExclusiveItemPPUp2, 0x020A2C9C
+.definelabel ExclusiveItemPPUp4, 0x020A2C48
+
+.definelabel TrueUnloadCurrentWazaP, 0x020A7268
+.definelabel ReadMoveValue, TrueUnloadCurrentWazaP+0x140
+.definelabel ReadMoveBuffer, ReadMoveValue+0xA0
+.definelabel ReadMoveset, ReadMoveBuffer+0x1C
+.definelabel ReadMovesetBuffer, ReadMoveset+0xA0
+; r0: result = ReadMoveValue(r0: move_id, r1: value_offset, r2: value_size)
+
+.definelabel CurrentWazaInfo, 0x020B0B1C ;{0x4: MovesetTableAddr, 0x4: WazaID, 0x4: MoveInfoTableAddr}
+.definelabel WazaFileNamesPtr, 0x020B0B28 ;{0x4: WazaP, 0x4: WazaP2}
+.definelabel MovesetTableAddr, 0x020B0B30 ;{0x4: WazaP, 0x4: WazaP2}
+.definelabel MoveInfoTableAddr, 0x020B0B38 ;{0x4: WazaP, 0x4: WazaP2}
+.definelabel WazaFileInfo, 0x020B0B40 ;{0x8: WazaP, 0x8: WazaP2}

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/fs_waza_p/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/fs_waza_p/na/offsets.asm
@@ -1,0 +1,75 @@
+; For use with ARMIPS
+; 2021/04/07
+; For Explorers of Sky NA Only
+; ------------------------------------------------------------------------------
+; Use filestreams to access waza_p/waza_p2 instead of loading it entirely
+; ------------------------------------------------------------------------------
+
+
+.relativeinclude on
+.nds
+.arm
+
+.definelabel FillWithZeros8Bytes, 0x02003228
+
+.definelabel LoadWazaP, 0x020133C4
+.definelabel LoadWazaP2, 0x020133EC
+.definelabel UnloadCurrentWazaP, 0x02013414
+
+.definelabel GetMoveFlags, 0x02013840
+.definelabel GetMoveType, 0x02013864
+.definelabel GetMovesetLevelUpPtr, 0x02013884
+.definelabel IsInvalidMoveset, 0x020138CC
+.definelabel GetMovesetHMTMPtr, 0x020138F4
+.definelabel GetMovesetEggPtr, 0x02013940
+.definelabel GetMoveUnk09, 0x0201398C
+.definelabel GetMoveNbHits, 0x020139AC
+.definelabel GetMoveBasePower, 0x020139CC
+.definelabel GetMoveBasePowerOverworld, 0x020139EC
+.definelabel GetMoveAccuracy, 0x02013A0C
+.definelabel GetMoveBasePP, 0x02013A30
+.definelabel GetMovePPWithBonus, 0x02013A50
+.definelabel GetMoveMaxGinsengBoost, 0x02013AD0
+.definelabel GetMoveMaxGinsengBoostOverworld, 0x02013AF0
+.definelabel GetMoveCriticalRate, 0x02013B10
+.definelabel IsIceBreaker, 0x02013B30
+.definelabel IsAffectedByTaunt, 0x02013B50
+.definelabel GetMoveRangeID, 0x02013B70
+.definelabel GetMoveActualAccuracy, 0x02013B90
+.definelabel GetMoveBasePowerWithID, 0x02013BE8
+.definelabel IsMoveRangeID13, 0x02013C04
+.definelabel GetMoveMessageID, 0x02013C30
+
+.definelabel IsAffectedByMagicCoat, 0x02013D08
+.definelabel IsSnatchable, 0x02013D24
+.definelabel IsMouthMove, 0x02013D40
+
+.definelabel ConvertOverwoldToDungeonMoveset, 0x020146E4
+
+.definelabel GetMoveCategory, 0x020151C8
+
+.definelabel OpenWaza, 0x02015294
+.definelabel SelectWaza, 0x020152FC
+
+.definelabel UnkGetString, 0x020258C4
+
+.definelabel EuclidianDivision, 0x0208FEA4
+
+.definelabel NullMoveset, 0x02098D64
+
+.definelabel IQSkillPPUp, 0x020A18A0
+.definelabel ExclusiveItemPPUp2, 0x020A18C8
+.definelabel ExclusiveItemPPUp4, 0x020A1874
+
+.definelabel TrueUnloadCurrentWazaP, 0x020A5E20
+.definelabel ReadMoveValue, TrueUnloadCurrentWazaP+0x140
+.definelabel ReadMoveBuffer, ReadMoveValue+0xA0
+.definelabel ReadMoveset, ReadMoveBuffer+0x1C
+.definelabel ReadMovesetBuffer, ReadMoveset+0xA0
+; r0: result = ReadMoveValue(r0: move_id, r1: value_offset, r2: value_size)
+
+.definelabel CurrentWazaInfo, 0x020AF6DC ;{0x4: MovesetTableAddr, 0x4: WazaID, 0x4: MoveInfoTableAddr}
+.definelabel WazaFileNamesPtr, 0x020AF6E8 ;{0x4: WazaP, 0x4: WazaP2}
+.definelabel MovesetTableAddr, 0x020AF6F0 ;{0x4: WazaP, 0x4: WazaP2}
+.definelabel MoveInfoTableAddr, 0x020AF6F8 ;{0x4: WazaP, 0x4: WazaP2}
+.definelabel WazaFileInfo, 0x020AF700 ;{0x8: WazaP, 0x8: WazaP2}

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/fs_waza_p/selector_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/fs_waza_p/selector_arm9.asm
@@ -1,0 +1,22 @@
+; For use with ARMIPS
+; 2021/04/07
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/offsets.asm"
+	.include "common/patch.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/offsets.asm"
+	.include "common/patch.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/offsets.asm"
+	.include "common/patch.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -897,6 +897,13 @@
 	  </OpenBin>
         </Patch>
         
+        <!-- A patch to externalize waza_p/waza_p2 files -->
+        <Patch id="ExternalizeWazaFile" >
+          <OpenBin filepath="arm9.bin">
+	  	<Include filename ="irdkwia_asm_mods/fs_waza_p/selector_arm9.asm"/>
+	  </OpenBin>
+        </Patch>
+        
         <!-- A patch to extract item code -->
         <Patch id="ExtractItemCode" >
           <OpenBin filepath="overlay/overlay_0029.bin">

--- a/skytemple_files/patch/handler/externalize_waza.py
+++ b/skytemple_files/patch/handler/externalize_waza.py
@@ -1,0 +1,73 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable, Dict, List, Set
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU, GAME_REGION_JP
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+from skytemple_files.common.i18n_util import _, get_locales
+from skytemple_files.data.str.handler import StrHandler
+
+PATCH_CHECK_ADDR_APPLIED_US = 0x13414
+PATCH_CHECK_ADDR_APPLIED_EU = 0x134BC
+PATCH_CHECK_ADDR_APPLIED_JP = 0x133E4
+PATCH_CHECK_INSTR_APPLIED = 0xE92D4010
+
+class ExternalizeWazaPatchHandler(AbstractPatchHandler, DependantPatch):
+
+    @property
+    def name(self) -> str:
+        return 'ExternalizeWazaFile'
+
+    @property
+    def description(self) -> str:
+        return _("""Use filestreams to access waza_p/waza_p2 data instead of loading them entirely.
+This patch is useless on its own.
+Depends on ActorAndLevelLoader patches, as it needs some space provided by this patch.""")
+
+    @property
+    def author(self) -> str:
+        return 'irdkwia'
+
+    @property
+    def version(self) -> str:
+        return '0.0.1'
+
+    def depends_on(self) -> List[str]:
+        return ['ActorAndLevelLoader']
+    
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_US, 4)!=PATCH_CHECK_INSTR_APPLIED
+            if config.game_region == GAME_REGION_EU:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_EU, 4)!=PATCH_CHECK_INSTR_APPLIED
+            if config.game_region == GAME_REGION_JP:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_JP, 4)!=PATCH_CHECK_INSTR_APPLIED
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        try:
+            apply()
+        except RuntimeError as ex:
+            raise ex
+
+    
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/handler/externalize_waza.py
+++ b/skytemple_files/patch/handler/externalize_waza.py
@@ -39,7 +39,7 @@ class ExternalizeWazaPatchHandler(AbstractPatchHandler, DependantPatch):
     def description(self) -> str:
         return _("""Use filestreams to access waza_p/waza_p2 data instead of loading them entirely.
 This patch is useless on its own.
-Depends on ActorAndLevelLoader patches, as it needs some space provided by this patch.""")
+Depends on the ActorAndLevelLoader patch, as it needs some space provided by this one.""")
 
     @property
     def author(self) -> str:

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -51,6 +51,7 @@ from skytemple_files.patch.handler.complete_team_control import CompleteTeamCont
 from skytemple_files.patch.handler.far_off_pal_overdrive import FarOffPalOverdrive
 from skytemple_files.patch.handler.partners_trigger_hidden_traps import PartnersTriggerHiddenTraps
 from skytemple_files.patch.handler.reduce_jumpcut_pause_time import ReduceJumpcutPauseTime
+from skytemple_files.patch.handler.externalize_waza import ExternalizeWazaPatchHandler
 from skytemple_files.patch.handler.extract_move_code import ExtractMoveCodePatchHandler
 from skytemple_files.patch.handler.extract_item_code import ExtractItemCodePatchHandler
 from skytemple_files.common.i18n_util import f, _
@@ -76,6 +77,7 @@ class PatchType(Enum):
     PARTNERS_TRIGGER_HIDDEN_TRAPS = PartnersTriggerHiddenTraps
     REDUCE_JUMPCUT_PAUSE_TIME = ReduceJumpcutPauseTime
     EXTRA_SPACE = ExtraSpacePatch
+    EXTERNALIZE_WAZA = ExternalizeWazaPatchHandler
     EXTRACT_MOVE_CODE = ExtractMoveCodePatchHandler
     EXTRACT_ITEM_CODE = ExtractItemCodePatchHandler
     ADD_TYPES = AddTypePatchHandler


### PR DESCRIPTION
This patch doesn't add anything on it's own, so it's useless in the current state.
Needs a LOT of tests though to know if it doesn't break anything related to moves or anything else.