### PR TITLE
Add a patch to change the game evolution system.

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/common/patch_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/common/patch_arm9.asm
@@ -1,0 +1,447 @@
+; For use with ARMIPS
+; 2021/04/10
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Change the evo system
+; ------------------------------------------------------------------------------
+
+.org GetEvolutions
+.area 0x88
+	stmdb  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r14}
+	sub r13,r13,#0x14
+	mov  r10,r0
+	mov  r9,r1
+	mov  r8,r2
+	mov  r11,r3
+	bl GetSpriteSize
+	mov  r4,r0
+	mov  r5,#0x0
+	mov  r6,#0x0
+	mov r0,r13
+	mov r1,r10
+	bl GetEvos
+	str r0, [r13, #+0x10]
+loop_get_evos:
+	mov r0,r6,lsl #0x1
+	ldr r7,[r13,r0]
+	cmp r8,#0x0
+	bne no_check_sprite_size
+	mov  r0,r7
+	bl GetSpriteSize
+	cmp r4,r0
+	bne end_loop_get_evos
+no_check_sprite_size:
+	cmp r11,#0x0
+	cmpeq r7,#0x140
+	movne  r0,r5,lsl #0x1
+	strneh r7,[r9,r0]
+	addne  r5,r5,#0x1
+end_loop_get_evos:
+	ldr r0,[r13, #+0x10]
+	add  r6,r6,#0x1
+	cmp r6,r0
+	blt loop_get_evos
+	mov  r0,r5
+	add r13,r13,#0x14
+	ldmia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
+.endarea
+
+.org GetEvolutionPossibilities
+.area 0x6F8
+	stmdb  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r14}
+	sub  r13,r13,#0x8
+	mov  r9,r0
+	mov  r8,r1
+	mov  r5,#0x0
+	strh r5,[r8, #+0x6]
+	strh r5,[r8, #+0x8]
+	add r0,r8,#0xA
+	mov r1, #0x30
+	bl FillWithZeros2BytesArray
+	ldrsh r0,[r9, #+0x4]
+	bl CanEvolve
+	cmp r0,#0x0
+	moveq  r0,#0x4
+	streqh r0,[r8, #+0x6]
+	beq return_evo_possibilities
+	add r0,r8,#0xA
+	ldrsh r1,[r9, #+0x4]
+	bl GetEvos
+	mov r5,r0
+	cmp r5,#0x0
+	moveq  r0,#0x4
+	streqh r0,[r8, #+0x6]
+	beq return_evo_possibilities
+	mov  r7,#0x0
+	b end_loop_check_cond
+loop_check_cond:
+	add  r0,r8,r7,lsl #0x1
+	ldrsh r10,[r0, #+0xa]
+	add  r0,r13,#0x0
+	mov  r1,r10
+	bl GetEvoParameters
+	ldrh r0,[r13, #+0x2]
+	mov  r4,#0x0
+	cmp r0,#0x4
+	addls  r15,r15,r0,lsl #0x2
+	b main_no_req
+	b main_no_req
+	b main_lvl
+	b main_iq
+	b main_item
+	b main_recruit
+main_lvl:
+	ldrb r1,[r9, #+0x1]
+	ldrsh r0,[r13, #+0x4]
+	cmp r1,r0
+	ldrlth r0,[r8, #+0x6]
+	movlt  r4,#0x1
+	orrlt  r0,r0,#0x2
+	strlth r0,[r8, #+0x6]
+	b main_no_req
+main_iq:
+	ldrsh r1,[r9, #+0x8]
+	ldrsh r0,[r13, #+0x4]
+	cmp r1,r0
+	ldrlth r0,[r8, #+0x6]
+	movlt  r4,#0x1
+	orrlt  r0,r0,#0x10
+	strlth r0,[r8, #+0x6]
+	b main_no_req
+main_item:
+	ldrsh r0,[r13, #+0x4]
+	bl GetItemPosition
+	cmp r0,#0x0
+	ldrlth r0,[r8, #+0x6]
+	movlt  r4,#0x1
+	orrlt  r0,r0,#0x8
+	strlth r0,[r8, #+0x6]
+	ldrgesh r1,[r13, #+0x4]
+	addge  r0,r8,r7,lsl #0x1
+	strgeh r1,[r0, #+0x1a]
+	b main_no_req
+main_recruit:
+	ldrsh r0,[r13, #+0x4]
+	mov  r1,#0x258
+	mov  r6,r4
+	bl EuclidianDivision
+	mov  r0,r1,lsl #0x10
+	mov  r0,r0,asr #0x10
+	mov  r1,r4
+	bl IsRecruited
+	cmp r0,#0x0
+	ldrsh r0,[r13, #+0x4]
+	mov  r1,#0x258
+	addne  r6,r6,#0x1
+	bl EuclidianDivision
+	mov  r0,r1,lsl #0x10
+	mov  r0,r0,asr #0x10
+	add  r0,r0,#0x258
+	mov  r0,r0,lsl #0x10
+	mov  r0,r0,asr #0x10
+	mov  r1,#0x0
+	bl IsRecruited
+	cmp r0,#0x0
+	addne  r6,r6,#0x1
+	cmp r6,#0x0
+	moveq  r4,#0x1
+main_no_req:
+	ldrh r0,[r13, #+0x6]
+	cmp r0,#0xF
+	addls  r15,r15,r0,lsl #0x2
+	b add_none
+	b add_none
+	b add_link_cable
+	b add_atk_g_def
+	b add_atk_l_def
+	b add_atk_e_def
+	b add_sun_ribbon
+	b add_lunar_ribbon
+	b add_beauty_scarf
+	b add_val_1
+	b add_val_0
+	b add_male
+	b add_female
+	b add_move_ancientpower
+	b add_move_rollout
+	b add_move_double_hit
+	b add_move_mimic
+add_move_ancientpower:
+	mov  r6,#0x0
+	mov  r4,#0x1
+	mov  r1,r6
+	mov  r0,#0x6
+loop_move_ancientpower:
+	mla  r3,r6,r0,r9
+	ldrb r2,[r3, #+0x22]
+	tst r2,#0x1
+	beq end_loop_move_ancientpower
+	ldrh r2,[r3, #+0x24]
+	cmp r2,#0x5D
+	moveq  r4,r1
+end_loop_move_ancientpower:
+	add  r6,r6,#0x1
+	cmp r6,#0x4
+	blt loop_move_ancientpower
+	b add_none
+add_move_rollout:
+	mov  r6,#0x0
+	mov  r4,#0x1
+	mov  r1,r6
+	mov  r0,#0x6
+loop_move_rollout:
+	mla  r3,r6,r0,r9
+	ldrb r2,[r3, #+0x22]
+	tst r2,#0x1
+	beq end_loop_move_rollout
+	ldrh r2,[r3, #+0x24]
+	cmp r2,#0x69
+	moveq  r4,r1
+end_loop_move_rollout:
+	add  r6,r6,#0x1
+	cmp r6,#0x4
+	blt loop_move_rollout
+	b add_none
+add_move_double_hit:
+	mov  r0,#0x0
+	ldr r1,=0x000001E7
+	mov  r4,#0x1
+	mov  r3,r0
+	mov  r2,#0x6
+loop_move_double_hit:
+	mla  r11,r0,r2,r9
+	ldrb r6,[r11, #+0x22]
+	tst r6,#0x1
+	beq end_loop_move_double_hit
+	ldrh r6,[r11, #+0x24]
+	cmp r6,r1
+	moveq  r4,r3
+end_loop_move_double_hit:
+	add  r0,r0,#0x1
+	cmp r0,#0x4
+	blt loop_move_double_hit
+	b add_none
+add_move_mimic:
+	mov  r0,#0x0
+	ldr r1,=0x00000147
+	mov  r4,#0x1
+	mov  r3,r0
+	mov  r2,#0x6
+loop_move_mimic:
+	mla  r11,r0,r2,r9
+	ldrb r6,[r11, #+0x22]
+	tst r6,#0x1
+	beq end_loop_move_mimic
+	ldrh r6,[r11, #+0x24]
+	cmp r6,r1
+	moveq  r4,r3
+end_loop_move_mimic:
+	add  r0,r0,#0x1
+	cmp r0,#0x4
+	blt loop_move_mimic
+	b add_none
+add_link_cable:
+	mov  r0,#0x97
+	bl GetItemPosition
+	cmp r0,#0x0
+	ldrlth r0,[r8, #+0x6]
+	movge  r1,#0x97
+	movlt  r4,#0x1
+	orrlt  r0,r0,#0x8
+	strlth r0,[r8, #+0x6]
+	addge  r0,r8,r7,lsl #0x1
+	strgeh r1,[r0, #+0x2a]
+	b add_none
+add_atk_g_def:
+	ldrb r1,[r9, #+0xc]
+	ldrb r0,[r9, #+0xe]
+	cmp r1,r0
+	movls  r4,#0x1
+	b add_none
+add_atk_l_def:
+	ldrb r1,[r9, #+0xc]
+	ldrb r0,[r9, #+0xe]
+	cmp r1,r0
+	movcs  r4,#0x1
+	b add_none
+add_atk_e_def:
+	ldrb r1,[r9, #+0xc]
+	ldrb r0,[r9, #+0xe]
+	cmp r1,r0
+	movne  r4,#0x1
+	b add_none
+add_sun_ribbon:
+	mov  r0,#0x37
+	bl GetItemPosition
+	cmp r0,#0x0
+	ldrlth r0,[r8, #+0x6]
+	movge  r1,#0x37
+	movlt  r4,#0x1
+	orrlt  r0,r0,#0x8
+	strlth r0,[r8, #+0x6]
+	addge  r0,r8,r7,lsl #0x1
+	strgeh r1,[r0, #+0x2a]
+	b add_none
+add_lunar_ribbon:
+	mov  r0,#0x38
+	bl GetItemPosition
+	cmp r0,#0x0
+	ldrlth r0,[r8, #+0x6]
+	movge  r1,#0x38
+	movlt  r4,#0x1
+	orrlt  r0,r0,#0x8
+	strlth r0,[r8, #+0x6]
+	addge  r0,r8,r7,lsl #0x1
+	strgeh r1,[r0, #+0x2a]
+	b add_none
+add_val_1:
+	ldrb r0,[r8, #+0x4]
+	tst r0,#0x1
+	movne  r4,#0x1
+	b add_none
+add_val_0:
+	ldrb r0,[r8, #+0x4]
+	tst r0,#0x1
+	moveq  r4,#0x1
+	b add_none
+add_beauty_scarf:
+	mov  r0,#0x36
+	bl GetItemPosition
+	cmp r0,#0x0
+	addge  r0,r8,r7,lsl #0x1
+	movge  r1,#0x36
+	movlt  r4,#0x1
+	strgeh r1,[r0, #+0x2a]
+	b add_none
+add_male:
+	ldrsh r0,[r9, #+0x4]
+	bl GetGender
+	cmp r0,#1
+	movne  r4,#0x1
+	b add_none
+add_female:
+	ldrsh r0,[r9, #+0x4]
+	bl GetGender
+	cmp r0,#2
+	movne  r4,#0x1
+add_none:
+	cmp r4,#0x0
+	ldreqh r0,[r8, #+0x6]
+	movne  r1,#0x0
+	orreq  r0,r0,#0x1
+	streqh r0,[r8, #+0x6]
+	addne  r0,r8,r7,lsl #0x1
+	streqh r10,[r8, #+0x8]
+	strneh r1,[r0, #+0xa]
+	add  r7,r7,#0x1
+end_loop_check_cond:
+	cmp r7,r5
+	blt loop_check_cond
+return_evo_possibilities:
+	add  r13,r13,#0x8
+	ldmia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
+	.pool
+CheckOpen:
+	stmdb  r13!,{r14}
+	ldr r1,=already_loaded
+	ldrb r0, [r1]
+	cmp r0,#0
+	bne no_open
+	mov r0, #1
+	strb r0, [r1]
+	ldr r0,=filestream
+	bl FStreamCtor
+	ldr r0,=filestream
+	ldr r1,=filename
+	bl FStreamFOpen
+no_open:
+	ldmia  r13!,{r15}
+GetEvos:
+	stmdb  r13!,{r4,r5,r14}
+	mov r4,r0
+	mov r5,r1
+	bl FStreamAlloc
+	bl CheckOpen
+	mov r1,r5,lsl #0x5
+	add r1,r1,#4
+	ldr r0,=filestream
+	mov r2, #0
+	bl FStreamSeek
+	ldr r0,=filestream
+	mov r1,r4
+	mov r2,#0x2
+	bl FStreamRead
+	ldrh r5,[r4]
+	ldr r0,=filestream
+	mov r1,r4
+	mov r2,#0x10
+	bl FStreamRead
+	bl FStreamDealloc
+	mov r0,r5
+	ldmia  r13!,{r4,r5,r15}
+	.pool
+AddStats:
+	stmdb  r13!,{r4,r5,r14}
+	sub r13,r13,#0xC
+	mov r4,r0 ; Pkmn Str
+	mov r5,r1 ; Evo ID
+	bl FStreamAlloc
+	bl CheckOpen
+	ldr r0,=filestream
+	mov r1, #0
+	mov r2, #0
+	bl FStreamSeek
+	ldr r0,=filestream
+	mov r1,r13
+	mov r2,#0x4
+	bl FStreamRead
+	ldr r1,[r13]
+	ldr r0,=filestream
+	mov r2,#0xA
+	mla r1,r2,r5,r1
+	mov r2,#0x0
+	bl FStreamSeek
+	ldr r0,=filestream
+	mov r1,r13
+	mov r2,#0xA
+	bl FStreamRead
+	bl FStreamDealloc
+	;r13 contains the stat entries (0x2: HP, 0x2: Atk + 0x2: SpAtk + 0x2: Def + 0x2: SpDef)
+	; HP Bonus
+	ldrsh r0,[r4, #+0xa]
+	ldrsh r1,[r13]
+	add r0,r1,r0
+	ldr r1,=0x3e7
+	cmp r0,r1
+	movgt r0,r1
+	cmp r0,#1
+	movlt r0,#1
+	strh r0,[r4, #+0xa]
+	mov r3,#0x0
+stats_loop:
+	add r2,r3,#0xC
+	ldrb r0,[r4, r2]
+	mov r1,r3,lsl #0x1
+	add r1,r1,#0x2
+	ldrsh r1,[r13, r1]
+	add r0,r1,r0
+	cmp r0,#0xFF
+	movgt r0,#0xFF
+	cmp r0,#1
+	movlt r0,#1
+	strb r0,[r4, r2]
+	add r3,r3,#1
+	cmp r3,#0x4
+	blt stats_loop
+	add r13,r13,#0xC
+	ldmia  r13!,{r4,r5,r15}
+	.pool
+filename:
+	.ascii "BALANCE/md_evo.bin"
+	dcb 0
+already_loaded:
+	.byte 0x0
+filestream:
+	.fill 0x48, 0x0
+	.fill (GetEvolutionPossibilities+0x6F8-.), 0xCC
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/common/patch_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/common/patch_arm9.asm
@@ -122,27 +122,11 @@ main_item:
 	b main_no_req
 main_recruit:
 	ldrsh r0,[r13, #+0x4]
-	mov  r1,#0x258
 	mov  r6,r4
-	bl EuclidianDivision
-	mov  r0,r1,lsl #0x10
-	mov  r0,r0,asr #0x10
-	mov  r1,r4
+	mov  r1,#1
 	bl IsRecruited
 	cmp r0,#0x0
-	ldrsh r0,[r13, #+0x4]
-	mov  r1,#0x258
-	addne  r6,r6,#0x1
-	bl EuclidianDivision
-	mov  r0,r1,lsl #0x10
-	mov  r0,r0,asr #0x10
-	add  r0,r0,#0x258
-	mov  r0,r0,lsl #0x10
-	mov  r0,r0,asr #0x10
-	mov  r1,#0x0
-	bl IsRecruited
-	cmp r0,#0x0
-	addne  r6,r6,#0x1
+	movne  r6,#0x1
 	cmp r6,#0x0
 	moveq  r4,#0x1
 main_no_req:

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/common/patch_overlay16.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/common/patch_overlay16.asm
@@ -1,0 +1,34 @@
+; For use with ARMIPS
+; 2021/04/10
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Change the evo system
+; ------------------------------------------------------------------------------
+
+.org EvoAddStats1
+.area 0xE8
+	ldr r1,=MainEvoMenuStruct
+	ldr r3,[r1, #+0x0]
+	ldr r0,[r3, #+0x3c]
+	ldrsh r1,[r3, #+0xa]
+	bl AddStats
+	ldr r2,=MainEvoMenuStruct
+	b end_evo_add_stats1
+	.pool
+	.fill (EvoAddStats1+0xE8-.), 0xCC
+end_evo_add_stats1:
+.endarea
+
+.org EvoAddStats2
+.area 0xE8
+	ldr r1,=MainEvoMenuStruct
+	ldr r3,[r1, #+0x0]
+	ldr r0,[r3, #+0x3c]
+	ldrsh r1,[r3, #+0xa]
+	bl AddStats
+	ldr r2,=MainEvoMenuStruct
+	b end_evo_add_stats2
+	.pool
+	.fill (EvoAddStats2+0xE8-.), 0xCC
+end_evo_add_stats2:
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/common/patch_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/common/patch_overlay29.asm
@@ -1,0 +1,51 @@
+; For use with ARMIPS
+; 2021/04/10
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Change the evo system
+; ------------------------------------------------------------------------------
+
+.org GenerateMissionEggPkmn
+.area GMEPSize
+	stmdb  r13!,{r3,r4,r5,r6,r14}
+	sub  r13,r13,#0xC
+	mov r4,r0
+	ldrb r0,[r0, #+0x16]
+	cmp r0,#0x5
+	bne no_egg
+	bl GetRandomSpawnPkmnID
+	mov  r6,r0
+	bl FStreamAlloc
+	bl CheckOpen
+	mov r1,r6,lsl #0x5
+	add r1,r1,#0x16
+	ldr r0,=filestream
+	mov r2, #0
+	bl FStreamSeek
+	ldr r0,=filestream
+	mov r1,r13
+	mov r2,#0x2
+	bl FStreamRead
+	ldrh r5,[r13]
+	ldr r0,=filestream
+	mov r1,r13
+	mov r2,#0xC
+	bl FStreamRead
+	bl FStreamDealloc
+	cmp r5,#0
+	beq str_egg
+	cmp r5,#1
+	ldreqsh r6,[r13]
+	beq str_egg
+	mov r0,r5
+	bl RandMax
+	mov r0,r0,lsl #0x1
+	ldrsh r6,[r13,r0]
+str_egg:
+	strh r6,[r4, #+0x18]
+no_egg:
+	add  r13,r13,#0xC
+	ldmia  r13!,{r3,r4,r5,r6,r15}
+	.pool
+	.fill (GenerateMissionEggPkmn+GMEPSize-.), 0xCC
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/eu/offsets.asm
@@ -1,0 +1,36 @@
+; For use with ARMIPS
+; 2021/04/10
+; For Explorers of Sky EU Only
+; ------------------------------------------------------------------------------
+; Change the evo system
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+.nds
+.arm
+
+.definelabel FillWithZeros2BytesArray, 0x0200326C
+
+.definelabel GetItemPosition, 0x0200D300
+
+.definelabel GetGender, 0x02052AE0
+.definelabel GetSpriteSize, 0x02052B18
+.definelabel CanEvolve, 0x02052CB4
+.definelabel GetEvoParameters, 0x02052DE8
+
+.definelabel GetEvolutions, 0x02054204
+
+.definelabel IsRecruited, 0x020554C4
+
+.definelabel GetEvolutionPossibilities, 0x02059E94
+
+.definelabel EuclidianDivision, 0x0209023C
+
+.definelabel EvoAddStats1, 0x0238B734
+.definelabel EvoAddStats2, 0x0238C734
+.definelabel MainEvoMenuStruct, 0x0238D980
+
+.definelabel RandMax, 0x022EB448
+.definelabel GetRandomSpawnPkmnID, 0x02338B68
+.definelabel GenerateMissionEggPkmn, 0x0234A4A0
+.definelabel GMEPSize, 0x1D0

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/jp/offsets.asm
@@ -1,0 +1,36 @@
+; For use with ARMIPS
+; 2021/04/10
+; For Explorers of Sky JP Only
+; ------------------------------------------------------------------------------
+; Change the evo system
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+.nds
+.arm
+
+.definelabel FillWithZeros2BytesArray, 0x0200326C
+
+.definelabel GetItemPosition, 0x0200D278
+
+.definelabel GetGender, 0x02052AE0
+.definelabel GetSpriteSize, 0x02052B18
+.definelabel CanEvolve, 0x02052CB4
+.definelabel GetEvoParameters, 0x02052DE8
+
+.definelabel GetEvolutions, 0x020541C0
+
+.definelabel IsRecruited, 0x02055480
+
+.definelabel GetEvolutionPossibilities, 0x02059E14
+
+.definelabel EuclidianDivision, 0x0209018C
+
+.definelabel EvoAddStats1, 0x0238C154
+.definelabel EvoAddStats2, 0x0238D164
+.definelabel MainEvoMenuStruct, 0x0238E3C0
+
+.definelabel RandMax, 0x022EC100
+.definelabel GetRandomSpawnPkmnID, 0x0233935C
+.definelabel GenerateMissionEggPkmn, 0x023498A0
+.definelabel GMEPSize, 0x180

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/na/offsets.asm
@@ -1,0 +1,36 @@
+; For use with ARMIPS
+; 2021/04/10
+; For Explorers of Sky NA Only
+; ------------------------------------------------------------------------------
+; Change the evo system
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+.nds
+.arm
+
+.definelabel FillWithZeros2BytesArray, 0x0200326C
+
+.definelabel GetItemPosition, 0x0200D278
+
+.definelabel GetGender, 0x020527A8
+.definelabel GetSpriteSize, 0x020527E0
+.definelabel CanEvolve, 0x0205297C
+.definelabel GetEvoParameters, 0x02052AB0
+
+.definelabel GetEvolutions, 0x02053E88
+
+.definelabel IsRecruited, 0x02055148
+
+.definelabel GetEvolutionPossibilities, 0x02059B18
+
+.definelabel EuclidianDivision, 0x0208FEA4
+
+.definelabel EvoAddStats1, 0x0238ABF4
+.definelabel EvoAddStats2, 0x0238BBF4
+.definelabel MainEvoMenuStruct, 0x0238CE40
+
+.definelabel RandMax, 0x022EAA98
+.definelabel GetRandomSpawnPkmnID, 0x02337F98
+.definelabel GenerateMissionEggPkmn, 0x023498A0
+.definelabel GMEPSize, 0x1D0

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/selector_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/selector_arm9.asm
@@ -1,0 +1,22 @@
+; For use with ARMIPS
+; 2021/04/10
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/offsets.asm"
+	.include "common/patch_arm9.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/offsets.asm"
+	.include "common/patch_arm9.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/offsets.asm"
+	.include "common/patch_arm9.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/selector_overlay16.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/selector_overlay16.asm
@@ -1,0 +1,19 @@
+; For use with ARMIPS
+; 2021/04/10
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "common/patch_overlay16.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "common/patch_overlay16.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "common/patch_overlay16.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/selector_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_evo/selector_overlay29.asm
@@ -1,0 +1,19 @@
+; For use with ARMIPS
+; 2021/04/10
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "common/patch_overlay29.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "common/patch_overlay29.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "common/patch_overlay29.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -910,7 +910,20 @@
 	  	<Include filename ="irdkwia_asm_mods/extract_sp_code/selector_overlay11.asm"/>
 	  </OpenBin>
         </Patch>
-        
+
+        <!-- A patch to reconfigure evolutions -->
+        <Patch id="ChangeEvoSystem" >
+          <OpenBin filepath="arm9.bin">
+	  	<Include filename ="irdkwia_asm_mods/change_evo/selector_arm9.asm"/>
+	  </OpenBin>
+          <OpenBin filepath="overlay/overlay_0016.bin">
+	  	<Include filename ="irdkwia_asm_mods/change_evo/selector_overlay16.asm"/>
+	  </OpenBin>
+          <OpenBin filepath="overlay/overlay_0029.bin">
+	  	<Include filename ="irdkwia_asm_mods/change_evo/selector_overlay29.asm"/>
+	  </OpenBin>
+        </Patch>
+
         <!-- A patch to add types to the type table -->
         <Patch id="AddTypes" >
           <OpenBin filepath="arm9.bin">
@@ -937,7 +950,7 @@
 	  	<Include filename ="irdkwia_asm_mods/stat_disp/selector_arm9.asm"/>
 	  </OpenBin>
         </Patch>
-        
+
         <!-- A patch to extract spinda bar's item list-->
         <Patch id="ExtractBarItemList" >
           <OpenBin filepath="overlay/overlay_0019.bin">

--- a/skytemple_files/common/types/file_types.py
+++ b/skytemple_files/common/types/file_types.py
@@ -39,6 +39,7 @@ from skytemple_files.data.md.handler import MdHandler
 from skytemple_files.data.str.handler import StrHandler
 from skytemple_files.data.waza_p.handler import WazaPHandler
 from skytemple_files.data.item_p.handler import ItemPHandler
+from skytemple_files.data.md_evo.handler import MdEvoHandler
 from skytemple_files.data.tbl_talk.handler import TblTalkHandler
 from skytemple_files.dungeon_data.fixed_bin.handler import FixedBinHandler
 from skytemple_files.dungeon_data.mappa_bin.handler import MappaBinHandler
@@ -156,6 +157,7 @@ class FileType:
     ITEM_P = ItemPHandler
     ITEM_SP = ItemSPHandler
     TBL_TALK = TblTalkHandler
+    MD_EVO = MdEvoHandler
 
     # These handlers assume the content to be Sir0 wrapped by default:
     MAPPA_BIN = MappaBinHandler

--- a/skytemple_files/data/md_evo/__init__.py
+++ b/skytemple_files/data/md_evo/__init__.py
@@ -1,0 +1,19 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+MEVO_ENTRY_LENGTH = 0x20
+MEVO_STATS_LENGTH = 0xA

--- a/skytemple_files/data/md_evo/handler.py
+++ b/skytemple_files/data/md_evo/handler.py
@@ -1,0 +1,31 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from skytemple_files.common.types.data_handler import DataHandler
+from skytemple_files.data.md_evo.model import MdEvo
+from skytemple_files.data.md_evo.writer import MdEvoWriter
+
+
+class MdEvoHandler(DataHandler[MdEvo]):
+    @classmethod
+    def deserialize(cls, data: bytes, **kwargs) -> 'MdEvo':
+        return MdEvo(data)
+
+    @classmethod
+    def serialize(cls, data: 'MdEvo', **kwargs) -> bytes:
+        return MdEvoWriter(data).write()
+

--- a/skytemple_files/data/md_evo/model.py
+++ b/skytemple_files/data/md_evo/model.py
@@ -1,0 +1,76 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+from skytemple_files.common.util import *
+from skytemple_files.common.i18n_util import _
+from skytemple_files.data.md_evo import *
+
+
+class MdEvoEntry(AutoString):
+    def __init__(self, data: bytes):
+        nb_evos = read_uintle(data, 0, 2)
+        self.evos = []
+        for x in range(2, nb_evos*2+2, 2):
+            self.evos.append(read_uintle(data, x, 2))
+        nb_eggs = read_uintle(data, 0x12, 2)
+        self.eggs = []
+        for x in range(0x14, nb_eggs*2+0x14, 2):
+            self.eggs.append(read_uintle(data, x, 2))
+    def to_bytes(self):
+        mevo_data = bytearray(MEVO_ENTRY_LENGTH)
+        write_uintle(mevo_data, len(self.evos), 0, 2)
+        for j,x in enumerate(self.evos):
+            write_uintle(mevo_data, x, j*2+2, 2)
+        write_uintle(mevo_data, len(self.eggs), 0x12, 2)
+        for j,x in enumerate(self.eggs):
+            write_uintle(mevo_data, x, j*2+0x14, 2)
+        return mevo_data
+
+class MdEvoStats(AutoString):
+    def __init__(self, data: bytes):
+        self.hp_bonus = read_sintle(data, 0, 2)
+        self.atk_bonus = read_sintle(data, 2, 2)
+        self.spatk_bonus = read_sintle(data, 4, 2)
+        self.def_bonus = read_sintle(data, 6, 2)
+        self.spdef_bonus = read_sintle(data, 8, 2)
+    def to_bytes(self):
+        mevo_data = bytearray(MEVO_STATS_LENGTH)
+        write_sintle(mevo_data, self.hp_bonus, 0, 2)
+        write_sintle(mevo_data, self.atk_bonus, 2, 2)
+        write_sintle(mevo_data, self.spatk_bonus, 4, 2)
+        write_sintle(mevo_data, self.def_bonus, 6, 2)
+        write_sintle(mevo_data, self.spdef_bonus, 8, 2)
+        return mevo_data
+
+
+class MdEvo(AutoString):
+    def __init__(self, data: bytes):
+        if not isinstance(data, memoryview):
+            data = memoryview(data)
+        limit = read_uintle(data, 0, 4)
+        self.evo_entries = []
+        for x in range(4, limit, MEVO_ENTRY_LENGTH):
+            self.evo_entries.append(MdEvoEntry(data[x:x+MEVO_ENTRY_LENGTH]))
+        self.evo_stats = []
+        for x in range(limit, len(data), MEVO_STATS_LENGTH):
+            self.evo_stats.append(MdEvoStats(data[x:x+MEVO_STATS_LENGTH]))
+    
+    def __eq__(self, other):
+        if not isinstance(other, MdEvo):
+            return False
+        return self.evo_entries == other.evo_entries and \
+               self.evo_stats == other.evo_stats

--- a/skytemple_files/data/md_evo/writer.py
+++ b/skytemple_files/data/md_evo/writer.py
@@ -1,0 +1,37 @@
+"""Converts MdEvo models back into the binary format used by the game"""
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Optional, Dict
+
+from skytemple_files.common.util import *
+from skytemple_files.data.md_evo import *
+from skytemple_files.data.md_evo.model import MdEvo
+
+
+class MdEvoWriter:
+    def __init__(self, model: MdEvo):
+        self.model = model
+
+    def write(self) -> bytes:
+        file_data = bytearray(4)
+        write_uintle(file_data, len(self.model.evo_entries)*MEVO_ENTRY_LENGTH+4, 0, 4)
+        
+        for x in self.model.evo_entries:
+            file_data += x.to_bytes()
+        for x in self.model.evo_stats:
+            file_data += x.to_bytes()
+        return bytes(file_data)

--- a/skytemple_files/patch/handler/change_evo.py
+++ b/skytemple_files/patch/handler/change_evo.py
@@ -1,0 +1,195 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable, Dict, List, Set
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU, GAME_REGION_JP
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler
+from skytemple_files.patch.asm_tools import AsmFunction
+from skytemple_files.common.i18n_util import _
+from skytemple_files.data.md.handler import MdHandler
+from skytemple_files.data.md.model import EvolutionMethod, AdditionalRequirement, Gender
+
+PATCH_CHECK_ADDR_APPLIED_US = 0x59B24
+PATCH_CHECK_ADDR_APPLIED_EU = 0x59EA0
+PATCH_CHECK_ADDR_APPLIED_JP = 0x59E20
+PATCH_CHECK_INSTR_APPLIED = 0xE1D960F4
+
+MEVO_PATH = "BALANCE/md_evo.bin"
+MEVO_ENTRY_LENGTH = 0x20
+MEVO_STATS_LENGTH = 0xA
+
+EVO_HP_BONUS_US = 0xA18C4
+EVO_HP_BONUS_EU = 0xA1E48
+EVO_HP_BONUS_JP = 0xA2C98
+EVO_PHYS_BONUS_US = 0xA18D0
+EVO_PHYS_BONUS_EU = 0xA1E54
+EVO_PHYS_BONUS_JP = 0xA2CA4
+EVO_SPEC_BONUS_US = 0xA18E4
+EVO_SPEC_BONUS_EU = 0xA1E68
+EVO_SPEC_BONUS_JP = 0xA2CB8
+
+MAX_TRY = 1000
+
+SPECIAL_EVOS = {462: [464],
+                463: [465],
+                1062: [1064],
+                1063: [1065],
+                1047: [450],
+                1048: [451],
+                1049: [452],
+                447: [453],
+                448: [453],
+                449: [453],
+                393: [394],
+                993: [994],
+                993: [520],
+                454: [],
+                1054: [455]}
+SPECIAL_EGGS = {379: [379],
+                380: [379],
+                381: [379],
+                382: [379],
+                979: [979],
+                980: [979],
+                981: [979],
+                982: [979],
+                460: [460],
+                461: [460],
+                1060: [1060],
+                1061: [1060],
+                455: [1054],
+                464: [462],
+                465: [463],
+                1064: [1062],
+                1065: [1063],
+                450: [1047],
+                451: [1048],
+                452: [1049],
+                453: [447,448,449]}
+class ChangeEvoSystemPatchHandler(AbstractPatchHandler):
+
+    @property
+    def name(self) -> str:
+        return 'ChangeEvoSystem'
+
+    @property
+    def description(self) -> str:
+        return _("""Change the evolution system.
+After applying this, every single Pokémon will have two lists for their evolution and children, and different stat bonuses when a Pokémon evolves into them.
+This supposedly removes most of the particular cases the game handles for evolutions. """)
+
+    @property
+    def author(self) -> str:
+        return 'irdkwia'
+
+    @property
+    def version(self) -> str:
+        return '0.0.1'
+    
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_US, 4)!=PATCH_CHECK_INSTR_APPLIED
+            if config.game_region == GAME_REGION_EU:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_EU, 4)!=PATCH_CHECK_INSTR_APPLIED
+            if config.game_region == GAME_REGION_JP:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_JP, 4)!=PATCH_CHECK_INSTR_APPLIED
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        if not self.is_applied(rom, config):
+            if config.game_version == GAME_VERSION_EOS:
+                if config.game_region == GAME_REGION_US:
+                    evo_hp_bonus = EVO_HP_BONUS_US
+                    evo_ph_bonus = EVO_PHYS_BONUS_US
+                    evo_sp_bonus = EVO_SPEC_BONUS_US
+                if config.game_region == GAME_REGION_EU:
+                    evo_hp_bonus = EVO_HP_BONUS_EU
+                    evo_ph_bonus = EVO_PHYS_BONUS_EU
+                    evo_sp_bonus = EVO_SPEC_BONUS_EU
+                if config.game_region == GAME_REGION_JP:
+                    evo_hp_bonus = EVO_HP_BONUS_JP
+                    evo_ph_bonus = EVO_PHYS_BONUS_JP
+                    evo_sp_bonus = EVO_SPEC_BONUS_JP
+            # Create Evo Table
+            md_bin = rom.getFileByName('BALANCE/monster.md')
+            md_model = MdHandler.deserialize(md_bin)
+
+
+            mevo_data = bytearray(len(md_model)*MEVO_ENTRY_LENGTH+4)
+            write_uintle(mevo_data, len(mevo_data), 0, 4)
+            for i in range(len(md_model)):
+                if i in SPECIAL_EVOS:
+                    next_stage = SPECIAL_EVOS[i]
+                else:
+                    next_stage = []
+                    for j,x in enumerate(md_model):
+                        if (i<600 and 1<=j<555) or (i>=600 and 601<=j<1155):
+                            if x.pre_evo_index==i and x.evo_method!=EvolutionMethod.NONE and (x.evo_param2!=AdditionalRequirement.MALE or i<600) and (x.evo_param2!=AdditionalRequirement.FEMALE or i>=600):
+                                next_stage.append(j)
+                write_uintle(mevo_data, len(next_stage), i*MEVO_ENTRY_LENGTH+4, 2)
+                for j,x in enumerate(next_stage):
+                    write_uintle(mevo_data, x, i*MEVO_ENTRY_LENGTH+j*2+6, 2)
+                if i in SPECIAL_EGGS:
+                    next_stage = SPECIAL_EGGS[i]
+                else:
+                    next_stage = []
+                    pre_evo = i
+                    tries = 0
+                    while md_model[pre_evo].pre_evo_index!=0:
+                        current = md_model[pre_evo]
+                        pre_evo = current.pre_evo_index
+                        if current.evo_param2==AdditionalRequirement.MALE and md_model[pre_evo%600].gender==Gender.MALE and md_model[pre_evo%600+600].gender==Gender.FEMALE:
+                            pre_evo = pre_evo%600
+                        elif current.evo_param2==AdditionalRequirement.FEMALE and md_model[pre_evo%600].gender==Gender.MALE and md_model[pre_evo%600+600].gender==Gender.FEMALE:
+                            pre_evo = pre_evo%600+600
+                        tries += 1
+                        if tries>=MAX_TRY:
+                            raise Exception(_("Infinite recursion detected in pre evolutions for md entry {i}. "))
+                    next_stage.append(pre_evo)
+                if next_stage!=[i]:
+                    write_uintle(mevo_data, len(next_stage), i*MEVO_ENTRY_LENGTH+0x16, 2)
+                    for j,x in enumerate(next_stage):
+                        write_uintle(mevo_data, x, i*MEVO_ENTRY_LENGTH+j*2+0x18, 2)
+            
+            hp_bonus = read_uintle(rom.arm9, evo_hp_bonus, 4)
+            atk_bonus = read_uintle(rom.arm9, evo_ph_bonus, 2)
+            def_bonus = read_uintle(rom.arm9, evo_ph_bonus+2, 2)
+            spatk_bonus = read_uintle(rom.arm9, evo_sp_bonus, 2)
+            spdef_bonus = read_uintle(rom.arm9, evo_sp_bonus+2, 2)
+            evo_add_stats = bytearray(MEVO_STATS_LENGTH)
+            write_uintle(evo_add_stats, hp_bonus, 0, 2)
+            write_uintle(evo_add_stats, atk_bonus, 2, 2)
+            write_uintle(evo_add_stats, spatk_bonus, 4, 2)
+            write_uintle(evo_add_stats, def_bonus, 6, 2)
+            write_uintle(evo_add_stats, spdef_bonus, 8, 2)
+            mevo_data += evo_add_stats*len(md_model)
+            if MEVO_PATH not in rom.filenames:
+                create_file_in_rom(rom, MEVO_PATH, mevo_data)
+            else:
+                rom.setFileByName(MEVO_PATH, mevo_data)
+        try:
+            apply()
+        except RuntimeError as ex:
+            raise ex
+
+    
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/handler/change_evo.py
+++ b/skytemple_files/patch/handler/change_evo.py
@@ -20,6 +20,7 @@ from ndspy.rom import NintendoDSRom
 
 from skytemple_files.common.util import *
 from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU, GAME_REGION_JP
+from skytemple_files.patch.category import PatchCategory
 from skytemple_files.patch.handler.abstract import AbstractPatchHandler
 from skytemple_files.patch.asm_tools import AsmFunction
 from skytemple_files.common.i18n_util import _
@@ -102,6 +103,10 @@ This supposedly removes most of the particular cases the game handles for evolut
     @property
     def version(self) -> str:
         return '0.0.1'
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.UTILITY
     
     def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
         if config.game_version == GAME_VERSION_EOS:

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -55,6 +55,7 @@ from skytemple_files.patch.handler.extract_move_code import ExtractMoveCodePatch
 from skytemple_files.patch.handler.extract_item_code import ExtractItemCodePatchHandler
 from skytemple_files.patch.handler.extract_sp_code import ExtractSPCodePatchHandler
 from skytemple_files.patch.handler.stat_disp import ChangeMoveStatDisplayPatchHandler
+from skytemple_files.patch.handler.change_evo import ChangeEvoSystemPatchHandler
 from skytemple_files.common.i18n_util import f, _
 
 CORE_PATCHES_BASE_DIR = os.path.join(get_resources_dir(), 'patches')
@@ -82,6 +83,7 @@ class PatchType(Enum):
     EXTRACT_ITEM_CODE = ExtractItemCodePatchHandler
     EXTRACT_SP_CODE = ExtractSPCodePatchHandler
     STAT_DISP = ChangeMoveStatDisplayPatchHandler
+    CHANGE_EVO_SYSTEM = ChangeEvoSystemPatchHandler
     ADD_TYPES = AddTypePatchHandler
     IMPLEMENT_FAIRY_GUMMIES = ImplementFairyGummiesPatchHandler
     EXTRACT_BAR_LIST = ExtractBarItemListPatchHandler


### PR DESCRIPTION
This patch changes how the game handles evolution. 

Creates two lists for each Pokémon: one that tells what it can evolve into and what Pokémon it has for children (important for eggs). This eliminates some particular cases the game normally handles to know that.
Also gives the possibility to set individual stat bonuses for each Pokémon when it evolved (stats bonuses are the ones from the Pokémon you evolved into).