### PR TITLE
Extend the Number of Pokémon entries

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/fs_mappa_edited.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/fs_mappa_edited.asm
@@ -1,0 +1,650 @@
+; For use with ARMIPS
+; 2021/04/14
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Use filestreams to partially load mappa files instead of loading entirely
+; ------------------------------------------------------------------------------
+
+;0x3C - 0x44 = Moves
+;0x50 - 0x98 = Filestream
+;0x98 - 0xAC = Header
+;0xAC - 0xC0 = Lists
+
+.org LoadMappaFileAttributes
+.area 0xA74
+	stmdb  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r14}
+	sub  r13,r13,#0xC0
+	ldr r3,=DungeonBaseStructurePtr
+	ldr r4,=DungeonAuxilaryStructurePtr
+	ldr r9,[r3, #+0x0]
+	ldr r7,[r4, #+0xc]
+	ldr r8,[r4, #+0x8]
+	add  r3,r9,#0x4A
+	str r1,[r13, #+0x0]
+	add  r4,r9,#0x348
+	mov  r5,r0
+	add  r1,r4,#0x400
+	add  r0,r3,#0x700
+	mov  r4,r2
+	str r8,[r13, #+0x48]
+	str r7,[r13, #+0x4c]
+	bl TransformDungeonData
+	ldrb r2,[r9, #+0x74a]
+	add  r0,r9,#0x28000
+	strb r2,[r0, #+0x6b0]
+	ldrb r2,[r9, #+0x74b]
+	strb r2,[r0, #+0x6b1]
+	ldrb r0,[r9, #+0x748]
+	bl GetNbPreviousFloors
+	mov  r6,#0x0
+	strh r0,[r9, #+0x20]
+	strh r6,[r9, #+0x1e]
+	ldrsh r2,[r9, #+0x20]
+	ldrsh r0,[r9, #+0x1e]
+	add  r0,r2,r0
+	strh r0,[r3, #+0x22]
+	str r6,[r13, #+0x28]
+	bl FStreamAlloc
+	add r0,r13,#0x50
+	bl FStreamCtor
+	ldr r0,[r9, #+0x7cc]
+	cmp r0,#0x1
+	ldreq r1,=TimeFilename
+	beq load
+	cmp r0,#0x2
+	ldreq r1,=DarknessFilename
+	ldrne r1,=SkyFilename
+load:
+	add r0,r13,#0x50
+	bl FStreamFOpen
+	bl FStreamDealloc
+	add r0,r13,#0x50
+	mov r1,#0x4
+	add r2,r13,#0x98
+	mov r3,#0x4
+	bl ReadAt
+	add r0,r13,#0x50
+	ldr r1,[r13,#+0x98]
+	add r2,r13,#0x98
+	mov r3,#0x14
+	bl ReadAt
+	ldr r1,[r13,#+0x98] ; Header + 0x0
+	add  r0,r9,#0x28000
+	ldrb r3,[r0, #+0x6b0]
+	ldrb r6,[r0, #+0x6b1]
+	add r0,r13,#0x50
+	add r1,r3,lsl #0x2
+	add r2,r13,#0xAC
+	mov r3,#0x4
+	bl ReadAt
+	mov  r3,#0x12
+	add r0,r13,#0x50
+	ldr r1,[r13,#+0xac]
+	mla  r1,r6,r3,r1
+	add r2,r13,#0xAC
+	bl ReadAt
+	ldrb r0,[r9, #+0x748]
+	bl GetNbFloorsPlus1
+	add  r1,r9,#0x2C000
+	strb r0,[r1, #+0xaf4]
+	ldrb r0,[r9, #+0x748]
+	cmp r0,#0xAE
+	moveq  r0,#0x1
+	movne  r0,#0x0
+	tst r0,#0xFF
+	beq no_decrement
+	bl UnknownMissionFunc
+	cmp r0,#0x0
+	bne no_decrement
+	add  r0,r9,#0x2C000
+	ldrb r1,[r0, #+0xaf4]
+	sub  r1,r1,#0x1
+	strb r1,[r0, #+0xaf4]
+no_decrement: ;///////// Floor Attributes
+	ldrsh r2,[r13,#+0xac] ; List + 0x0
+	ldr r3,[r13,#+0x9c] ; Header + 0x4
+	add  r1,r3,r2,lsl #0x5
+	ldr r0,=0x000286B2
+	add  r2,r9,r0
+	mov  r3,#0x20
+	add r0,r13,#0x50
+	bl ReadAt
+	;///////// End Floor Attributes
+	;///////// Trap Attributes
+	ldr r2,=0x000286CE
+	ldr r3,=0x0002CB08
+	ldrsh r7,[r9, r2]
+	mov  r0,#0x0
+	strh r7,[r9, r3]
+	rsb  r8,r2,#0x55000
+	add r0,r13,#0x50
+	ldrsh r7,[r13,#+0xb0] ; List + 0x4
+	ldr  r1,[r13,#+0xa8] ; header + 0x10
+	add r1,r1,r7,lsl #0x2
+	add r2,r9,r8
+	add r2,r2,#2
+	mov r3,#0x4
+	bl ReadAt
+	add r0,r13,#0x50
+	add r1,r8,#2
+	ldr r1,[r9,r1]
+	add r2,r9,r8
+	mov r3,#0x32
+	bl ReadAt
+	cmp r4,#0x0
+	beq no_spec_process
+	mov  r0,r5
+	blx r4
+	;///////// End Trap Attributes
+no_spec_process:
+	ldrsh r0,[r13,#+0xae] ; List + 0x2
+	ldr r1,[r13,#+0xa4] ; Header + 0xc
+	add r1,r1,r0,lsl #0x2
+	add r0,r13,#0x50
+	add r2,r13,#0x8
+	mov r3,#0x4
+	bl ReadAt
+	ldr r6,[r13, #+0x8]
+	cmp r5,#0x0
+	bne quick_saved
+	ldr r0,=DungeonAuxilaryStructurePtr
+	mov  r4,#0x0
+	ldrh r2,[r0, #+0x0]
+	ldrh r1,[r0, #+0x2]
+	mov  r0,r4
+	mov  r8,r4
+	str r4,[r13, #+0xc]
+	str r4,[r13, #+0x4]
+	strh r2,[r13, #+0x44]
+	strh r1,[r13, #+0x46]
+	mov  r11,#0x1
+	bl UnknownFunc1
+	bl UnknownFunc2
+	str r0,[r13, #+0x10]
+	ldr r3,=0x0000FFFF
+	ldr r0,=0x0002C9EA
+	mov  r5,r4
+loop_init_store:
+	add  r2,r9,r5,lsl #0x1
+	strh r3,[r2, r0]
+	add  r5,r5,#0x1
+	cmp r5,#0x10
+	blt loop_init_store
+	bl IsItemForSpecialSpawnInBag
+	cmp r0,#0x0
+	movne  r0,#0x1
+	strne r0,[r13, #+0x4]
+	ldrb r0,[r9, #+0x748]
+	bl IsDojoDungeon
+	cmp r0,#0x0
+	movne  r0,#0x1
+	strne r0,[r13, #+0x4]
+	ldr r0,=NbIndepEntries*2
+	mov  r1,#0xF
+	bl MemAlloc
+	str r0,[r13, #+0x18]
+	bl GetNbRecruited
+	mov  r0,#0x100
+	mov  r1,#0xF
+	bl MemAlloc
+	mov  r7,r0
+	ldr r0,=0x00000229
+	mov  r10,#0x0
+	sub  r0,r0,#0xAA
+	str r0,[r13, #+0x20]
+	ldr r0,=0x00000229 
+	rsb  r0,r0,#0x600
+	str r0,[r13, #+0x24]
+monster_loop:
+	mov  r0,#0x0
+	str r0,[r13, #+0x8]
+	add r0,r13,#0x50
+	add r1,r6,r10,lsl #0x3
+	add r2,r13,#0x3C
+	mov r3,#0x8
+	bl ReadAt
+	add r0,r13,#0x3C
+	bl ModMonster
+	movs r5,r0
+	beq monster_entry_null
+	ldr r1,=0x00000229
+	cmp r5,r1
+	streqh r10,[r13, #+0x44]
+	beq end_monster_loop
+	ldr r1,[r13, #+0x20]
+	cmp r5,r1
+	ldrne r1,[r13, #+0x24]
+	cmpne r5,r1
+	streqh r10,[r13, #+0x46]
+	beq end_monster_loop
+	bl CanMonsterSpawn
+	cmp r0,#0x0
+	addeq  r10,r10,#0x1
+	beq monster_loop
+	add  r0,r9,#0x28000
+	ldrb r0,[r0, #+0x6c4]
+	bl IsBossFight
+	cmp r0,#0x0
+	bne end_monster_loop
+	mov  r0,r5
+	bl IsSatisfyingScenarioConditionToSpawn
+	cmp r0,#0x0
+	beq end_monster_loop
+	mov  r0,r5
+	bl NeedItemToSpawn
+	cmp r0,#0x0
+	beq need_item
+	mov  r1,r5
+	add  r0,r9,#0x7D0
+	bl IsInSpawnList
+	cmp r0,#0x0
+	ldreq r0,[r13, #+0x10]
+	cmpeq r0,#0x0
+	ldreq r0,[r13, #+0x18]
+	moveq  r1,r5,lsl #0x1
+	ldreqsh r0,[r0, r1]
+	cmpeq r0,#0x0
+	bne end_monster_loop
+	ldr r0,[r13, #+0x4]
+	cmp r0,#0x0
+	beq end_monster_loop
+	mov  r8,r5
+	add r0,r13,#0x3C
+	bl GetSpawnLevel
+	and  r0,r0,#0xFF
+	str r0,[r13, #+0xc]
+	b end_monster_loop
+need_item:
+	mov  r0,#0x1
+	str r0,[r13, #+0x8]
+end_monster_loop:
+	ldr r0,[r13, #+0x8] ; Need Item to spawn
+	cmp r0,#0x0
+	strne r10,[r7,+r4, lsl #0x2]
+	addne  r4,r4,#0x1
+	add  r10,r10,#0x1
+	b monster_loop
+monster_entry_null:
+	add  r0,r9,#0x700
+	strh r8,[r0, #+0xa8]
+	mov  r0,#0x10
+	ldr r1,[r13, #+0xc]
+	strb r1,[r9, #+0x7aa]
+	bl RandMax
+	add  r0,r0,#0x1
+	str r0,[r13, #+0x14]
+	sub  r0,r4,#0x1
+	mov  r10,#0x0
+	str r0,[r13, #+0x1c]
+	b end_special_pkmn_loop
+special_pkmn_loop:
+	mov  r5,#0x0
+	b end_special_pkmn_inner_loop
+special_pkmn_inner_loop:
+	mov  r0,r4
+	bl RandMax
+	ldr r2,[r7,+r5, lsl #0x2]
+	ldr r1,[r7,+r0, lsl #0x2]
+	str r1,[r7,+r5, lsl #0x2]
+	str r2,[r7,+r0, lsl #0x2]
+	add  r5,r5,#0x1
+end_special_pkmn_inner_loop:
+	ldr r0,[r13, #+0x1c]
+	cmp r5,r0
+	blt special_pkmn_inner_loop
+	add  r10,r10,#0x1
+end_special_pkmn_loop:
+	ldr r0,[r13, #+0x14]
+	cmp r10,r0
+	blt special_pkmn_loop
+	ldr r0,[r13, #+0x0]
+	cmp r0,#0x0
+	movne  r4,#0x0
+	bne no_special_spawn
+	cmp r4,#0xE
+	movge  r4,#0xE
+no_special_spawn:
+	ldr r0,=0x00000229
+	bl GetSpriteFileSize
+	add  r5,r0,#0x0
+	ldr r0,=0x0000017F
+	bl GetSpriteFileSize
+	ldr r1,[r13, #+0x10]
+	add  r5,r5,r0
+	cmp r1,#0x0
+	beq special_file_size
+	bl UnknownGetSize
+	add  r5,r5,r0
+	b no_compute_special_pokemon_size
+special_file_size:
+	cmp r8,#0x0
+	beq no_compute_special_pokemon_size
+	mov  r0,r8
+	bl GetSpriteFileSize
+	add  r5,r5,r0
+no_compute_special_pokemon_size:
+	mov  r8,#0x0
+	b end_compute_file_size_loop
+compute_file_size_loop:
+	ldr r2,[r7,+r8, lsl #0x2]
+	add  r1,r9,r8,lsl #0x1
+	ldr r0,=0x0002C9EA
+	strh r2,[r1, r0]
+	ldr r0,[r7,+r8, lsl #0x2]
+	add r1,r6,r0,lsl #0x3
+	add r0,r13,#0x50
+	add r2,r13,#0x3C
+	mov r3,#0x8
+	bl ReadAt
+	add  r0,r13,#0x3C
+	bl ModMonster
+	mov  r10,r0
+	add  r0,r13,#0x3C
+	bl GetSpawnLevel
+	cmp r11,r0
+	movlt  r11,r0
+	mov  r0,r10
+	bl GetTotalSpriteFileSize
+	add  r5,r5,r0
+	add  r8,r8,#0x1
+end_compute_file_size_loop:
+	cmp r8,r4
+	blt compute_file_size_loop
+	ldr r1,=0x0002C9E6
+	cmp r5,#0x58000
+	strh r11,[r9, r1]
+	bls total_file_size_ok
+	sub  r10,r4,#0x1
+	mov  r8,#0x0
+	add  r11,r1,#0x4
+	b end_reduce_total_file_size_loop
+reduce_total_file_size_loop:
+	ldr r0,[r7,+r10, lsl #0x2]
+	add r1,r6,r0,lsl #0x3
+	add r0,r13,#0x50
+	add r2,r13,#0x34
+	mov r3,#0x8
+	bl ReadAt
+	add  r0,r13,#0x34
+	bl ModMonster
+	bl GetTotalSpriteFileSize
+	sub  r5,r5,r0
+	ldr r0,=0x0000FFFF
+	cmp r5,#0x58000
+	add  r1,r9,r10,lsl #0x1
+	strh r0,[r1, r11]
+	add  r8,r8,#0x1
+	bcc total_file_size_reduced
+	sub  r10,r10,#0x1
+end_reduce_total_file_size_loop:
+	cmp r10,#0x0
+	bge reduce_total_file_size_loop
+total_file_size_reduced:
+	sub  r4,r4,r8
+total_file_size_ok:
+	ldrh r2,[r13, #+0x44]
+	ldr r0,=0x0000FFFF
+	cmp r2,r0
+	beq no_statue
+	ldr r0,=0x0002C9EA
+	add  r1,r9,r4,lsl #0x1
+	strh r2,[r1, r0]
+	add  r4,r4,#0x1
+no_statue:
+	ldrh r2,[r13, #+0x46]
+	ldr r0,=0x0000FFFF
+	cmp r2,r0
+	ldrne r0,=0x0002C9EA
+	addne  r1,r9,r4,lsl #0x1
+	strneh r2,[r1, r0]
+	ldr r2,=0x0002C9EA
+	mov  r1,#0x0
+loop_sort_pkmn_id:
+	mov  r0,r1
+	b end_inner_loop_sort_pkmn_id
+inner_loop_sort_pkmn_id:
+	add  r5,r9,r0,lsl #0x1
+	add  r4,r9,r1,lsl #0x1
+	ldrh r8,[r5, r2]
+	ldrh r5,[r4, r2]
+	cmp r5,r8
+	strhih r8,[r4, r2]
+	addhi  r4,r9,r0,lsl #0x1
+	strhih r5,[r4, r2]
+	add  r0,r0,#0x1
+end_inner_loop_sort_pkmn_id:
+	cmp r0,#0x10
+	blt inner_loop_sort_pkmn_id
+	add  r1,r1,#0x1
+	cmp r1,#0xF
+	blt loop_sort_pkmn_id
+	ldr r0,[r13, #+0x18]
+	bl MemFree
+	mov  r0,r7
+	bl MemFree
+	bl UnknownFunc3
+quick_saved:
+	mov  r5,#0x0
+	ldrb r0,[r9, #+0x748]
+	mov  r8,r5
+	bl UnknownFunc4
+	cmp r0,#0x0
+	beq label_46
+	mov  r0,#0xB
+	bl UnknownFunc5
+	cmp r0,#0x0
+	bne label_45
+	mov  r0,#0xA
+	bl UnknownFunc5
+	cmp r0,#0x0
+	beq label_46
+label_45:
+	mov  r5,#0x1
+label_46:
+	mov  r10,#0x0
+	b end_copy_spawn_entry_loop
+copy_spawn_entry_loop:
+	ldr r0,=0x0002C9EA
+	ldr r1,=0x0000FFFF
+	add  r2,r9,r10,lsl #0x1
+	ldrh r3,[r2, r0]
+	cmp r3,r1
+	beq break_copy_spawn_entry
+	add r1,r6,r3,lsl #0x3
+	add r0,r13,#0x50
+	add r2,r13,#0x2C
+	mov r3,#0x8
+	bl ReadAt
+	add  r0,r13,#0x2C
+	bl ModMonster
+	cmp r5,#0x0
+	ldrne r2,=0x00000229
+	cmpne r0,r2
+	subne  r1,r2,#0xAA
+	cmpne r0,r1
+	rsbne  r1,r2,#0x600
+	cmpne r0,r1
+	bne no_copy_spawn_entry
+	add  r7,r13,#0x2C
+	mov  r2,#0x4
+	add  r1,r9,r8,lsl #0x3
+	add  r1,r1,#0x164
+	add  r3,r1,#0x2C800
+copy_monster_spawn_loop:
+	ldrh r1,[r7],#+0x2
+	subs r2,r2,#0x1
+	strh r1,[r3],#+0x2
+	bne copy_monster_spawn_loop
+	add  r8,r8,#0x1
+no_copy_spawn_entry:
+	add  r10,r10,#0x1
+end_copy_spawn_entry_loop:
+	cmp r10,#0x10
+	blt copy_spawn_entry_loop
+break_copy_spawn_entry:
+	bl IsFixedFloor
+	cmp r0,#0x0
+	beq no_fixed_floor
+	ldr r3,=0x0002C9E6
+	rsb  r1,r8,#0x10
+	add  r2,r9,#0x4000
+	add  r0,r9,#0x164
+	add  r0,r0,#0x2C800
+	ldrb r2,[r2, #+0xda]
+	ldrsh r3,[r9, r3]
+	add  r0,r0,r8,lsl #0x3
+	bl UnknownFunc6
+	add  r1,r9,#0x12000
+	str r0,[r1, #+0xb20]
+	add  r0,r9,#0x12000
+	ldr r0,[r0, #+0xb20]
+	add  r8,r8,r0
+no_fixed_floor:
+	ldr r0,=0x0002C9E4
+	mov  r5,#0x0
+	strh r8,[r9, r0]
+	b end_nullify_spawn_entry_loop
+nullify_spawn_entry_loop:
+	mov  r1,r5
+	add  r0,r9,#0x164
+	add  r0,r0,#0x2C800
+	add  r0,r0,r8,lsl #0x3
+	bl StoreMonsterID
+	add  r8,r8,#0x1
+end_nullify_spawn_entry_loop:
+	cmp r8,#0x10
+	blt nullify_spawn_entry_loop
+	mov  r0,#0xB10
+	mov  r1,#0x0
+	bl MemAlloc
+	mov r6,r0
+	ldr r1,=0x0002C9E8
+	mov  r4,#0x0
+	strh r4,[r9, r1]
+all_item_lists_loop:
+	; //////// Handle Item lists
+	add  r1,r13,r4,lsl #0x1
+	ldrsh r2,[r1, #+0xb2] ; List + 0x6 + ???
+	ldr r5,[r13,#+0xa0] ; Header + 0x8
+	add r1,r5,r2,lsl #0x2
+	add r0,r13,#0x50
+	add r2,r13,#0x2C
+	mov r3,#0x4
+	bl ReadAt
+	bl FStreamAlloc
+	add r0,r13,#0x50
+	ldr r1,[r13,#+0x2c]
+	mov r2,#0
+	bl FStreamSeek
+	mov  r1,#0x0
+	ldr r5,=0xFFFF8AD0
+	mov  r8,r1
+	mov  r10,r1
+	rsb  r7,r5,#0x0
+	b end_item_load_loop
+item_load_loop:
+	add r0,r13,#0x50
+	add r1,r13,#0x2C
+	mov r2,#2
+	bl FStreamRead
+	ldrh r11,[r13,#+0x2c]
+	cmp r11,r5,lsr #0x10
+	moveq  r0,r8,lsl #0x1
+	streqh r11,[r6, r0]
+	addeq  r8,r8,#0x1
+	beq end_item_load_loop
+	cmp r11,r7
+	bcc single_value_item
+	add  r11,r11,r5
+	b end_multiple_zeros_item_loop
+multiple_zeros_item_loop:
+	mov  r0,r8,lsl #0x1
+	strh r10,[r6, r0]
+	add  r8,r8,#0x1
+	sub  r11,r11,#0x1
+end_multiple_zeros_item_loop:
+	cmp r11,#0x0
+	bne multiple_zeros_item_loop
+	b end_item_load_loop
+single_value_item:
+	mov  r0,r8,lsl #0x1
+	strh r11,[r6, r0]
+	add  r8,r8,#0x1
+end_item_load_loop:
+	cmp r8,#0x17C
+	blt item_load_loop
+	; ////////// End Handle Item Lists
+	bl FStreamDealloc
+	mov  r1,#0xB10
+	mul  r1,r4,r1
+	mov  r2,#0x0
+	ldr r5,=0x000286D2
+	mov  r3,r2
+loop_copy_item_cat_chances:
+	mov  r10,r2,lsl #0x1
+	ldrh r10,[r6, r10]
+	add  r8,r1,r9
+	add  r8,r8,r2,lsl #0x1
+	add  r3,r3,#0x1
+	strh r10,[r8, r5]
+	cmp r3,#0x10
+	add  r2,r2,#0x1
+	blt loop_copy_item_cat_chances
+	ldr r5,=0x000286F2
+	mov  r3,#0x0
+loop_copy_item_chances:
+	mov  r10,r2,lsl #0x1
+	ldrh r10,[r6, r10]
+	add  r8,r1,r9
+	add  r8,r8,r3,lsl #0x1
+	add  r3,r3,#0x1
+	strh r10,[r8, r5]
+	cmp r3,#0x16C
+	add  r2,r2,#0x1
+	blt loop_copy_item_chances
+	add  r4,r4,#0x1
+	cmp r4,#0x6
+	blt all_item_lists_loop
+	mov  r8,#0x0
+	ldr r2,=0x000286F2
+	ldr r1,=0x0002C9E8
+	ldr r3,=0x0000FFFF
+	mov  r0,r8
+loop_copy_normal_item_chances:
+	add  r7,r9,r8,lsl #0x1
+	ldrh r5,[r7, r2]
+	cmp r5,r3
+	streqh r0,[r7, r2]
+	ldreq r5,[r4, #+0x0]
+	streqh r8,[r5, r1]
+	add  r8,r8,#0x1
+	cmp r8,#0x16C
+	blt loop_copy_normal_item_chances
+	mov r0,r6
+	bl MemFree
+	bl FStreamAlloc
+	add r0,r13,#0x50
+	bl FStreamClose
+	bl FStreamDealloc
+	add  r13,r13,#0xC0
+	ldmia  r13!,{r3,r4,r5,r6,r7,r8,r9,r10,r11,r15}
+	.pool
+ReadAt: ;ReadAt(r0: fstream, r1: start, r2: buffer, r3: offset)
+	stmdb  r13!,{r4,r5,r6,r7,r14}
+	mov r4,r0
+	mov r7,r1
+	mov r5,r2
+	mov r6,r3
+	bl FStreamAlloc
+	mov r0,r4
+	mov r1,r7
+	mov r2,#0
+	bl FStreamSeek
+	mov r0,r4
+	mov r1,r5
+	mov r2,r6
+	bl FStreamRead
+	bl FStreamDealloc
+	ldmia  r13!,{r4,r5,r6,r7,r15}
+	.fill (LoadMappaFileAttributes+0xA74-.), 0xCC
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/fs_mappa_edited.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/fs_mappa_edited.asm
@@ -457,14 +457,21 @@ copy_spawn_entry_loop:
 	bl ReadAt
 	add  r0,r13,#0x2C
 	bl ModMonster
+	ldr r2,=0x00000229
+	cmp r0,r2
+	beq no_kecleon
+	sub  r1,r2,#0xAA
+	cmp r0,r1
+	beq kecleon
+	rsb  r1,r2,#0x600
+	cmp r0,r1
+	beq kecleon
 	cmp r5,#0x0
-	ldrne r2,=0x00000229
-	cmpne r0,r2
-	subne  r1,r2,#0xAA
-	cmpne r0,r1
-	rsbne  r1,r2,#0x600
-	cmpne r0,r1
 	bne no_copy_spawn_entry
+	b no_kecleon
+kecleon:
+	bl SetKecleonEntryForFloor
+no_kecleon:
 	add  r7,r13,#0x2C
 	mov  r2,#0x4
 	add  r1,r9,r8,lsl #0x3

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_arm9.asm
@@ -1,5 +1,27 @@
 ; ///////////////////////// arm9.bin
 
+; Change Mission Available Pokemons
+
+.org HookMissionGeneratePossiblePokemonList1
+.area 0x4
+	mov r0,NbIndepEntries*2
+.endarea
+.org HookMissionGeneratePossiblePokemonList2
+.area 0x4
+	cmp r6,NbIndepEntries
+.endarea
+
+; Change Max Count for Pokédex / Special Log
+
+.org HookLimitSearchSpecialLog
+.area 0x4
+	.word NbIndepEntries
+.endarea
+.org HookPokedexMax
+.area 0x4
+	.word PokedexMax
+.endarea
+
 ; Change Exclusive Items Check
 
 .org HookExclusiveItemCheck

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_arm9.asm
@@ -1,0 +1,304 @@
+; ///////////////////////// arm9.bin
+
+; //// TODO LIST
+; 0x02050244: Adventure Log Special Pokémon
+; ////
+
+; Change sort by name
+
+.org HookN2MSearch
+.area 0x6C
+	cmp r0,#0x0
+	movlt  r0,#0x0
+	bxlt r14
+	ldr r2,=MonsterFilePtr
+	ldr r2,[r2, #+0x14]
+	mov r0,r0,lsl #0x1
+	ldrsh r0,[r2,r0]
+	bx r14
+	.pool
+	.fill (HookN2MSearch+0x6C-.), 0xCC
+.endarea
+
+.org HookN2MSearchBase
+.area 0x1C
+	cmp r0,#0x0
+	bge n2m_base_continue
+	mov  r0,#0x0
+	ldmia  r13!,{r3,r15}
+	.fill 0xC, 0xCC
+n2m_base_continue:
+.endarea
+
+.org HookM2NSearch
+.area 0x6C
+	cmp r0,#0x0
+	movlt r0,#0x0
+	ldr r1,=MonsterFilePtr
+	ldr r3,[r1, #+0x1C]
+	mov r0,r0,lsl #0x1
+	ldrsh r0,[r3,r0]
+	bx r14
+	.pool
+	.fill (HookM2NSearch+0x6C-.), 0xCC
+.endarea
+
+.org HookM2NSearchBase
+.area 0x28
+	cmp r0,#0x0
+	movlt r0,#0x0
+	b m2n_base_continue
+	.fill 0x1C, 0xCC
+m2n_base_continue:
+.endarea
+
+; Change sort by Dex Number
+
+.org HookSortNb1
+.area 0x4
+	bl GetDexNb
+.endarea
+.org HookSortNb2
+.area 0x4
+	bl GetDexNb
+.endarea
+
+; ModMonster
+
+.org HookModMonster
+.area 0x4
+	.word NbIndepEntries
+.endarea
+
+; Invalid Movesets
+
+.org IsInvalidMoveset
+.area 0x28
+	cmp r0,#0x0
+	ble below_lower_bound
+	ldr r1,=NbIndepEntries
+	cmp r0,r1
+	blt below_upper_bound
+below_lower_bound:
+	mov  r0,#0x1
+	bx r14
+below_upper_bound:
+	mov  r0,#0x0
+	bx r14
+	.pool
+.endarea
+.org IsInvalidMovesetEgg
+.area 0x4
+	.word NbIndepEntries
+.endarea
+
+; Lists
+
+.org HookListForDungeon
+.area 0x4
+	.word NbIndepEntries*2
+.endarea
+
+; Swap Entries
+
+.org IsValid
+.area 0x5C
+	cmp r0,#0x0
+	movle  r0,#0x0
+	movgt  r0,#0x1
+	bx r14
+	.fill 0x4C, 0xCC
+.endarea
+.org GetSecondFormIfValid
+.area 0x3C
+	bx r14
+	.fill 0x38, 0xCC
+.endarea
+.org GetFirstFormIfValid
+.area 0x44
+	bx r14
+	.fill 0x40, 0xCC
+.endarea
+
+
+; Moves
+
+; Change GetMovesetLevelUpPtr
+.org HookGetMovesetLevelUpPtr
+.area 0x10
+	nop
+	nop
+	nop
+	nop
+	;cmp r4,NbIndepEntries
+	;subge  r0,r4,NbIndepEntries
+	;movge  r0,r0,lsl #0x10
+	;movge  r4,r0,asr #0x10
+.endarea
+
+; Change GetMovesetHMTMPtr
+.org HookGetMovesetHMTMPtr
+.area 0x10
+	nop
+	nop
+	nop
+	nop
+	;cmp r4,NbIndepEntries
+	;subge  r0,r4,NbIndepEntries
+	;movge  r0,r0,lsl #0x10
+	;movge  r4,r0,asr #0x10
+.endarea
+
+
+; Change GetMovesetEggPtr
+.org HookGetMovesetEggPtr
+.area 0x10
+	nop
+	nop
+	nop
+	nop
+	;cmp r4,NbIndepEntries
+	;subge  r0,r4,NbIndepEntries
+	;movge  r0,r0,lsl #0x10
+	;movge  r4,r0,asr #0x10
+.endarea
+
+; Portraits
+
+.org HookPortrait1
+.area 0x4
+	cmp r7,#0x0
+.endarea
+.org HookPortrait2
+.area 0x4
+	ble HookPortrait3
+.endarea
+.org HookPortrait3
+.area 0x8
+	nop
+	nop
+.endarea
+.org HookPortrait4
+.area 0x4
+	bne HookPortrait1
+.endarea
+
+; Strings
+
+.org HookStringsPkmn1
+.area 0x8
+	add  r0,r1,Pkmn_StrID_L
+	add  r0,r0,Pkmn_StrID_H
+.endarea
+.org HookStringsPkmn2
+.area 0x8
+	add  r0,r1,Pkmn_StrID_L
+	add  r0,r0,Pkmn_StrID_H
+.endarea
+.org HookStringsPkmn3
+.area 0x8
+	add  r0,r1,Pkmn_StrID_L
+	add  r0,r0,Pkmn_StrID_H
+.endarea
+.org HookStringsPkmn4
+.area 0x8
+	add  r0,r1,Pkmn_StrID_L
+	add  r0,r0,Pkmn_StrID_H
+.endarea
+.org HookStringsPkmn5
+.area 0x8
+	add  r0,r1,Pkmn_StrID_L
+	add  r0,r0,Pkmn_StrID_H
+.endarea
+.org HookStringsCate1
+.area 0x8
+	add  r0,r1,Cate_StrID_L
+	add  r0,r0,Cate_StrID_H
+.endarea
+
+; monster.md
+
+.org HookMdAccess1
+.area 0x8
+	mov r1,r0
+	nop
+.endarea
+
+.org HookMdAccess2
+.area 0xC
+	mov r1,r0
+	mov r4,r2
+	nop
+.endarea
+
+.org HookMdAccess3
+.area 0xC
+	mov r1,r0
+	mov r4,r2
+	nop
+.endarea
+
+.org HookMdAccess4
+.area 0x8
+	mov r1,r0
+	nop
+.endarea
+
+.org HookMdAccess5
+.area 0x8
+	mov r1,r0
+	nop
+.endarea
+
+.org HookMdAccess6
+.area 0x8
+	mov r1,r0
+	nop
+.endarea
+
+; Sprite Size in monster.md (0x2C)
+.org HookMdAccess7
+.area 0x38
+	ldr r2,=MonsterFilePtr
+	mov  r1,#0x44
+	ldr r2,[r2, #+0x0]
+	smlabb r0,r0,r1,r2
+	ldrb r0,[r0, #+0x2C]
+	cmp r0,#0x0
+	ldmeqia  r13!,{r3,r15}
+	cmp r0,#0x6
+	movls  r0,#0x6
+	ldmia  r13!,{r3,r15}
+	.pool
+.endarea
+
+; Sprite File Size in monster.md (0x2D)
+.org HookMdAccess8
+.area 0x20
+	ldr r2,=MonsterFilePtr
+	mov  r1,#0x44
+	ldr r2,[r2, #+0x0]
+	smlabb r0,r0,r1,r2
+	ldrb r0,[r0, #+0x2D]
+	mov  r0,r0,lsl #0x9
+	bx r14
+	.pool
+.endarea
+
+.org HookMdAccess9
+.area 0xC
+	mov r1,r0
+	mov r4,r2
+	nop
+.endarea
+
+.org HookMdAccess10
+.area 0x8
+	mov r1,r0
+	nop
+.endarea
+
+; evolution possibilities
+
+; TODO: Different Implementation
+

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_arm9.asm
@@ -116,8 +116,14 @@ below_upper_bound:
 .endarea
 .org GetFirstFormIfValid
 .area 0x44
+	ldr r2,=MonsterFilePtr
+	mov  r1,#0x44
+	ldr r2,[r2, #+0x0]
+	smlabb r0,r0,r1,r2
+	ldrsh r0,[r0, #+0x0]
 	bx r14
-	.fill 0x40, 0xCC
+	.pool
+	.fill (GetFirstFormIfValid+0x44-.), 0xCC
 .endarea
 
 

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_arm9.asm
@@ -1,5 +1,117 @@
 ; ///////////////////////// arm9.bin
 
+; Change Mission And Spinda Bar Lists
+
+.org HookMissionPkmnLimit1
+.area 0x4
+	.word NbIndepEntries
+.endarea
+
+.org HookMissionPkmnLimit2
+.area 0x4
+	.word NbIndepEntries
+.endarea
+
+.org IsPkmnIDNotInMFList
+.area 0x44
+	stmdb  r13!,{r14}
+	bl IsMFPkmn
+	cmp r0, #0
+	moveq  r0,#0x1
+	movne  r0,#0x0
+	ldmia  r13!,{r15}
+	.pool
+	.fill (IsPkmnIDNotInMFList+0x44-.), 0xCC
+.endarea
+
+.org IsPkmnIDNotStoryForbidden
+.area 0x80
+	stmdb  r13!,{r4,r5,r14}
+	mov  r4,r0
+	bl GetFirstFormIfValid
+	mov  r5,r0
+	mov  r0,#0x9
+	bl GetPerformanceFlagWithChecks
+	cmp r0,#0x0
+	bne out_of_story
+	mov  r0,r4
+	bl IsSFPkmn
+	cmp r0,#0
+	movne  r0,#0x0
+	ldmneia  r13!,{r4,r5,r15}
+	bl GetPlayerPkmnStr
+	ldrsh r0,[r0, #+0x4]
+	bl GetFirstFormIfValid
+	cmp r5,r0
+	moveq  r0,#0x0
+	ldmeqia  r13!,{r4,r5,r15}
+	bl GetPartnerPkmnStr
+	ldrsh r0,[r0, #+0x4]
+	bl GetFirstFormIfValid
+	cmp r5,r0
+	moveq  r0,#0x0
+	ldmeqia  r13!,{r4,r5,r15}
+out_of_story:
+	mov  r0,#0x1
+	ldmia  r13!,{r4,r5,r15}
+	.pool
+	.fill (IsPkmnIDNotStoryForbidden+0x80-.), 0xCC
+.endarea
+
+.org PkmnIDMissionForbiddenList
+.area 0xF8
+IsSFPkmn:
+	ldr r2,=MonsterFilePtr
+	mov  r1,#0x44
+	ldr r2,[r2, #+0x0]
+	smlabb r0,r0,r1,r2
+	ldrb r0,[r0, #+0x1a]
+	tst r0,#0x8
+	movne  r0,#0x1
+	moveq  r0,#0x0
+	bx r14
+	.pool
+IsMFPkmn:
+	ldr r2,=MonsterFilePtr
+	mov  r1,#0x44
+	ldr r2,[r2, #+0x0]
+	smlabb r0,r0,r1,r2
+	ldrb r0,[r0, #+0x1a]
+	tst r0,#0x4
+	movne  r0,#0x1
+	moveq  r0,#0x0
+	bx r14
+	.pool
+IsSpecialSpindaNormalRecruitPkmn:
+	ldr r2,=MonsterFilePtr
+	mov  r1,#0x44
+	ldr r2,[r2, #+0x0]
+	smlabb r0,r0,r1,r2
+	ldrb r0,[r0, #+0x1a]
+	tst r0,#0x2
+	movne  r0,#0x1
+	moveq  r0,#0x0
+	bx r14
+	.pool
+	.fill (PkmnIDMissionForbiddenList+0xF8-.), 0xCC
+.endarea
+
+.org StoryForbiddenPkmnList
+.area 0x2A
+IsSpecialSpindaEggRecruitPkmn:
+	ldr r2,=MonsterFilePtr
+	mov  r1,#0x44
+	ldr r2,[r2, #+0x0]
+	smlabb r0,r0,r1,r2
+	ldrb r0,[r0, #+0x1a]
+	tst r0,#0x1
+	movne  r0,#0x1
+	moveq  r0,#0x0
+	bx r14
+	.pool
+	.fill (StoryForbiddenPkmnList+0x2A-.), 0xCC
+.endarea
+
 ; Change Mission Available Pokemons
 
 .org HookMissionGeneratePossiblePokemonList1

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_overlay11.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_overlay11.asm
@@ -1,0 +1,12 @@
+; ///////////////////////// overlay_0011.bin
+
+; TblTalk
+
+.org HookTblTalk1
+.area 0x8
+	add r0,r0,NbIndepEntries
+	sub r0,r0,#1
+	;add  r0,r0,#0xAF
+	;add  r0,r0,#0x400
+.endarea
+

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_overlay11.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_overlay11.asm
@@ -1,5 +1,20 @@
 ; ///////////////////////// overlay_0011.bin
 
+;
+ .org HookDisplay
+.area 0x24
+	bl GetPlayerPkmnStr
+	cmp r0,#0x0
+	moveq r4,#1
+	beq label_0
+	ldrsh r0,[r0, #+0x4]
+	bl GotoGetGender
+	cmp r0, #1
+	moveq  r4,#0x0
+	movne  r4,#0x1
+label_0:
+.endarea
+
 ; TblTalk
 
 .org HookTblTalk1

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_overlay19.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_overlay19.asm
@@ -1,0 +1,41 @@
+; ///////////////////////// overlay_0019.bin
+
+; SpindaRecruit2
+
+.org HookSpindaRecruitGender1
+.area 0x34
+	ldrsh r4,[r5, r1]
+	b end_spinda_recruit_g1
+	.fill 0x28, 0xCC
+	mov  r4,#0x0
+end_spinda_recruit_g1:
+.endarea
+
+.org HookSpindaRecruitGender2
+.area 0x34
+	ldrsh r4,[r5, r1]
+	b end_spinda_recruit_g2
+	.fill 0x28, 0xCC
+	mov  r4,#0x0
+end_spinda_recruit_g2:
+.endarea
+
+.org HookSpindaRecruitGender3
+.area 0x34
+	ldrsh r4,[r5, r1]
+	b end_spinda_recruit_g3
+	.fill 0x28, 0xCC
+	mov  r4,#0x0
+end_spinda_recruit_g3:
+.endarea
+
+; SpindaRecruit
+
+.org HookSpindaRecruit1
+.area 0x4
+	mov r0,NbIndepEntries*2
+.endarea
+.org HookSpindaRecruit2
+.area 0x4
+	cmp r6,NbIndepEntries
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_overlay19.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_overlay19.asm
@@ -1,5 +1,68 @@
 ; ///////////////////////// overlay_0019.bin
 
+; Spinda recruit tables
+
+.org HookSpindaRecruitTable1
+.area 0x4
+	mov r0,NbIndepEntries*2
+.endarea
+
+.org HookSpindaRecruitTable2
+.area 0x3C
+	mov  r6,#0x0
+	mov  r5,r0
+	mov  r7,r6
+loop_spinda_recruit_table_1:
+	mov  r0,r7
+	bl IsSpecialSpindaEggRecruitPkmn
+	cmp r0, #0
+	movne  r0,r7
+	blne GotoCheckValidPkmnIDForMissions
+	cmp r0,#0x0
+	movne r0,r6,lsl #0x1
+	strneh r7,[r5,r0]
+	addne  r6,r6,#0x1
+next_step_recruit_table_1:
+	add  r7,r7,#0x1
+	cmp r7,NbIndepEntries
+	blt loop_spinda_recruit_table_1
+.endarea
+
+.org HookSpindaRecruitTable3
+.area 0x4
+	mov r0,NbIndepEntries*2
+.endarea
+
+.org HookSpindaRecruitTable4
+.area 0x4C
+	mov  r6,#0x0
+	mov  r5,r0
+	mov  r7,r6
+loop_spinda_recruit_table_2:
+	mov  r0,r7
+	bl IsSpecialSpindaNormalRecruitPkmn
+	cmp r0, #0
+	movne  r0,r7
+	blne GotoCheckValidPkmnIDForMissions
+	cmp r0,#0x0
+	beq next_step_recruit_table_2
+	mov  r0,r7
+	bl 0x020527C4
+	cmp r0,#0x1
+	moveq r0,r6,lsl #0x1
+	streqh r7,[r5,r0]
+	addeq  r6,r6,#0x1
+next_step_recruit_table_2:
+	add  r7,r7,#0x1
+	cmp r7,NbIndepEntries
+	blt loop_spinda_recruit_table_2
+.endarea
+
+.org RecruitablePokemonsTable
+.area 0xD8
+	.fill 0xD8, 0xCC
+.endarea
+
 ; SpindaRecruit2
 
 .org HookSpindaRecruitGender1

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_overlay29.asm
@@ -1,5 +1,22 @@
 ; ///////////////////////// overlay_0029.bin
 
+; Change StoreSpriteFileIndexBothGenders
+
+.org StoreSpriteFileIndexBothGenders
+.area 0xC8
+	stmdb  r13!,{r3,r14}
+	ldr r2,=DungeonBaseStructurePtr
+	ldr r2,[r2, #+0x0]
+	mov  r3,r1
+	add  r1,r2,MDDSpr_L
+	add  r2,r1,MDDSpr_H
+	mov  r1,r0,lsl #0x1
+	strh r3,[r2, r1]
+	ldmia  r13!,{r3,r15}
+	.pool
+	.fill (StoreSpriteFileIndexBothGenders+0xC8-.), 0xCC
+.endarea
+
 ; Kecleon
 
 .org SetKecleonEntryForFloor
@@ -88,11 +105,7 @@ kecleon_hold:
 	add  r0,r0,MDDSpr_L
 	add  r4,r0,MDDSpr_H
 .endarea
-.org HookDungeonSpriteFile2
-.area 0x8
-	add  r1,r2,MDDSpr_L
-	add  r5,r1,MDDSpr_H
-.endarea
+; 2 is in StoreSpriteFileIndexBothGenders
 .org HookDungeonSpriteFile3
 .area 0xC
 	add  r1,r1,MDDSpr_L

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_overlay29.asm
@@ -1,0 +1,205 @@
+; ///////////////////////// overlay_0029.bin
+
+; Monster Modulo
+
+.org HookDungeonMonsterMod1
+.area 0x8
+	mov r1, r0
+	nop
+.endarea
+.org HookDungeonMonsterMod2
+.area 0x14
+	mov r1, r0
+	mov  r8,r2
+	mov  r7,r3
+	ldr r6,[r13, #+0x34]
+	nop
+.endarea
+.org HookDungeonMonsterMod3
+.area 0x8
+	mov r1, r0
+	nop
+.endarea
+
+; Limits
+
+.org HookDungeonMonsterLimit1
+.area 0x4
+	.word NbIndepEntries
+.endarea
+.org HookDungeonMonsterLimit2
+.area 0x4
+	.word NbIndepEntries
+.endarea
+.org HookDungeonMonsterLimit3
+.area 0x4
+	.word NbIndepEntries
+.endarea
+.org HookDungeonMonsterLimit4
+.area 0x4
+	.word NbIndepEntries
+.endarea
+
+; Dungeon Data Structure Size
+
+.org HookDungeonStructSize1
+.area 0x4
+	.word DungeonDataStructSize
+.endarea
+.org HookDungeonStructSize2
+.area 0x4
+	.word DungeonDataStructSize
+.endarea
+
+; Sprite File Index
+
+.org HookDungeonSpriteFile1
+.area 0x8
+	add  r0,r0,MDDSpr_L
+	add  r4,r0,MDDSpr_H
+.endarea
+.org HookDungeonSpriteFile2
+.area 0x8
+	add  r1,r2,MDDSpr_L
+	add  r5,r1,MDDSpr_H
+.endarea
+.org HookDungeonSpriteFile3
+.area 0xC
+	add  r1,r1,MDDSpr_L
+	mov  r0,r5
+	add  r4,r1,MDDSpr_H
+.endarea
+.org HookDungeonSpriteFile4
+.area 0x4
+	.word MDDSpr_L+MDDSpr_H
+.endarea
+.org HookDungeonSpriteFile5
+.area 0x4
+	.word MDDSpr_L+MDDSpr_H
+.endarea
+.org HookDungeonSpriteFile6
+.area 0x4
+	.word MDDSpr_L+MDDSpr_H
+.endarea
+.org HookDungeonSpriteFile7
+.area 0x4
+	.word MDDSpr_L+MDDSpr_H
+.endarea
+
+; Dungeon Recruit Index
+
+.org HookDungeonRec1
+.area 0x10
+	add  r0,r0,MDDRec_H
+	add  r2,r2,#0x1
+	strb r10,[r0, MDDRec_L]
+	cmp r2,NbIndepEntries
+.endarea
+.org HookDungeonRec2
+.area 0x8
+	add  r0,r0,MDDRec_H
+	ldrb r0,[r0, MDDRec_L]
+.endarea
+.org HookDungeonRec3
+.area 0x8
+	add  r1,r0,MDDRec_H
+	strb r0,[r1, MDDRec_L]
+.endarea
+.org HookDungeonRec4
+.area 0x8
+	add  r0,r0,MDDRec_H
+	strb r1,[r0, MDDRec_L]
+.endarea
+.org HookDungeonRec5
+.area 0x18
+	add  r0,r0,MDDRec_H
+	ldrb r3,[r0, MDDRec_L]
+	add  r4,r4,#0x1
+	cmp r3,#0x0
+	streqb r2,[r0, MDDRec_L]
+	cmp r4,NbIndepEntries
+.endarea
+.org HookDungeonRec6
+.area 0x8
+	add  r0,r0,MDDRec_H
+	ldrb r4,[r0, MDDRec_L]
+.endarea
+
+; TblTalk
+
+.org HookTblTalk2
+.area 0x4
+	.word NbIndepEntries+0x23
+.endarea
+
+.org HookTblTalk3
+.area 0x4
+	moveq  r4,NbIndepEntries
+.endarea
+
+.org HookTblTalk4
+.area 0x4
+	ldr r4,[r15, #+0x18c]
+	;ldreq r4,[r15, #+0x18c]
+.endarea
+
+.org HookTblTalk5
+.area 0x4
+	addeq  r4,r4,#1
+	;addeq  r4,r1,#0x31C
+.endarea
+
+.org HookTblTalk6
+.area 0x4
+	moveq  r4,NbIndepEntries+0x20
+.endarea
+
+.org HookTblTalk7
+.area 0x8
+	.word NbIndepEntries+0x1
+	.word NbIndepEntries+0x2
+.endarea
+.org HookTblTalk8
+.area 0x10
+	.word NbIndepEntries+0x1D
+	.word NbIndepEntries+0x1F
+	.word NbIndepEntries+0x21
+	.word NbIndepEntries+0x3
+.endarea
+.org HookTblTalk9
+.area 0x20
+	.word NbIndepEntries+0x14
+	.word NbIndepEntries+0x16
+	.word NbIndepEntries+0x17
+	.word NbIndepEntries+0x18
+	.word NbIndepEntries+0x19
+	.word NbIndepEntries+0x1A
+	.word NbIndepEntries+0x1B
+	.word NbIndepEntries+0x1C
+.endarea
+.org HookTblTalk10
+.area 0x10
+	.word NbIndepEntries+0x8
+	.word NbIndepEntries+0x23
+.endarea
+.org HookTblTalk11
+.area 0x40
+	.word (NbIndepEntries+0x8)*0x10000+0x00FA
+	.word (NbIndepEntries+0x5)*0x10000+0x00D9
+	.word (NbIndepEntries+0x6)*0x10000+0x00DB
+	.word (NbIndepEntries+0x4)*0x10000+0x00DC
+	.word (NbIndepEntries+0x7)*0x10000+0x00DD
+	.word (NbIndepEntries+0xE)*0x10000+0x00DE
+	.word (NbIndepEntries+0x10)*0x10000+0x00DF
+	.word (NbIndepEntries+0x11)*0x10000+0x00E0
+	.word (NbIndepEntries+0x22)*0x10000+0x00E1
+	.word (NbIndepEntries+0xD)*0x10000+0x00E2
+	.word (NbIndepEntries+0xF)*0x10000+0x00EC
+	.word (NbIndepEntries+0x15)*0x10000+0x00EE
+	.word (NbIndepEntries+0x12)*0x10000+0x00EF
+	.word (NbIndepEntries+0x13)*0x10000+0x00F0
+	.word (NbIndepEntries+0x14)*0x10000+0x00E3
+	.word (NbIndepEntries+0x8)*0x10000+0x00FA
+.endarea
+
+

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_overlay29.asm
@@ -1,5 +1,23 @@
 ; ///////////////////////// overlay_0029.bin
 
+; Kecleon
+
+.org SetKecleonEntryForFloor
+.area 0x38
+	str r0, [kecleon_hold]
+	bx r14
+	.fill 0x30, 0xCC
+.endarea
+
+.org GetKecleonEntryForFloor
+.area 0x1C
+	ldr r0, [kecleon_hold]
+	bx r14
+kecleon_hold:
+	.word 0x0
+	.fill 0x10, 0xCC
+.endarea
+
 ; Monster Modulo
 
 .org HookDungeonMonsterMod1
@@ -34,6 +52,18 @@
 .org HookDungeonMonsterLimit3
 .area 0x4
 	.word NbIndepEntries
+.endarea
+
+; Limit 4: Change other things
+
+.org HookDungeonMonsterLimit4C1
+.area 0x8
+	ldr r2,[r15, #+0x78] ;527
+	cmp r0,r2
+.endarea
+.org HookDungeonMonsterLimit4C2
+.area 0x4
+	sub r1,r2,#0x2 ;525
 .endarea
 .org HookDungeonMonsterLimit4
 .area 0x4

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_overlay31.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/common/patch_overlay31.asm
@@ -1,0 +1,20 @@
+; ///////////////////////// overlay_0031.bin
+
+; Recruitment search
+
+.org HookRecSearch1
+.area 0x8
+	sub  r13,r13,NbIndepEntries
+	nop
+.endarea
+
+.org HookRecSearch2
+.area 0x8
+	nop
+	add  r13,r13,NbIndepEntries
+.endarea
+
+.org HookRecSearch3
+.area 0x4
+	.word NbIndepEntries
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/constants.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/constants.asm
@@ -1,0 +1,11 @@
+; Target: 2048 indep. entries
+.definelabel NbIndepEntries, 0x800
+.definelabel DungeonDataStructSize, 0x2CB14+NbIndepEntries*3
+.definelabel MDDRec_H, 0x2C800
+.definelabel MDDRec_L, 0x314
+.definelabel MDDSpr_H, 0x2D400
+.definelabel MDDSpr_L, 0x74
+.definelabel Pkmn_StrID_H, 0x4800
+.definelabel Pkmn_StrID_L, 0x33
+.definelabel Cate_StrID_H, 0x5000
+.definelabel Cate_StrID_L, 0x33

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/constants.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/constants.asm
@@ -9,3 +9,4 @@
 .definelabel Pkmn_StrID_L, 0x33
 .definelabel Cate_StrID_H, 0x5000
 .definelabel Cate_StrID_L, 0x33
+.definelabel PokedexMax, 0x4A0

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/offsets.asm
@@ -28,8 +28,6 @@
 .definelabel GetSpawnLevel, 0x02054834
 .definelabel GotoGetGender, 0x02054ADC
 
-.definelabel GetSecondFormIfValid, 0x02054F20
-
 .definelabel GetNbRecruited, 0x020555F0
 
 .definelabel IsBossFight, 0x022E11A4
@@ -117,12 +115,16 @@
 ; //////////////////////////////////////////////////////
 ; patch overlay_0029.bin
 
+.definelabel SetKecleonEntryForFloor, 0x022F7D6C
+.definelabel GetKecleonEntryForFloor, 0x022F7DA4
 .definelabel HookDungeonMonsterMod1, 0x022FCB48
 .definelabel HookDungeonMonsterMod2, 0x022FCC44
 .definelabel HookDungeonMonsterMod3, 0x0231AE44
 .definelabel HookDungeonMonsterLimit1, 0x022F7CB4
 .definelabel HookDungeonMonsterLimit2, 0x022F81E8
 .definelabel HookDungeonMonsterLimit3, 0x02344C28
+.definelabel HookDungeonMonsterLimit4C1, 0x02344E10
+.definelabel HookDungeonMonsterLimit4C2, 0x02344E38
 .definelabel HookDungeonMonsterLimit4, 0x02344E88
 .definelabel HookDungeonStructSize1, 0x022DF3B8
 .definelabel HookDungeonStructSize2, 0x022DF3EC

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/offsets.asm
@@ -132,7 +132,6 @@
 ; //////////////////////////////////////////////////////
 ; patch overlay_0011.bin
 
-.definelabel GetPlayerPkmnStr, 0x02055AEC
 .definelabel HookDisplay, 0x022DCBC4
 .definelabel HookTblTalk1, 0x022E04DC
 

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/offsets.asm
@@ -68,6 +68,15 @@
 ; //////////////////////////////////////////////////////
 ; patch arm9.bin
 
+.definelabel HookExclusiveItemCheck, 0x02011090
+.definelabel HookAdventureLogSpecialCheck, 0x02050580
+.definelabel HookReadSave, 0x0204D900
+.definelabel HookWriteSave, 0x0204D710
+.definelabel SetPkmnFlag1, 0x0204D484
+.definelabel GetPkmnFlag1, 0x0204D4C0
+.definelabel SetPkmnFlag2, 0x0204D4FC
+.definelabel GetPkmnFlag2, 0x0204D540
+.definelabel ProgressStructPtr, 0x020B0890
 .definelabel IsValid, 0x02054AE8
 .definelabel HookN2MSearch, 0x020B5128
 .definelabel HookN2MSearchBase, 0x020B5198
@@ -113,8 +122,18 @@
 .definelabel HookTblTalk1, 0x022E04DC
 
 ; //////////////////////////////////////////////////////
+; patch overlay_0019.bin
+
+.definelabel HookSpindaRecruitGender1, 0x0238AD70
+.definelabel HookSpindaRecruitGender2, 0x0238AE14
+.definelabel HookSpindaRecruitGender3, 0x0238AECC
+.definelabel HookSpindaRecruit1, 0x0238AD08
+.definelabel HookSpindaRecruit2, 0x0238AD54
+
+; //////////////////////////////////////////////////////
 ; patch overlay_0029.bin
 
+.definelabel StoreSpriteFileIndexBothGenders, 0x022F7DC4
 .definelabel SetKecleonEntryForFloor, 0x022F7D6C
 .definelabel GetKecleonEntryForFloor, 0x022F7DA4
 .definelabel HookDungeonMonsterMod1, 0x022FCB48
@@ -129,7 +148,6 @@
 .definelabel HookDungeonStructSize1, 0x022DF3B8
 .definelabel HookDungeonStructSize2, 0x022DF3EC
 .definelabel HookDungeonSpriteFile1, 0x022F7AFC
-.definelabel HookDungeonSpriteFile2, 0x022F7DD8
 .definelabel HookDungeonSpriteFile3, 0x022F7FA4
 .definelabel HookDungeonSpriteFile4, 0x022F7D5C
 .definelabel HookDungeonSpriteFile5, 0x022F7F80

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/offsets.asm
@@ -1,0 +1,158 @@
+; For use with ARMIPS
+; 2021/04/14
+; For Explorers of Sky EU Only
+; ------------------------------------------------------------------------------
+; Use filestreams to partially load mappa files instead of loading entirely
+; ------------------------------------------------------------------------------
+
+
+.relativeinclude on
+.nds
+.arm
+
+.definelabel IsItemForSpecialSpawnInBag, 0x0200F0F8
+
+.definelabel CanMonsterSpawn, 0x0204D698
+
+.definelabel GetNbFloorsPlus1, 0x0204F8EC
+.definelabel GetNbPreviousFloors, 0x0204F918
+.definelabel TransformDungeonData, 0x0204F984
+
+.definelabel IsDojoDungeon, 0x020517E8
+
+.definelabel GetSpriteFileSize, 0x02052B54
+.definelabel NeedItemToSpawn, 0x02052E98
+
+.definelabel ModMonster, 0x020547FC
+.definelabel StoreMonsterID, 0x0205481C
+.definelabel GetSpawnLevel, 0x02054834
+.definelabel GotoGetGender, 0x02054ADC
+
+.definelabel GetSecondFormIfValid, 0x02054F20
+
+.definelabel GetNbRecruited, 0x020555F0
+
+.definelabel IsBossFight, 0x022E11A4
+
+.definelabel LoadMappaFileAttributes, 0x022E796C
+
+.definelabel RandMax, 0x022EB448
+
+.definelabel UnknownFunc1, 0x022EB5FC
+.definelabel UnknownFunc3, 0x022EB614
+
+.definelabel GetTotalSpriteFileSize, 0x022F7A20
+
+.definelabel IsFemaleFloor, 0x022F7D6C
+
+.definelabel IsSatisfyingScenarioConditionToSpawn, 0x022FBFF8
+
+.definelabel IsInSpawnList, 0x0231BE5C
+
+.definelabel IsFixedFloor, 0x02336DA4
+
+.definelabel UnknownFunc6, 0x02344A04
+
+.definelabel UnknownMissionFunc, 0x02349D4C
+.definelabel UnknownFunc5, 0x02349E1C
+.definelabel UnknownFunc2, 0x02349F4C
+.definelabel UnknownGetSize, 0x02349F78
+.definelabel UnknownFunc4, 0x0234A0A4
+
+.definelabel DungeonAuxilaryStructurePtr, 0x02352190
+
+.definelabel TimeFilename, 0x023521A5
+.definelabel DarknessFilename, 0x023521C1
+.definelabel SkyFilename, 0x023521DD
+
+.definelabel DungeonBaseStructurePtr, 0x02354138
+
+; //////////////////////////////////////////////////////
+; patch arm9.bin
+
+.definelabel IsValid, 0x02054AE8
+.definelabel HookN2MSearch, 0x020B5128
+.definelabel HookN2MSearchBase, 0x020B5198
+.definelabel MonsterFilePtr, 0x020B12D0
+.definelabel HookM2NSearch, 0x020B5200
+.definelabel HookM2NSearchBase, 0x020B5270
+.definelabel HookSortNb1, 0x0203B8B8
+.definelabel HookSortNb2, 0x0203B8F0
+.definelabel GetDexNb, 0x02052A78
+.definelabel HookModMonster, 0x02054818
+.definelabel IsInvalidMoveset, 0x02013974
+.definelabel IsInvalidMovesetEgg, 0x02053ED8
+.definelabel HookListForDungeon, 0x02055700
+.definelabel GetSecondFormIfValid, 0x02054F20
+.definelabel GetFirstFormIfValid, 0x02054F5C
+.definelabel HookGetMovesetLevelUpPtr, 0x02013934
+.definelabel HookGetMovesetHMTMPtr, 0x020139A4
+.definelabel HookGetMovesetEggPtr, 0x020139F0
+.definelabel HookPortrait1, 0x0204DC28
+.definelabel HookPortrait2, 0x0204DC44
+.definelabel HookPortrait3, 0x0204DD14
+.definelabel HookPortrait4, 0x0204DD30
+.definelabel HookStringsPkmn1, 0x020526E0
+.definelabel HookStringsPkmn2, 0x02052720
+.definelabel HookStringsPkmn3, 0x02052798
+.definelabel HookStringsPkmn4, 0x020529C8
+.definelabel HookStringsPkmn5, 0x02052A0C
+.definelabel HookStringsCate1, 0x02052AB0
+.definelabel HookMdAccess1, 0x020526D8
+.definelabel HookMdAccess2, 0x02052714
+.definelabel HookMdAccess3, 0x0205278C
+.definelabel HookMdAccess4, 0x020529C0
+.definelabel HookMdAccess5, 0x02052A04
+.definelabel HookMdAccess6, 0x02052AA8
+.definelabel HookMdAccess7, 0x02052B1C
+.definelabel HookMdAccess8, 0x02052B54
+.definelabel HookMdAccess9, 0x02053B2C
+.definelabel HookMdAccess10, 0x02053B4C
+
+; //////////////////////////////////////////////////////
+; patch overlay_0011.bin
+
+.definelabel HookTblTalk1, 0x022E04DC
+
+; //////////////////////////////////////////////////////
+; patch overlay_0029.bin
+
+.definelabel HookDungeonMonsterMod1, 0x022FCB48
+.definelabel HookDungeonMonsterMod2, 0x022FCC44
+.definelabel HookDungeonMonsterMod3, 0x0231AE44
+.definelabel HookDungeonMonsterLimit1, 0x022F7CB4
+.definelabel HookDungeonMonsterLimit2, 0x022F81E8
+.definelabel HookDungeonMonsterLimit3, 0x02344C28
+.definelabel HookDungeonMonsterLimit4, 0x02344E88
+.definelabel HookDungeonStructSize1, 0x022DF3B8
+.definelabel HookDungeonStructSize2, 0x022DF3EC
+.definelabel HookDungeonSpriteFile1, 0x022F7AFC
+.definelabel HookDungeonSpriteFile2, 0x022F7DD8
+.definelabel HookDungeonSpriteFile3, 0x022F7FA4
+.definelabel HookDungeonSpriteFile4, 0x022F7D5C
+.definelabel HookDungeonSpriteFile5, 0x022F7F80
+.definelabel HookDungeonSpriteFile6, 0x022F81B0
+.definelabel HookDungeonSpriteFile7, 0x022FC5E4
+.definelabel HookDungeonRec1, 0x022FCAF0
+.definelabel HookDungeonRec2, 0x022FCB64
+.definelabel HookDungeonRec3, 0x022FCBB4
+.definelabel HookDungeonRec4, 0x022FCBD8
+.definelabel HookDungeonRec5, 0x022FCC00
+.definelabel HookDungeonRec6, 0x0231AE58
+.definelabel HookTblTalk2, 0x022F6770
+.definelabel HookTblTalk3, 0x0234DC2C
+.definelabel HookTblTalk4, 0x0234DC60
+.definelabel HookTblTalk5, 0x0234DC6C
+.definelabel HookTblTalk6, 0x0234DC8C
+.definelabel HookTblTalk7, 0x0234DDE8
+.definelabel HookTblTalk8, 0x0234DDF4
+.definelabel HookTblTalk9, 0x0234DE08
+.definelabel HookTblTalk10, 0x0234DE2C
+.definelabel HookTblTalk11, 0x02354400
+
+; //////////////////////////////////////////////////////
+; patch overlay_0031.bin
+
+.definelabel HookRecSearch1, 0x02389AB0
+.definelabel HookRecSearch2, 0x02389D7C
+.definelabel HookRecSearch3, 0x02389D94

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/offsets.asm
@@ -68,6 +68,15 @@
 ; //////////////////////////////////////////////////////
 ; patch arm9.bin
 
+.definelabel HookMissionPkmnLimit1, 0x0205D484
+.definelabel HookMissionPkmnLimit2, 0x0205D2B0
+.definelabel IsPkmnIDNotInMFList, 0x02062D90
+.definelabel IsPkmnIDNotStoryForbidden, 0x02062E60
+.definelabel GetPerformanceFlagWithChecks, 0x0204CDCC
+.definelabel GetPlayerPkmnStr, 0x02055AEC
+.definelabel GetPartnerPkmnStr, 0x02055B14
+.definelabel PkmnIDMissionForbiddenList, 0x020A43AC
+.definelabel StoryForbiddenPkmnList, 0x020A4314
 .definelabel HookMissionGeneratePossiblePokemonList1, 0x0205FAD8
 .definelabel HookMissionGeneratePossiblePokemonList2, 0x0205FB10
 .definelabel HookLimitSearchSpecialLog, 0x02050574
@@ -128,6 +137,12 @@
 ; //////////////////////////////////////////////////////
 ; patch overlay_0019.bin
 
+.definelabel RecruitablePokemonsTable, 0x0238E628
+.definelabel HookSpindaRecruitTable1, 0x0238ADB8
+.definelabel HookSpindaRecruitTable2, 0x0238ADC4
+.definelabel HookSpindaRecruitTable3, 0x0238AE60
+.definelabel HookSpindaRecruitTable4, 0x0238AE6C
+.definelabel GotoCheckValidPkmnIDForMissions, 0x02062DE4
 .definelabel HookSpindaRecruitGender1, 0x0238AD70
 .definelabel HookSpindaRecruitGender2, 0x0238AE14
 .definelabel HookSpindaRecruitGender3, 0x0238AECC

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/offsets.asm
@@ -68,6 +68,10 @@
 ; //////////////////////////////////////////////////////
 ; patch arm9.bin
 
+.definelabel HookMissionGeneratePossiblePokemonList1, 0x0205FAD8
+.definelabel HookMissionGeneratePossiblePokemonList2, 0x0205FB10
+.definelabel HookLimitSearchSpecialLog, 0x02050574
+.definelabel HookPokedexMax, 0x02050578
 .definelabel HookExclusiveItemCheck, 0x02011090
 .definelabel HookAdventureLogSpecialCheck, 0x02050580
 .definelabel HookReadSave, 0x0204D900

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/eu/offsets.asm
@@ -132,6 +132,8 @@
 ; //////////////////////////////////////////////////////
 ; patch overlay_0011.bin
 
+.definelabel GetPlayerPkmnStr, 0x02055AEC
+.definelabel HookDisplay, 0x022DCBC4
 .definelabel HookTblTalk1, 0x022E04DC
 
 ; //////////////////////////////////////////////////////

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/constants.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/constants.asm
@@ -10,3 +10,4 @@
 .definelabel Pkmn_StrID_L, 0x14
 .definelabel Cate_StrID_H, 0x5100
 .definelabel Cate_StrID_L, 0x74
+.definelabel PokedexMax, 0x4A0

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/constants.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/constants.asm
@@ -1,0 +1,12 @@
+; ///// TODO
+; Target: 2400 indep. entries
+.definelabel NbIndepEntries, 0x960
+.definelabel DungeonDataStructSize, 0x2CB14+NbIndepEntries*3
+.definelabel MDDRec_H, 0x2C800
+.definelabel MDDRec_L, 0x314
+.definelabel MDDSpr_H, 0x2D400
+.definelabel MDDSpr_L, 0x74
+.definelabel Pkmn_StrID_H, 0x4800
+.definelabel Pkmn_StrID_L, 0x14
+.definelabel Cate_StrID_H, 0x5100
+.definelabel Cate_StrID_L, 0x74

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/offsets.asm
@@ -120,12 +120,16 @@
 ; //////////////////////////////////////////////////////
 ; patch overlay_0029.bin
 
+.definelabel SetKecleonEntryForFloor, 0x022F73B4
+.definelabel GetKecleonEntryForFloor, 0x022F73EC
 .definelabel HookDungeonMonsterMod1, 0x022FC14C
 .definelabel HookDungeonMonsterMod2, 0x022FC248
 .definelabel HookDungeonMonsterMod3, 0x0231A3E4
 .definelabel HookDungeonMonsterLimit1, 0x022F72FC
 .definelabel HookDungeonMonsterLimit2, 0x022F7830
 .definelabel HookDungeonMonsterLimit3, 0x02344044
+.definelabel HookDungeonMonsterLimit4C1, 0x0234422C
+.definelabel HookDungeonMonsterLimit4C2, 0x02344254
 .definelabel HookDungeonMonsterLimit4, 0x023442A4
 .definelabel HookDungeonStructSize1, 0x022DEA78
 .definelabel HookDungeonStructSize2, 0x022DEAAC

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/offsets.asm
@@ -137,6 +137,8 @@
 ; //////////////////////////////////////////////////////
 ; patch overlay_0011.bin
 
+.definelabel GetPlayerPkmnStr, 0x02055770
+.definelabel HookDisplay, 0x022DC284
 .definelabel HookTblTalk1, 0x022DFB9C
 
 ; //////////////////////////////////////////////////////

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/offsets.asm
@@ -73,6 +73,10 @@
 ; //////////////////////////////////////////////////////
 ; patch arm9.bin
 
+.definelabel HookMissionGeneratePossiblePokemonList1, 0x0205F75C
+.definelabel HookMissionGeneratePossiblePokemonList2, 0x0205F794
+.definelabel HookLimitSearchSpecialLog, 0x0205023C
+.definelabel HookPokedexMax, 0x02050240
 .definelabel HookExclusiveItemCheck, 0x02010FE8
 .definelabel HookAdventureLogSpecialCheck, 0x02050248
 .definelabel HookReadSave, 0x0204D5C8

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/offsets.asm
@@ -73,6 +73,15 @@
 ; //////////////////////////////////////////////////////
 ; patch arm9.bin
 
+.definelabel HookMissionPkmnLimit1, 0x0205D108
+.definelabel HookMissionPkmnLimit2, 0x0205CF34
+.definelabel IsPkmnIDNotInMFList, 0x02062A14
+.definelabel IsPkmnIDNotStoryForbidden, 0x02062AE4
+.definelabel GetPerformanceFlagWithChecks, 0x0204CA94
+.definelabel GetPlayerPkmnStr, 0x02055770
+.definelabel GetPartnerPkmnStr, 0x02055798
+.definelabel PkmnIDMissionForbiddenList, 0x020A3DAC
+.definelabel StoryForbiddenPkmnList, 0x020A3D14
 .definelabel HookMissionGeneratePossiblePokemonList1, 0x0205F75C
 .definelabel HookMissionGeneratePossiblePokemonList2, 0x0205F794
 .definelabel HookLimitSearchSpecialLog, 0x0205023C
@@ -133,6 +142,12 @@
 ; //////////////////////////////////////////////////////
 ; patch overlay_0019.bin
 
+.definelabel RecruitablePokemonsTable, 0x0238DAF4
+.definelabel HookSpindaRecruitTable1, 0x0238A278
+.definelabel HookSpindaRecruitTable2, 0x0238A284
+.definelabel HookSpindaRecruitTable3, 0x0238A320
+.definelabel HookSpindaRecruitTable4, 0x0238A32C
+.definelabel GotoCheckValidPkmnIDForMissions, 0x02062A58
 .definelabel HookSpindaRecruitGender1, 0x0238A230
 .definelabel HookSpindaRecruitGender2, 0x0238A2D4
 .definelabel HookSpindaRecruitGender3, 0x0238A38C

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/offsets.asm
@@ -73,6 +73,15 @@
 ; //////////////////////////////////////////////////////
 ; patch arm9.bin
 
+.definelabel HookExclusiveItemCheck, 0x02010FE8
+.definelabel HookAdventureLogSpecialCheck, 0x02050248
+.definelabel HookReadSave, 0x0204D5C8
+.definelabel HookWriteSave, 0x0204D3D8
+.definelabel SetPkmnFlag1, 0x0204D14C
+.definelabel GetPkmnFlag1, 0x0204D188
+.definelabel SetPkmnFlag2, 0x0204D1C4
+.definelabel GetPkmnFlag2, 0x0204D208
+.definelabel ProgressStructPtr, 0x020AFF74
 .definelabel IsValid, 0x0205476C
 .definelabel HookN2MSearch, 0x020B47E8
 .definelabel HookN2MSearchBase, 0x020B4858
@@ -118,8 +127,18 @@
 .definelabel HookTblTalk1, 0x022DFB9C
 
 ; //////////////////////////////////////////////////////
+; patch overlay_0019.bin
+
+.definelabel HookSpindaRecruitGender1, 0x0238A230
+.definelabel HookSpindaRecruitGender2, 0x0238A2D4
+.definelabel HookSpindaRecruitGender3, 0x0238A38C
+.definelabel HookSpindaRecruit1, 0x0238A1C8
+.definelabel HookSpindaRecruit2, 0x0238A214
+
+; //////////////////////////////////////////////////////
 ; patch overlay_0029.bin
 
+.definelabel StoreSpriteFileIndexBothGenders, 0x022F740C
 .definelabel SetKecleonEntryForFloor, 0x022F73B4
 .definelabel GetKecleonEntryForFloor, 0x022F73EC
 .definelabel HookDungeonMonsterMod1, 0x022FC14C
@@ -134,7 +153,6 @@
 .definelabel HookDungeonStructSize1, 0x022DEA78
 .definelabel HookDungeonStructSize2, 0x022DEAAC
 .definelabel HookDungeonSpriteFile1, 0x022F7144
-.definelabel HookDungeonSpriteFile2, 0x022F7420
 .definelabel HookDungeonSpriteFile3, 0x022F75EC
 .definelabel HookDungeonSpriteFile4, 0x022F73A4
 .definelabel HookDungeonSpriteFile5, 0x022F75C8

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/offsets.asm
@@ -137,7 +137,6 @@
 ; //////////////////////////////////////////////////////
 ; patch overlay_0011.bin
 
-.definelabel GetPlayerPkmnStr, 0x02055770
 .definelabel HookDisplay, 0x022DC284
 .definelabel HookTblTalk1, 0x022DFB9C
 

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/jp/offsets.asm
@@ -1,0 +1,161 @@
+; For use with ARMIPS
+; 2021/04/14
+; For Explorers of Sky JP Only
+; ------------------------------------------------------------------------------
+; Use filestreams to partially load mappa files instead of loading entirely
+; ------------------------------------------------------------------------------
+
+; WARNING! Not Tested!
+
+.relativeinclude on
+.nds
+.arm
+
+.definelabel IsItemForSpecialSpawnInBag, 0x0200F020
+
+.definelabel CanMonsterSpawn, 0x0204D6C0
+
+.definelabel GetNbFloorsPlus1, 0x0204F90C
+.definelabel GetNbPreviousFloors, 0x0204F938
+.definelabel TransformDungeonData, 0x0204F9A4
+
+.definelabel IsDojoDungeon, 0x02051800
+
+.definelabel GetSpriteFileSize, 0x02052B54
+.definelabel NeedItemToSpawn, 0x02052E98
+
+.definelabel ModMonster, 0x020547B8
+.definelabel StoreMonsterID, 0x020547D8
+.definelabel GetSpawnLevel, 0x020547F0
+.definelabel GotoGetGender, 0x02054A98
+
+.definelabel GetSecondFormIfValid, 0x02054EDC
+
+.definelabel GetNbRecruited, 0x02055610
+
+.definelabel IsBossFight, 0x022E1EF4
+
+.definelabel LoadMappaFileAttributes, 0x022E862C
+
+.definelabel RandMax, 0x022EC100
+
+.definelabel UnknownFunc1, 0x022EC2B4
+.definelabel UnknownFunc3, 0x022EC2CC
+
+.definelabel GetTotalSpriteFileSize, 0x022F8634
+
+.definelabel IsFemaleFloor, 0x022F897C
+
+.definelabel IsSatisfyingScenarioConditionToSpawn, 0x022FCAC0
+
+.definelabel IsInSpawnList, 0x0231C8C8
+
+.definelabel IsFixedFloor, 0x023375A4
+
+.definelabel UnknownFunc6, 0x023451E4
+
+.definelabel UnknownMissionFunc, 0x0234A474
+.definelabel UnknownFunc5, 0x0234A544
+.definelabel UnknownFunc2, 0x0234A674
+.definelabel UnknownGetSize, 0x0234A6A0
+.definelabel UnknownFunc4, 0x0234A7CC
+
+.definelabel DungeonAuxilaryStructurePtr, 0x02352804
+
+.definelabel TimeFilename, 0x02352819
+.definelabel DarknessFilename, 0x02352835
+.definelabel SkyFilename, 0x02352851
+
+.definelabel DungeonBaseStructurePtr, 0x023547b8
+
+
+; ////// TODO
+; //////////////////////////////////////////////////////
+; patch arm9.bin
+
+.definelabel IsValid, 0x0205476C
+.definelabel HookN2MSearch, 0x020B47E8
+.definelabel HookN2MSearchBase, 0x020B4858
+.definelabel MonsterFilePtr, 0x020B09B4
+.definelabel HookM2NSearch, 0x020B48C0
+.definelabel HookM2NSearchBase, 0x020B4930
+.definelabel HookSortNb1, 0x0203B5BC
+.definelabel HookSortNb2, 0x0203B5F4
+.definelabel GetDexNb, 0x02052740
+.definelabel HookModMonster, 0x0205449C
+.definelabel IsInvalidMoveset, 0x020138CC
+.definelabel IsInvalidMovesetEgg, 0x02053B5C
+.definelabel HookListForDungeon, 0x02055384
+.definelabel GetSecondFormIfValid, 0x02054BA4
+.definelabel GetFirstFormIfValid, 0x02054BE0
+.definelabel HookGetMovesetLevelUpPtr, 0x0201388C
+.definelabel HookGetMovesetHMTMPtr, 0x020138FC
+.definelabel HookGetMovesetEggPtr, 0x02013948
+.definelabel HookPortrait1, 0x0204D8F0
+.definelabel HookPortrait2, 0x0204D90C
+.definelabel HookPortrait3, 0x0204D9DC
+.definelabel HookPortrait4, 0x0204D9F8
+.definelabel HookStringsPkmn1, 0x020523A8
+.definelabel HookStringsPkmn2, 0x020523E8
+.definelabel HookStringsPkmn3, 0x02052460
+.definelabel HookStringsPkmn4, 0x02052690
+.definelabel HookStringsPkmn5, 0x020526D4
+.definelabel HookStringsCate1, 0x02052778
+.definelabel HookMdAccess1, 0x020523A0
+.definelabel HookMdAccess2, 0x020523DC
+.definelabel HookMdAccess3, 0x02052454
+.definelabel HookMdAccess4, 0x02052688
+.definelabel HookMdAccess5, 0x020526CC
+.definelabel HookMdAccess6, 0x02052770
+.definelabel HookMdAccess7, 0x020527E4
+.definelabel HookMdAccess8, 0x0205281C
+.definelabel HookMdAccess9, 0x020537B0
+.definelabel HookMdAccess10, 0x020537D0
+
+; //////////////////////////////////////////////////////
+; patch overlay_0011.bin
+
+.definelabel HookTblTalk1, 0x022DFB9C
+
+; //////////////////////////////////////////////////////
+; patch overlay_0029.bin
+
+.definelabel HookDungeonMonsterMod1, 0x022FC14C
+.definelabel HookDungeonMonsterMod2, 0x022FC248
+.definelabel HookDungeonMonsterMod3, 0x0231A3E4
+.definelabel HookDungeonMonsterLimit1, 0x022F72FC
+.definelabel HookDungeonMonsterLimit2, 0x022F7830
+.definelabel HookDungeonMonsterLimit3, 0x02344044
+.definelabel HookDungeonMonsterLimit4, 0x023442A4
+.definelabel HookDungeonStructSize1, 0x022DEA78
+.definelabel HookDungeonStructSize2, 0x022DEAAC
+.definelabel HookDungeonSpriteFile1, 0x022F7144
+.definelabel HookDungeonSpriteFile2, 0x022F7420
+.definelabel HookDungeonSpriteFile3, 0x022F75EC
+.definelabel HookDungeonSpriteFile4, 0x022F73A4
+.definelabel HookDungeonSpriteFile5, 0x022F75C8
+.definelabel HookDungeonSpriteFile6, 0x022F77F8
+.definelabel HookDungeonSpriteFile7, 0x022FBBE8
+.definelabel HookDungeonRec1, 0x022FC0F4
+.definelabel HookDungeonRec2, 0x022FC168
+.definelabel HookDungeonRec3, 0x022FC1B8
+.definelabel HookDungeonRec4, 0x022FC1DC
+.definelabel HookDungeonRec5, 0x022FC204
+.definelabel HookDungeonRec6, 0x0231A3F8
+.definelabel HookTblTalk2, 0x022F5DB4
+.definelabel HookTblTalk3, 0x0234D02C
+.definelabel HookTblTalk4, 0x0234D060
+.definelabel HookTblTalk5, 0x0234D06C
+.definelabel HookTblTalk6, 0x0234D08C
+.definelabel HookTblTalk7, 0x0234D1E8
+.definelabel HookTblTalk8, 0x0234D1F4
+.definelabel HookTblTalk9, 0x0234D208
+.definelabel HookTblTalk10, 0x0234D22C
+.definelabel HookTblTalk11, 0x023537E8
+
+; //////////////////////////////////////////////////////
+; patch overlay_0031.bin
+
+.definelabel HookRecSearch1, 0x02388E8C
+.definelabel HookRecSearch2, 0x02389158
+.definelabel HookRecSearch3, 0x02389170

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/constants.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/constants.asm
@@ -9,3 +9,4 @@
 .definelabel Pkmn_StrID_L, 0x14
 .definelabel Cate_StrID_H, 0x5000
 .definelabel Cate_StrID_L, 0x14
+.definelabel PokedexMax, 0x4A0

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/constants.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/constants.asm
@@ -1,0 +1,11 @@
+; Target: 2048 indep. entries
+.definelabel NbIndepEntries, 0x800
+.definelabel DungeonDataStructSize, 0x2CB14+NbIndepEntries*3
+.definelabel MDDRec_H, 0x2C800
+.definelabel MDDRec_L, 0x314
+.definelabel MDDSpr_H, 0x2D000
+.definelabel MDDSpr_L, 0x314
+.definelabel Pkmn_StrID_H, 0x4800
+.definelabel Pkmn_StrID_L, 0x14
+.definelabel Cate_StrID_H, 0x5000
+.definelabel Cate_StrID_L, 0x14

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/offsets.asm
@@ -68,6 +68,10 @@
 ; //////////////////////////////////////////////////////
 ; patch arm9.bin
 
+.definelabel HookMissionGeneratePossiblePokemonList1, 0x0205F75C
+.definelabel HookMissionGeneratePossiblePokemonList2, 0x0205F794
+.definelabel HookLimitSearchSpecialLog, 0x0205023C
+.definelabel HookPokedexMax, 0x02050240
 .definelabel HookExclusiveItemCheck, 0x02010FE8
 .definelabel HookAdventureLogSpecialCheck, 0x02050248
 .definelabel HookReadSave, 0x0204D5C8

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/offsets.asm
@@ -68,6 +68,15 @@
 ; //////////////////////////////////////////////////////
 ; patch arm9.bin
 
+.definelabel HookExclusiveItemCheck, 0x02010FE8
+.definelabel HookAdventureLogSpecialCheck, 0x02050248
+.definelabel HookReadSave, 0x0204D5C8
+.definelabel HookWriteSave, 0x0204D3D8
+.definelabel SetPkmnFlag1, 0x0204D14C
+.definelabel GetPkmnFlag1, 0x0204D188
+.definelabel SetPkmnFlag2, 0x0204D1C4
+.definelabel GetPkmnFlag2, 0x0204D208
+.definelabel ProgressStructPtr, 0x020AFF74
 .definelabel IsValid, 0x0205476C
 .definelabel HookN2MSearch, 0x020B47E8
 .definelabel HookN2MSearchBase, 0x020B4858
@@ -113,8 +122,18 @@
 .definelabel HookTblTalk1, 0x022DFB9C
 
 ; //////////////////////////////////////////////////////
+; patch overlay_0019.bin
+
+.definelabel HookSpindaRecruitGender1, 0x0238A230
+.definelabel HookSpindaRecruitGender2, 0x0238A2D4
+.definelabel HookSpindaRecruitGender3, 0x0238A38C
+.definelabel HookSpindaRecruit1, 0x0238A1C8
+.definelabel HookSpindaRecruit2, 0x0238A214
+
+; //////////////////////////////////////////////////////
 ; patch overlay_0029.bin
 
+.definelabel StoreSpriteFileIndexBothGenders, 0x022F740C
 .definelabel SetKecleonEntryForFloor, 0x022F73B4
 .definelabel GetKecleonEntryForFloor, 0x022F73EC
 .definelabel HookDungeonMonsterMod1, 0x022FC14C
@@ -129,7 +148,6 @@
 .definelabel HookDungeonStructSize1, 0x022DEA78
 .definelabel HookDungeonStructSize2, 0x022DEAAC
 .definelabel HookDungeonSpriteFile1, 0x022F7144
-.definelabel HookDungeonSpriteFile2, 0x022F7420
 .definelabel HookDungeonSpriteFile3, 0x022F75EC
 .definelabel HookDungeonSpriteFile4, 0x022F73A4
 .definelabel HookDungeonSpriteFile5, 0x022F75C8

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/offsets.asm
@@ -1,0 +1,156 @@
+; For use with ARMIPS
+; 2021/04/14
+; For Explorers of Sky NA Only
+; ------------------------------------------------------------------------------
+; Use filestreams to partially load mappa files instead of loading entirely
+; ------------------------------------------------------------------------------
+
+
+.relativeinclude on
+.nds
+.arm
+
+.definelabel IsItemForSpecialSpawnInBag, 0x0200F050
+
+.definelabel CanMonsterSpawn, 0x0204D360
+
+.definelabel TransformDungeonData, 0x0204F64C
+.definelabel GetNbFloorsPlus1, 0x0204F5B4
+.definelabel GetNbPreviousFloors, 0x0204F5E0
+
+.definelabel IsDojoDungeon, 0x020514B0
+
+.definelabel GetSpriteFileSize, 0x0205281C
+.definelabel NeedItemToSpawn, 0x02052B60
+
+.definelabel ModMonster, 0x02054480
+.definelabel StoreMonsterID, 0x020544A0
+.definelabel GetSpawnLevel, 0x020544B8
+.definelabel GotoGetGender, 0x02054760
+
+.definelabel GetNbRecruited, 0x02055274
+
+.definelabel IsBossFight, 0x022E0864
+
+.definelabel LoadMappaFileAttributes, 0x022E6FBC
+
+.definelabel RandMax, 0x022EAA98
+
+.definelabel UnknownFunc1, 0x022EAC4C
+.definelabel UnknownFunc3, 0x022EAC64
+
+.definelabel GetTotalSpriteFileSize, 0x022F7068
+
+.definelabel IsFemaleFloor, 0x022F73B4
+
+.definelabel IsSatisfyingScenarioConditionToSpawn, 0x022FB5EC
+
+.definelabel IsInSpawnList, 0x0231B3FC
+
+.definelabel IsFixedFloor, 0x023361D4
+
+.definelabel UnknownFunc6, 0x02343E20
+
+.definelabel UnknownMissionFunc, 0x0234914C
+.definelabel UnknownFunc5, 0x0234921C
+.definelabel UnknownFunc2, 0x0234934C
+.definelabel UnknownGetSize, 0x02349378
+.definelabel UnknownFunc4, 0x023494A4
+
+.definelabel DungeonAuxilaryStructurePtr, 0x02351584
+
+.definelabel TimeFilename, 0x02351599
+.definelabel DarknessFilename, 0x023515B5
+.definelabel SkyFilename, 0x023515D1
+
+.definelabel DungeonBaseStructurePtr, 0x02353538
+
+; //////////////////////////////////////////////////////
+; patch arm9.bin
+
+.definelabel IsValid, 0x0205476C
+.definelabel HookN2MSearch, 0x020B47E8
+.definelabel HookN2MSearchBase, 0x020B4858
+.definelabel MonsterFilePtr, 0x020B09B4
+.definelabel HookM2NSearch, 0x020B48C0
+.definelabel HookM2NSearchBase, 0x020B4930
+.definelabel HookSortNb1, 0x0203B5BC
+.definelabel HookSortNb2, 0x0203B5F4
+.definelabel GetDexNb, 0x02052740
+.definelabel HookModMonster, 0x0205449C
+.definelabel IsInvalidMoveset, 0x020138CC
+.definelabel IsInvalidMovesetEgg, 0x02053B5C
+.definelabel HookListForDungeon, 0x02055384
+.definelabel GetSecondFormIfValid, 0x02054BA4
+.definelabel GetFirstFormIfValid, 0x02054BE0
+.definelabel HookGetMovesetLevelUpPtr, 0x0201388C
+.definelabel HookGetMovesetHMTMPtr, 0x020138FC
+.definelabel HookGetMovesetEggPtr, 0x02013948
+.definelabel HookPortrait1, 0x0204D8F0
+.definelabel HookPortrait2, 0x0204D90C
+.definelabel HookPortrait3, 0x0204D9DC
+.definelabel HookPortrait4, 0x0204D9F8
+.definelabel HookStringsPkmn1, 0x020523A8
+.definelabel HookStringsPkmn2, 0x020523E8
+.definelabel HookStringsPkmn3, 0x02052460
+.definelabel HookStringsPkmn4, 0x02052690
+.definelabel HookStringsPkmn5, 0x020526D4
+.definelabel HookStringsCate1, 0x02052778
+.definelabel HookMdAccess1, 0x020523A0
+.definelabel HookMdAccess2, 0x020523DC
+.definelabel HookMdAccess3, 0x02052454
+.definelabel HookMdAccess4, 0x02052688
+.definelabel HookMdAccess5, 0x020526CC
+.definelabel HookMdAccess6, 0x02052770
+.definelabel HookMdAccess7, 0x020527E4
+.definelabel HookMdAccess8, 0x0205281C
+.definelabel HookMdAccess9, 0x020537B0
+.definelabel HookMdAccess10, 0x020537D0
+
+; //////////////////////////////////////////////////////
+; patch overlay_0011.bin
+
+.definelabel HookTblTalk1, 0x022DFB9C
+
+; //////////////////////////////////////////////////////
+; patch overlay_0029.bin
+
+.definelabel HookDungeonMonsterMod1, 0x022FC14C
+.definelabel HookDungeonMonsterMod2, 0x022FC248
+.definelabel HookDungeonMonsterMod3, 0x0231A3E4
+.definelabel HookDungeonMonsterLimit1, 0x022F72FC
+.definelabel HookDungeonMonsterLimit2, 0x022F7830
+.definelabel HookDungeonMonsterLimit3, 0x02344044
+.definelabel HookDungeonMonsterLimit4, 0x023442A4
+.definelabel HookDungeonStructSize1, 0x022DEA78
+.definelabel HookDungeonStructSize2, 0x022DEAAC
+.definelabel HookDungeonSpriteFile1, 0x022F7144
+.definelabel HookDungeonSpriteFile2, 0x022F7420
+.definelabel HookDungeonSpriteFile3, 0x022F75EC
+.definelabel HookDungeonSpriteFile4, 0x022F73A4
+.definelabel HookDungeonSpriteFile5, 0x022F75C8
+.definelabel HookDungeonSpriteFile6, 0x022F77F8
+.definelabel HookDungeonSpriteFile7, 0x022FBBE8
+.definelabel HookDungeonRec1, 0x022FC0F4
+.definelabel HookDungeonRec2, 0x022FC168
+.definelabel HookDungeonRec3, 0x022FC1B8
+.definelabel HookDungeonRec4, 0x022FC1DC
+.definelabel HookDungeonRec5, 0x022FC204
+.definelabel HookDungeonRec6, 0x0231A3F8
+.definelabel HookTblTalk2, 0x022F5DB4
+.definelabel HookTblTalk3, 0x0234D02C
+.definelabel HookTblTalk4, 0x0234D060
+.definelabel HookTblTalk5, 0x0234D06C
+.definelabel HookTblTalk6, 0x0234D08C
+.definelabel HookTblTalk7, 0x0234D1E8
+.definelabel HookTblTalk8, 0x0234D1F4
+.definelabel HookTblTalk9, 0x0234D208
+.definelabel HookTblTalk10, 0x0234D22C
+.definelabel HookTblTalk11, 0x023537E8
+
+; //////////////////////////////////////////////////////
+; patch overlay_0031.bin
+
+.definelabel HookRecSearch1, 0x02388E8C
+.definelabel HookRecSearch2, 0x02389158
+.definelabel HookRecSearch3, 0x02389170

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/offsets.asm
@@ -115,12 +115,16 @@
 ; //////////////////////////////////////////////////////
 ; patch overlay_0029.bin
 
+.definelabel SetKecleonEntryForFloor, 0x022F73B4
+.definelabel GetKecleonEntryForFloor, 0x022F73EC
 .definelabel HookDungeonMonsterMod1, 0x022FC14C
 .definelabel HookDungeonMonsterMod2, 0x022FC248
 .definelabel HookDungeonMonsterMod3, 0x0231A3E4
 .definelabel HookDungeonMonsterLimit1, 0x022F72FC
 .definelabel HookDungeonMonsterLimit2, 0x022F7830
 .definelabel HookDungeonMonsterLimit3, 0x02344044
+.definelabel HookDungeonMonsterLimit4C1, 0x0234422C
+.definelabel HookDungeonMonsterLimit4C2, 0x02344254
 .definelabel HookDungeonMonsterLimit4, 0x023442A4
 .definelabel HookDungeonStructSize1, 0x022DEA78
 .definelabel HookDungeonStructSize2, 0x022DEAAC

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/offsets.asm
@@ -132,7 +132,6 @@
 ; //////////////////////////////////////////////////////
 ; patch overlay_0011.bin
 
-.definelabel GetPlayerPkmnStr, 0x02055770
 .definelabel HookDisplay, 0x022DC284
 .definelabel HookTblTalk1, 0x022DFB9C
 

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/offsets.asm
@@ -68,6 +68,15 @@
 ; //////////////////////////////////////////////////////
 ; patch arm9.bin
 
+.definelabel HookMissionPkmnLimit1, 0x0205D108
+.definelabel HookMissionPkmnLimit2, 0x0205CF34
+.definelabel IsPkmnIDNotInMFList, 0x02062A14
+.definelabel IsPkmnIDNotStoryForbidden, 0x02062AE4
+.definelabel GetPerformanceFlagWithChecks, 0x0204CA94
+.definelabel GetPlayerPkmnStr, 0x02055770
+.definelabel GetPartnerPkmnStr, 0x02055798
+.definelabel PkmnIDMissionForbiddenList, 0x020A3DAC
+.definelabel StoryForbiddenPkmnList, 0x020A3D14
 .definelabel HookMissionGeneratePossiblePokemonList1, 0x0205F75C
 .definelabel HookMissionGeneratePossiblePokemonList2, 0x0205F794
 .definelabel HookLimitSearchSpecialLog, 0x0205023C
@@ -128,6 +137,12 @@
 ; //////////////////////////////////////////////////////
 ; patch overlay_0019.bin
 
+.definelabel RecruitablePokemonsTable, 0x0238DAF4
+.definelabel HookSpindaRecruitTable1, 0x0238A278
+.definelabel HookSpindaRecruitTable2, 0x0238A284
+.definelabel HookSpindaRecruitTable3, 0x0238A320
+.definelabel HookSpindaRecruitTable4, 0x0238A32C
+.definelabel GotoCheckValidPkmnIDForMissions, 0x02062A58
 .definelabel HookSpindaRecruitGender1, 0x0238A230
 .definelabel HookSpindaRecruitGender2, 0x0238A2D4
 .definelabel HookSpindaRecruitGender3, 0x0238A38C

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/na/offsets.asm
@@ -132,6 +132,8 @@
 ; //////////////////////////////////////////////////////
 ; patch overlay_0011.bin
 
+.definelabel GetPlayerPkmnStr, 0x02055770
+.definelabel HookDisplay, 0x022DC284
 .definelabel HookTblTalk1, 0x022DFB9C
 
 ; //////////////////////////////////////////////////////

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/selector_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/selector_arm9.asm
@@ -1,0 +1,25 @@
+; For use with ARMIPS
+; 2021/04/14
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/constants.asm"
+	.include "na/offsets.asm"
+	.include "common/patch_arm9.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/constants.asm"
+	.include "eu/offsets.asm"
+	.include "common/patch_arm9.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/constants.asm"
+	.include "jp/offsets.asm"
+	.include "common/patch_arm9.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/selector_overlay11.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/selector_overlay11.asm
@@ -1,0 +1,19 @@
+; For use with ARMIPS
+; 2021/04/14
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "common/patch_overlay11.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "common/patch_overlay11.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "common/patch_overlay11.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/selector_overlay19.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/selector_overlay19.asm
@@ -1,0 +1,19 @@
+; For use with ARMIPS
+; 2021/04/14
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "common/patch_overlay19.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "common/patch_overlay19.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "common/patch_overlay19.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/selector_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/selector_overlay29.asm
@@ -1,0 +1,22 @@
+; For use with ARMIPS
+; 2021/04/14
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "common/fs_mappa_edited.asm"
+	.include "common/patch_overlay29.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "common/fs_mappa_edited.asm"
+	.include "common/patch_overlay29.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "common/fs_mappa_edited.asm"
+	.include "common/patch_overlay29.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/selector_overlay31.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/expand_poke_list/selector_overlay31.asm
@@ -1,0 +1,19 @@
+; For use with ARMIPS
+; 2021/04/14
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "common/patch_overlay31.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "common/patch_overlay31.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "common/patch_overlay31.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -1020,6 +1020,21 @@
 	  </OpenBin>
         </Patch>
         
+        <Patch id="ExpandPokeList" >
+          <OpenBin filepath="arm9.bin">
+		  <Include filename ="irdkwia_asm_mods/expand_poke_list/selector_arm9.asm"/>
+          </OpenBin>
+          <OpenBin filepath="overlay/overlay_0011.bin">
+		  <Include filename ="irdkwia_asm_mods/expand_poke_list/selector_overlay11.asm"/>
+          </OpenBin>
+          <OpenBin filepath="overlay/overlay_0029.bin">
+		  <Include filename ="irdkwia_asm_mods/expand_poke_list/selector_overlay29.asm"/>
+          </OpenBin>
+          <OpenBin filepath="overlay/overlay_0031.bin">
+		  <Include filename ="irdkwia_asm_mods/expand_poke_list/selector_overlay31.asm"/>
+          </OpenBin>
+        </Patch>
+        
         <!-- A patch that fixes the unused dungeon chance -->
         <Patch id="UnusedDungeonChancePatch" >
           <OpenBin filepath="overlay/overlay_0029.bin">

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -580,7 +580,11 @@
     <!--Explorers of Sky, North America-->
     <Game id="EoS_NA" id2="EoSWVC_NA">
       <Languages>
-        <Language filename="text_e.str" name="English" locale="en-US" />
+        <Language filename="text_e.str" name="English" locale="en-US">
+        	<m2n filename="st_m2n_j.bin" />
+        	<n2m filename="st_n2m_j.bin" />
+        	<i2n filename="st_i2n_j.bin" />
+        </Language>
       </Languages>
       <StringBlocks>
         <StringBlock name="Explorer Ranks Names"                   beg="374"  end="387"/>
@@ -661,6 +665,8 @@
         <StringBlock name="Spinda's Juice Bar Strings"             beg="17800"  end="17900"/>
         <StringBlock name="Recycle Shop Strings"                   beg="17900"  end="17960"/>
         <StringBlock name="Staff Roll"                             beg="17960"  end="18451"/>
+        <StringBlock name="New Pokemon Names"                          beg="18451"  end="20499"/>
+        <StringBlock name="New Pokemon Categories"                     beg="20499"  end="22547"/>
       </StringBlocks>
     </Game>
     
@@ -712,11 +718,31 @@
     <!--Explorers of Sky, Europe-->
     <Game id="EoS_EU" id2="EoSWVC_EU">
       <Languages>
-        <Language filename="text_e.str" name="English"  locale="en-US" />
-        <Language filename="text_f.str" name="French"   locale="fr-FR" />
-        <Language filename="text_g.str" name="German"   locale="de-DE" />
-        <Language filename="text_i.str" name="Italian"  locale="it-IT" />
-        <Language filename="text_s.str" name="Spanish"  locale="es-ES" />
+        <Language filename="text_e.str" name="English"  locale="en-US">
+        	<m2n filename="st_m2n_e.bin" />
+        	<n2m filename="st_n2m_e.bin" />
+        	<i2n filename="st_i2n_e.bin" />
+        </Language>
+        <Language filename="text_f.str" name="French"   locale="fr-FR">
+        	<m2n filename="st_m2n_f.bin" />
+        	<n2m filename="st_n2m_f.bin" />
+        	<i2n filename="st_i2n_f.bin" />
+        </Language>
+        <Language filename="text_g.str" name="German"   locale="de-DE">
+        	<m2n filename="st_m2n_g.bin" />
+        	<n2m filename="st_n2m_g.bin" />
+        	<i2n filename="st_i2n_g.bin" />
+        </Language>
+        <Language filename="text_i.str" name="Italian"  locale="it-IT">
+        	<m2n filename="st_m2n_i.bin" />
+        	<n2m filename="st_n2m_i.bin" />
+        	<i2n filename="st_i2n_i.bin" />
+        </Language>
+        <Language filename="text_s.str" name="Spanish"  locale="es-ES">
+        	<m2n filename="st_m2n_s.bin" />
+        	<n2m filename="st_n2m_s.bin" />
+        	<i2n filename="st_i2n_s.bin" />
+        </Language>
       </Languages>
       <StringBlocks>
         <StringBlock name="Explorer Ranks Names"                   beg="374"  end="387"/>
@@ -796,6 +822,8 @@
         <StringBlock name="Spinda's Juice Bar Strings"             beg="17831"  end="17931"/>
         <StringBlock name="Recycle Shop Strings"                   beg="17931"  end="17991"/>
         <StringBlock name="Staff Roll"                             beg="17991"  end="18482"/>
+        <StringBlock name="New Pokemon Names"                          beg="18482"  end="20530"/>
+        <StringBlock name="New Pokemon Categories"                     beg="20530"  end="22578"/>
       </StringBlocks>
     </Game>
     

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -1055,6 +1055,9 @@
           <OpenBin filepath="overlay/overlay_0011.bin">
 		  <Include filename ="irdkwia_asm_mods/expand_poke_list/selector_overlay11.asm"/>
           </OpenBin>
+          <OpenBin filepath="overlay/overlay_0019.bin">
+		  <Include filename ="irdkwia_asm_mods/expand_poke_list/selector_overlay19.asm"/>
+          </OpenBin>
           <OpenBin filepath="overlay/overlay_0029.bin">
 		  <Include filename ="irdkwia_asm_mods/expand_poke_list/selector_overlay29.asm"/>
           </OpenBin>

--- a/skytemple_files/common/ppmdu_config/data.py
+++ b/skytemple_files/common/ppmdu_config/data.py
@@ -18,7 +18,7 @@ For now, the documentation of fields is in the pmd2data.xml.
 #
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
-from typing import List, Dict, Union, Pattern
+from typing import List, Dict, Union, Pattern, Optional
 
 from skytemple_files.common.ppmdu_config.dungeon_data import Pmd2DungeonData
 from skytemple_files.common.ppmdu_config.script_data import Pmd2ScriptData
@@ -108,13 +108,19 @@ class Pmd2Binary(AutoString):
         self.functions: Dict[str, Pmd2BinaryFunction] = {x.name: x for x in functions}
         self.pointers: Dict[str, Pmd2BinaryPointer] = {x.name: x for x in pointers}
 
+class Pmd2SortLists(AutoString):
+    def __init__(self, m2n: Optional[str], n2m: Optional[str], i2n: Optional[str]):
+        self.m2n = m2n
+        self.n2m = n2m
+        self.i2n = i2n
 
 class Pmd2Language(AutoString):
-    def __init__(self, filename: str, name: str, name_localized: str, locale: str):
+    def __init__(self, filename: str, name: str, name_localized: str, locale: str, sort_lists: Pmd2SortLists):
         self.filename = filename
         self.name = name
         self.name_localized = name_localized
         self.locale = locale
+        self.sort_lists = sort_lists
 
     def __str__(self):
         return self.name_localized

--- a/skytemple_files/common/ppmdu_config/xml_reader.py
+++ b/skytemple_files/common/ppmdu_config/xml_reader.py
@@ -157,11 +157,22 @@ class Pmd2XmlReader:
                         for e_sub in e_game:
                             if e_sub.tag == 'Languages':
                                 for e_language in e_sub:
+                                    m2n = None
+                                    n2m = None
+                                    i2n = None
+                                    for e_sort in e_language:
+                                        if e_sort.tag=="m2n":
+                                            m2n=e_sort.attrib['filename']
+                                        elif e_sort.tag=="n2m":
+                                            n2m=e_sort.attrib['filename']
+                                        elif e_sort.tag=="i2n":
+                                            i2n=e_sort.attrib['filename']
                                     languages.append(Pmd2Language(
                                         e_language.attrib['filename'],
                                         e_language.attrib['name'],
                                         self._(e_language.attrib['name']),
                                         e_language.attrib['locale'],
+                                        Pmd2SortLists(m2n, n2m, i2n)
                                     ))
                             if e_sub.tag == 'StringBlocks':
                                 for e_string_block in e_sub:

--- a/skytemple_files/common/util.py
+++ b/skytemple_files/common/util.py
@@ -16,6 +16,7 @@
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 import bisect
 import re
+import unicodedata
 import warnings
 from itertools import groupby
 from typing import List, Tuple, TYPE_CHECKING, Iterable
@@ -39,6 +40,13 @@ MONSTER_BIN = 'MONSTER/monster.bin'
 
 DEBUG = False
 
+
+def normalize_string(x: str):
+    """Returns a normalized ASCII string for sorting purposes."""
+    # TODO, does not handle everything
+    x = x.lower()
+    x=unicodedata.normalize('NFKD', x).encode('ascii', 'ignore')
+    return x
 
 def open_utf8(file, mode='r', *args, **kwargs):
     """Like open, but always uses the utf-8 encoding, on all platforms."""

--- a/skytemple_files/data/dbg/xml_export_test.py
+++ b/skytemple_files/data/dbg/xml_export_test.py
@@ -26,7 +26,7 @@ from skytemple_files.common.types.file_types import FileType
 from skytemple_files.common.util import get_ppmdu_config_for_rom
 from skytemple_files.common.xml_util import prettify
 from skytemple_files.container.bin_pack.model import BinPack
-from skytemple_files.data.md.model import NUM_ENTITIES, Md
+from skytemple_files.data.md.model import MdProperties, Md
 from skytemple_files.data.monster_xml import monster_xml_export, monster_xml_import
 from skytemple_files.data.waza_p.model import WazaP
 from skytemple_files.graphics.kao.model import Kao, SUBENTRIES
@@ -53,7 +53,7 @@ for lang in config.string_index_data.languages:
     languages[lang.name] = FileType.STR.deserialize(rom.getFileByName('MESSAGE/' + lang.filename))
 
 
-for md_base_index in range(0, NUM_ENTITIES):
+for md_base_index in range(0, MdProperties.NUM_ENTITIES):
     md_gender1 = None
     md_gender2 = None
     names = None
@@ -64,8 +64,8 @@ for md_base_index in range(0, NUM_ENTITIES):
     portraits2 = None
 
     md_gender1 = md.entries[md_base_index]
-    if NUM_ENTITIES + md_base_index < len(md.entries):
-        md_gender2 = md.entries[NUM_ENTITIES + md_base_index]
+    if MdProperties.NUM_ENTITIES + md_base_index < len(md.entries):
+        md_gender2 = md.entries[MdProperties.NUM_ENTITIES + md_base_index]
 
     string_id = config.string_index_data.string_blocks['Pokemon Names'].begin + md_base_index
     cat_string_id = config.string_index_data.string_blocks['Pokemon Categories'].begin + md_base_index
@@ -90,10 +90,10 @@ for md_base_index in range(0, NUM_ENTITIES):
         for kao_i in range(0, SUBENTRIES):
             portraits.append(kao.get(stat_id, kao_i))
 
-    if stat_id > -1 and NUM_ENTITIES + stat_id < kao.toc_len:
+    if stat_id > -1 and MdProperties.NUM_ENTITIES + stat_id < kao.toc_len:
         portraits2 = []
         for kao_i in range(0, SUBENTRIES):
-            portraits2.append(kao.get(NUM_ENTITIES + stat_id, kao_i))
+            portraits2.append(kao.get(MdProperties.NUM_ENTITIES + stat_id, kao_i))
     
     xml = monster_xml_export(
         config.game_version, md_gender1, md_gender2,

--- a/skytemple_files/data/md/model.py
+++ b/skytemple_files/data/md/model.py
@@ -21,7 +21,15 @@ from skytemple_files.common.util import *
 from skytemple_files.common.i18n_util import f, _
 
 
-NUM_ENTITIES = 2400
+# Honestly, I don't know a better way to do that
+class MdProperties:
+    NUM_ENTITIES = 600
+    MAX_POSSIBLE = 554
+
+# This is only for compatibility issues
+# The one that should be used is in MdProperties
+NUM_ENTITIES = 600
+
 MD_ENTRY_LEN = 68
 
 
@@ -455,7 +463,7 @@ class MdEntry(AutoString):
 
     @property
     def md_index_base(self):
-        return self.md_index % NUM_ENTITIES
+        return self.md_index % MdProperties.NUM_ENTITIES
 
 
 class Md:

--- a/skytemple_files/data/md/model.py
+++ b/skytemple_files/data/md/model.py
@@ -21,7 +21,7 @@ from skytemple_files.common.util import *
 from skytemple_files.common.i18n_util import f, _
 
 
-NUM_ENTITIES = 600
+NUM_ENTITIES = 2400
 MD_ENTRY_LEN = 68
 
 
@@ -397,18 +397,18 @@ class ShadowSize(Enum):
 
 class MdEntry(AutoString):
     def __init__(self, *, bitflag1: int, **data):
-        self.md_index: int = -1
-        self.entid: int = -1
-        self.unk31: int = -1
-        self.national_pokedex_number: int = -1
-        self.base_movement_speed: int = -1
-        self.pre_evo_index: int = -1
+        self.md_index: int = 0
+        self.entid: int = 0
+        self.unk31: int = 0
+        self.national_pokedex_number: int = 0
+        self.base_movement_speed: int = 0
+        self.pre_evo_index: int = 0
         self.evo_method: EvolutionMethod = EvolutionMethod.NONE
-        self.evo_param1: int = -1
+        self.evo_param1: int = 0
         self.evo_param2: AdditionalRequirement = AdditionalRequirement.NONE
-        self.sprite_index: int = -1
+        self.sprite_index: int = 0
         self.gender: Gender = Gender.INVALID
-        self.body_size: int = -1
+        self.body_size: int = 0
         self.type_primary: PokeType = PokeType.NONE
         self.type_secondary: PokeType = PokeType.NONE
         self.movement_type: MovementType = MovementType.STANDARD
@@ -418,35 +418,35 @@ class MdEntry(AutoString):
         self.bitfield1_0, self.bitfield1_1, self.bitfield1_2, self.bitfield1_3, \
             self.can_move, self.bitfield1_5, self.can_evolve, self.item_required_for_spawning = \
             (bool(bitflag1 >> i & 1) for i in range(8))
-        self.exp_yield: int = -1
-        self.recruit_rate1: int = -1
-        self.base_hp: int = -1
-        self.recruit_rate2: int = -1
-        self.base_atk: int = -1
-        self.base_sp_atk: int = -1
-        self.base_def: int = -1
-        self.base_sp_def: int = -1
-        self.weight: int = -1
-        self.size: int = -1
-        self.unk17: int = -1
-        self.unk18: int = -1
+        self.exp_yield: int = 0
+        self.recruit_rate1: int = 0
+        self.base_hp: int = 0
+        self.recruit_rate2: int = 0
+        self.base_atk: int = 0
+        self.base_sp_atk: int = 0
+        self.base_def: int = 0
+        self.base_sp_def: int = 0
+        self.weight: int = 0
+        self.size: int = 0
+        self.unk17: int = 0
+        self.unk18: int = 0
         self.shadow_size: ShadowSize = ShadowSize.SMALL
-        self.chance_spawn_asleep: int = -1
+        self.chance_spawn_asleep: int = 0
         # @End:
         # The % of HP that this pokémon species regenerates at the end of each turn is equal to 1/(value * 2)
         # (Before applying any modifiers)
         # The final value is capped between 1/30 and 1/500
-        self.hp_regeneration: int = -1
-        self.unk21_h: int = -1
-        self.base_form_index: int = -1
-        self.exclusive_item1: int = -1
-        self.exclusive_item2: int = -1
-        self.exclusive_item3: int = -1
-        self.exclusive_item4: int = -1
-        self.unk27: int = -1
-        self.unk28: int = -1
-        self.unk29: int = -1
-        self.unk30: int = -1
+        self.hp_regeneration: int = 0
+        self.unk21_h: int = 0
+        self.base_form_index: int = 0
+        self.exclusive_item1: int = 0
+        self.exclusive_item2: int = 0
+        self.exclusive_item3: int = 0
+        self.exclusive_item4: int = 0
+        self.unk27: int = 0
+        self.unk28: int = 0
+        self.unk29: int = 0
+        self.unk30: int = 0
 
         for key in data:
             if not hasattr(self, key):

--- a/skytemple_files/patch/arm_patcher.py
+++ b/skytemple_files/patch/arm_patcher.py
@@ -134,27 +134,6 @@ class ArmPatcher:
                                                     "'armips' is inside your system's PATH.")) from ex
 
                 if retcode != 0:
-
-                    logger.warning("Failed applying an armips patch. Debugging information follow.")
-                    logger.warning("Tmp dir name: " + tmp)
-                    logger.warning("Patch dir name: " + patch_file_dir)
-                    contents = "???"
-                    try:
-                        lsresult = subprocess.Popen(['ls', '-la', tmp],
-                                                    stdout=subprocess.PIPE,
-                                                    stderr=subprocess.STDOUT)
-                        lsresult.wait()
-                        contents = str(lsresult.stdout.read(), 'utf-8')
-                    except BaseException:
-                        pass
-                    logger.warning("Contents of dir:\n" + contents)
-                    stdout = "???"
-                    try:
-                        stdout = str(result.stdout.read(), 'utf-8')
-                    except BaseException:
-                        pass
-                    logger.warning("Stdout:\n" + stdout)
-
                     raise PatchError(_("ARMIPS reported an error while applying the patch."),
                                      str(result.stdout.read(), 'utf-8'), str(result.stderr.read(), 'utf-8') if result.stderr else '')
 

--- a/skytemple_files/patch/handler/expand_poke_list.py
+++ b/skytemple_files/patch/handler/expand_poke_list.py
@@ -1,0 +1,228 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import *
+from skytemple_files.data.str.handler import StrHandler
+
+from skytemple_files.data.level_bin_entry.model import LEVEL_BIN_ENTRY_LEVEL_LEN
+from skytemple_files.data.md_evo.handler import MdEvoHandler
+from skytemple_files.data.md_evo.model import MdEvoEntry, MdEvoStats
+from skytemple_files.data.md_evo import MEVO_ENTRY_LENGTH, MEVO_STATS_LENGTH
+from skytemple_files.compression_container.pkdpx.handler import PkdpxHandler
+from skytemple_files.container.sir0.handler import Sir0Handler
+from skytemple_files.container.bin_pack.handler import BinPackHandler
+from skytemple_files.data.val_list.handler import ValListHandler
+from skytemple_files.data.waza_p.handler import WazaPHandler
+from skytemple_files.data.waza_p.model import MoveLearnset
+from skytemple_files.data.md.handler import MdHandler
+from skytemple_files.data.md.model import MdEntry
+from skytemple_files.graphics.kao.handler import KaoHandler
+from skytemple_files.graphics.kao.model import SUBENTRIES
+from skytemple_files.data.tbl_talk.handler import TblTalkHandler
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU, GAME_REGION_JP
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler
+
+
+NUM_PREVIOUS_ENTRIES = 600
+
+PATCH_CHECK_ADDR_APPLIED_US = 0x5449C
+PATCH_CHECK_ADDR_APPLIED_EU = 0x54818
+PATCH_CHECK_ADDR_APPLIED_JP = 0x0
+PATCH_CHECK_INSTR_APPLIED = 0x00000483
+
+US_NEW_PKMN_STR_REGION = 0x4814
+US_NEW_CAT_STR_REGION = 0x5014
+US_FILE_ASSOC = {"MESSAGE/text_e.str": ("BALANCE/st_m2n_j.bin", "BALANCE/st_n2m_j.bin")}
+EU_NEW_PKMN_STR_REGION = 0x4833
+EU_NEW_CAT_STR_REGION = 0x5033
+EU_FILE_ASSOC = {"MESSAGE/text_e.str": ("BALANCE/st_m2n_e.bin", "BALANCE/st_n2m_e.bin"),
+             "MESSAGE/text_f.str": ("BALANCE/st_m2n_f.bin", "BALANCE/st_n2m_f.bin"),
+             "MESSAGE/text_g.str": ("BALANCE/st_m2n_g.bin", "BALANCE/st_n2m_g.bin"),
+             "MESSAGE/text_i.str": ("BALANCE/st_m2n_i.bin", "BALANCE/st_n2m_i.bin"),
+             "MESSAGE/text_s.str": ("BALANCE/st_m2n_s.bin", "BALANCE/st_n2m_s.bin")}
+NUM_NEW_ENTRIES = 2048
+
+DUMMY_LS = 150 # Using Mewtwo's learnset, as it's supposed to be one of the biggest
+DUMMY_PERSONALITY = 0x20 # Using Dialga's personality
+class ExpandPokeListPatchHandler(AbstractPatchHandler):
+
+    @property
+    def name(self) -> str:
+        return 'ExpandPokeList'
+
+    @property
+    def description(self) -> str:
+        return 'Expand the pokemon entries allowed to 2048, and makes all entries independent.'
+
+    @property
+    def author(self) -> str:
+        return 'irdkwia'
+
+    @property
+    def version(self) -> str:
+        return '-1.0.0'
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_US, 4)!=PATCH_CHECK_INSTR_APPLIED
+            if config.game_region == GAME_REGION_EU:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_EU, 4)!=PATCH_CHECK_INSTR_APPLIED
+            if config.game_region == GAME_REGION_JP:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_JP, 4)!=PATCH_CHECK_INSTR_APPLIED
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                new_pkmn_str_region = US_NEW_PKMN_STR_REGION
+                new_cat_str_region = US_NEW_CAT_STR_REGION
+                file_assoc = US_FILE_ASSOC
+        if not self.is_applied(rom, config):
+            bincfg = config.binaries['arm9.bin']
+            binary = bytearray(get_binary_from_rom_ppmdu(rom, bincfg))
+            
+            # Apply the patch
+            for filename in get_files_from_rom_with_extension(rom, 'str'):
+                bin_before = rom.getFileByName(filename)
+                strings = StrHandler.deserialize(bin_before)
+                block = config.string_index_data.string_blocks['Pokemon Names']
+                monsters = strings.strings[block.begin:block.end]
+                strings.strings[block.begin:block.end] = [""]*(block.end-block.begin)
+                block = config.string_index_data.string_blocks['Pokemon Categories']
+                cats = strings.strings[block.begin:block.end]
+                strings.strings[block.begin:block.end] = [""]*(block.end-block.begin)
+                for x in range(NUM_NEW_ENTRIES):
+                    if x<NUM_PREVIOUS_ENTRIES*2:
+                        str_pkmn = monsters[x%NUM_PREVIOUS_ENTRIES]
+                    else:
+                        str_pkmn = "DmyPk%04d"%x
+                    if len(strings.strings)<=new_pkmn_str_region+x-1:
+                        strings.strings.append(str_pkmn)
+                    else:
+                        strings.strings[new_pkmn_str_region+x-1]=str_pkmn
+                for x in range(NUM_NEW_ENTRIES):
+                    if x<NUM_PREVIOUS_ENTRIES*2:
+                        str_cat = cats[x%NUM_PREVIOUS_ENTRIES]
+                    else:
+                        str_cat = "DmyCa%04d"%x
+                    if len(strings.strings)<=new_cat_str_region+x-1:
+                        strings.strings.append(str_cat)
+                    else:
+                        strings.strings[new_cat_str_region+x-1]=str_cat
+                bin_after = StrHandler.serialize(strings)
+                rom.setFileByName(filename, bin_after)
+                
+                sorted_list = list(enumerate(strings.strings[new_pkmn_str_region-1:new_pkmn_str_region-1+NUM_NEW_ENTRIES]))
+                sorted_list.sort(key=lambda x:x[1])
+                sorted_list = [x[0] for x in sorted_list]
+                inv_sorted_list = [sorted_list.index(i) for i in range(NUM_NEW_ENTRIES)]
+                m2n_model = ValListHandler.deserialize(rom.getFileByName(file_assoc[filename][0]))
+                m2n_model.set_list(inv_sorted_list)
+                rom.setFileByName(file_assoc[filename][0], ValListHandler.serialize(m2n_model))
+                n2m_model = ValListHandler.deserialize(rom.getFileByName(file_assoc[filename][1]))
+                n2m_model.set_list(sorted_list)
+                rom.setFileByName(file_assoc[filename][1], ValListHandler.serialize(n2m_model))
+                
+
+            # Expand kao file
+            kao_bin = rom.getFileByName('FONT/kaomado.kao')
+            kao_model = KaoHandler.deserialize(kao_bin)
+            kao_model.expand(NUM_NEW_ENTRIES-1)
+            for i in range(NUM_PREVIOUS_ENTRIES-1):
+                for j in range(SUBENTRIES):
+                    a = kao_model.get(i, j)
+                    b = kao_model.get(i+NUM_PREVIOUS_ENTRIES, j)
+                    if b==None and a!=None:
+                        kao_model.set(i+NUM_PREVIOUS_ENTRIES, j, a)
+            rom.setFileByName('FONT/kaomado.kao', KaoHandler.serialize(kao_model))
+            
+            # Expand tbl_talk
+            tlk_bin = rom.getFileByName('MESSAGE/tbl_talk.tlk')
+            tlk_model = TblTalkHandler.deserialize(tlk_bin)
+            while tlk_model.get_nb_monsters()<NUM_NEW_ENTRIES:
+                tlk_model.add_monster_personality(DUMMY_PERSONALITY)
+            rom.setFileByName('MESSAGE/tbl_talk.tlk', TblTalkHandler.serialize(tlk_model))
+
+            # Add monsters
+            md_bin = rom.getFileByName('BALANCE/monster.md')
+            md_model = MdHandler.deserialize(md_bin)
+            while len(md_model.entries)<NUM_NEW_ENTRIES:
+                md_model.entries.append(MdEntry(bitflag1=0, entid=len(md_model.entries)))
+            block = bincfg.blocks['MonsterSpriteData']
+            data = binary[block.begin:block.end]+binary[block.begin:block.end]
+            data += b'\x00\x00'*(NUM_NEW_ENTRIES-(len(data)//2))
+            for i in range(0,len(data),2):
+                md_model.entries[i//2].unk17 = data[i]
+                md_model.entries[i//2].unk18 = data[i+1]
+            rom.setFileByName('BALANCE/monster.md', MdHandler.serialize(md_model))
+            
+            # Add moves
+            waza_p_bin = rom.getFileByName('BALANCE/waza_p.bin')
+            waza_p_model = WazaPHandler.deserialize(waza_p_bin)
+            while len(waza_p_model.learnsets)<NUM_PREVIOUS_ENTRIES:
+                waza_p_model.learnsets.append(waza_p_model.learnsets[DUMMY_LS]) # Max Moveset
+            waza_p_model.learnsets = waza_p_model.learnsets+waza_p_model.learnsets
+            while len(waza_p_model.learnsets)<NUM_NEW_ENTRIES:
+                waza_p_model.learnsets.append(waza_p_model.learnsets[DUMMY_LS]) # Max Moveset
+            rom.setFileByName('BALANCE/waza_p.bin', WazaPHandler.serialize(waza_p_model))
+
+            # Add moves 2
+            waza_p_bin = rom.getFileByName('BALANCE/waza_p2.bin')
+            waza_p_model = WazaPHandler.deserialize(waza_p_bin)
+            while len(waza_p_model.learnsets)<NUM_PREVIOUS_ENTRIES:
+                waza_p_model.learnsets.append(waza_p_model.learnsets[DUMMY_LS]) # Max Moveset
+            waza_p_model.learnsets = waza_p_model.learnsets+waza_p_model.learnsets
+            while len(waza_p_model.learnsets)<NUM_NEW_ENTRIES:
+                waza_p_model.learnsets.append(waza_p_model.learnsets[DUMMY_LS]) # Max Moveset
+            rom.setFileByName('BALANCE/waza_p2.bin', WazaPHandler.serialize(waza_p_model))
+
+            # Add levels
+            level_bin = rom.getFileByName('BALANCE/m_level.bin')
+            level_model = BinPackHandler.deserialize(level_bin)
+            while len(level_model.get_files_bytes())<NUM_PREVIOUS_ENTRIES:
+                new_bytes_unpacked = bytes(LEVEL_BIN_ENTRY_LEVEL_LEN*100)
+                new_bytes_pkdpx = PkdpxHandler.serialize(PkdpxHandler.compress(new_bytes_unpacked))
+                new_bytes = Sir0Handler.serialize(Sir0Handler.wrap(new_bytes_pkdpx, []))
+                level_model.append(new_bytes) # Empty Levelup data
+            for i in range(NUM_PREVIOUS_ENTRIES):
+                level_model.append(level_model[i])
+            while len(level_model.get_files_bytes())<NUM_NEW_ENTRIES:
+                new_bytes_unpacked = bytes(LEVEL_BIN_ENTRY_LEVEL_LEN*100)
+                new_bytes_pkdpx = PkdpxHandler.serialize(PkdpxHandler.compress(new_bytes_unpacked))
+                new_bytes = Sir0Handler.serialize(Sir0Handler.wrap(new_bytes_pkdpx, []))
+                level_model.append(new_bytes) # Empty Levelup data
+            rom.setFileByName('BALANCE/m_level.bin', BinPackHandler.serialize(level_model))
+
+            # Add evolutions
+            evo_bin = rom.getFileByName('BALANCE/md_evo.bin')
+            evo_model = MdEvoHandler.deserialize(evo_bin)
+            while len(evo_model.evo_entries)<NUM_NEW_ENTRIES:
+                evo_model.evo_entries.append(MdEvoEntry(bytearray(MEVO_ENTRY_LENGTH)))
+            while len(evo_model.evo_stats)<NUM_NEW_ENTRIES:
+                evo_model.evo_stats.append(MdEvoStats(bytearray(MEVO_STATS_LENGTH)))
+            rom.setFileByName('BALANCE/md_evo.bin', MdEvoHandler.serialize(evo_model))
+
+        try:
+            apply()
+        except RuntimeError as ex:
+            raise ex
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/handler/expand_poke_list.py
+++ b/skytemple_files/patch/handler/expand_poke_list.py
@@ -40,7 +40,7 @@ from skytemple_files.graphics.kao.handler import KaoHandler
 from skytemple_files.graphics.kao.model import SUBENTRIES
 from skytemple_files.data.tbl_talk.handler import TblTalkHandler
 from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU, GAME_REGION_JP
-from skytemple_files.patch.handler.abstract import AbstractPatchHandler
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
 from skytemple_files.common.i18n_util import _
 
 
@@ -71,7 +71,7 @@ NUM_NEW_ENTRIES = 2048
 DUMMY_PKMN = 553
 DUMMY_LS = 150 # Using Mewtwo's learnset, as it's supposed to be one of the biggest
 DUMMY_PERSONALITY = 0x20 # Using Dialga's personality
-class ExpandPokeListPatchHandler(AbstractPatchHandler):
+class ExpandPokeListPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def name(self) -> str:
@@ -79,8 +79,10 @@ class ExpandPokeListPatchHandler(AbstractPatchHandler):
 
     @property
     def description(self) -> str:
-        return _("""Expand the pokemon entries allowed to 2048, and makes all entries independent.
-It is strongly recommended to fix any dungeon error before applying this patch. """)
+        return _("""Expand the pokemon entries allowed to 2048, and makes all the entries independent.
+Needs ChangeEvoSystem, ExternalizeWazaFile, ExternalizeMappaFile patches to work.
+It is strongly recommended to fix any dungeon error before applying this patch,
+and to save a backup of your ROM before applying this.""")
 
     @property
     def author(self) -> str:
@@ -90,6 +92,9 @@ It is strongly recommended to fix any dungeon error before applying this patch. 
     def version(self) -> str:
         return '-1.0.0'
 
+    def depends_on(self) -> List[str]:
+        return ["ChangeEvoSystem", "ExternalizeWazaFile", "ExternalizeMappaFile"]
+    
     def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
         if config.game_version == GAME_VERSION_EOS:
             if config.game_region == GAME_REGION_US:

--- a/skytemple_files/patch/handler/expand_poke_list.py
+++ b/skytemple_files/patch/handler/expand_poke_list.py
@@ -181,6 +181,12 @@ It is strongly recommended to fix any dungeon error before applying this patch. 
             md_model = MdHandler.deserialize(md_bin)
             while len(md_model.entries)<NUM_NEW_ENTRIES:
                 md_model.entries.append(MdEntry(bitflag1=0, entid=len(md_model.entries)))
+            for i in range(NUM_PREVIOUS_ENTRIES):
+                md_model.entries[i].entid=i
+                if md_model.entries[NUM_PREVIOUS_ENTRIES+i].gender==Gender.INVALID:
+                    md_model.entries[NUM_PREVIOUS_ENTRIES+i].entid=NUM_PREVIOUS_ENTRIES+i
+                else:
+                    md_model.entries[NUM_PREVIOUS_ENTRIES+i].entid=i
             block = bincfg.blocks['MonsterSpriteData']
             data = binary[block.begin:block.end]+binary[block.begin:block.end]
             data += b'\x00\x00'*(NUM_NEW_ENTRIES-(len(data)//2))

--- a/skytemple_files/patch/handler/expand_poke_list.py
+++ b/skytemple_files/patch/handler/expand_poke_list.py
@@ -40,6 +40,7 @@ from skytemple_files.graphics.kao.handler import KaoHandler
 from skytemple_files.graphics.kao.model import SUBENTRIES
 from skytemple_files.data.tbl_talk.handler import TblTalkHandler
 from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU, GAME_REGION_JP
+from skytemple_files.patch.category import PatchCategory
 from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
 from skytemple_files.common.i18n_util import _
 
@@ -103,8 +104,12 @@ and to save a backup of your ROM before applying this.""")
     def version(self) -> str:
         return '-1.0.0'
 
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.IMPROVEMENT_TWEAK
+
     def depends_on(self) -> List[str]:
-        return [] #["ChangeEvoSystem", "ExternalizeWazaFile", "ExternalizeMappaFile"]
+        return ["ChangeEvoSystem", "ExternalizeWazaFile", "ExternalizeMappaFile"]
     
     def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
         if config.game_version == GAME_VERSION_EOS:

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -58,6 +58,7 @@ from skytemple_files.patch.handler.extract_sp_code import ExtractSPCodePatchHand
 from skytemple_files.patch.handler.stat_disp import ChangeMoveStatDisplayPatchHandler
 from skytemple_files.patch.handler.change_evo import ChangeEvoSystemPatchHandler
 from skytemple_files.patch.handler.externalize_mappa import ExternalizeMappaPatchHandler
+from skytemple_files.patch.handler.expand_poke_list import ExpandPokeListPatchHandler
 from skytemple_files.common.i18n_util import f, _
 
 CORE_PATCHES_BASE_DIR = os.path.join(get_resources_dir(), 'patches')
@@ -91,6 +92,7 @@ class PatchType(Enum):
     ADD_TYPES = AddTypePatchHandler
     IMPLEMENT_FAIRY_GUMMIES = ImplementFairyGummiesPatchHandler
     EXTRACT_BAR_LIST = ExtractBarItemListPatchHandler
+    EXPAND_POKE_LIST = ExpandPokeListPatchHandler
 
 
 class PatchPackageError(RuntimeError):


### PR DESCRIPTION
Pull requests #104, #105, #106 need to be merged before that
EXPERIMENTAL! Always make a backup before there is a 99.99% chance I forgot something that will break the game and changes can't be reverted
Tests are needed for almost everything in the game

If/When this works properly, extends the number of possible Pokémon slots from 600 entries with 2 possible forms to 2048 independent entries
Tries to maintain consistency upon applying the patch, this includes: 

[ASM]: 
- all the data access function for movesets, monster properties and portraits have been changed to work with the new system
- special monster personalities have been moved after the new entries
- special fixed floor monster IDs have been moved after the new entries IDs
- the code that spawned 2nd forms in even floors has been removed
- missions and Spinda bar can theoretically spawn new entries: unused flags in monster.md were turned into flags that sets mission attributes for each Pokémon
- recruitment search menu looks for the new entries
- the Adventure Log functions looks for the new Pokédex IDs up to 1184

[Files]: 
- waza_p.bin/waza_p2.bin movesets are extended and slots that where originally 2nd forms have a copy of the 1st form movesets
- same for m_level.bin level curves
- tbl_talk.tlk is also extended to contain new entries personalities
- kaomado is extended and missing portraits for 2nd forms are filled with 1st forms when available
- Pokémon Names and Categories have been moved to the end of the *.str files
- the newly md_evo.bin created file from patch #104 is also extended for new entries evolutions
- special Pokémon indices (>=1155) for fixed floor properties have been moved
- mappa_s.bin is reworked to explicitly contain female entries if they are valid on even floors, like they used to
- obviously, monster.md is extended to contain more entries; also, the hardcoded arm9 table MonsterSpriteData that contained dungeon sprite size and sprite file size values have been moved to the unk17 unk18 properties of that file (which are unused/don't have any code to access them); property entid now contains the id of the 1st form of an entry, used for many checks in the game (was unused)