### PR TITLE
A patch to provide support for changing textbox bg color.

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_tbbg/common/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_tbbg/common/patch.asm
@@ -1,0 +1,19 @@
+; For use with ARMIPS
+; 2021/07/10
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Provides a way to change the textbox bg
+; ------------------------------------------------------------------------------
+
+.org HookSetBGColor
+.area 0x1C
+	ldr r0,[color]
+	str r0,[r5, #+0x60]
+	b after
+color:
+	.word 0x90202020 ; Color
+	.word 0x0
+	.word 0x0
+after:
+	add  r0,r5,#0x74
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_tbbg/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_tbbg/eu/offsets.asm
@@ -1,0 +1,13 @@
+; For use with ARMIPS
+; 2021/07/10
+; For Explorers of Sky EU Only
+; ------------------------------------------------------------------------------
+; Provides a way to change the textbox bg
+; ------------------------------------------------------------------------------
+
+
+.relativeinclude on
+.nds
+.arm
+
+.definelabel HookSetBGColor, 0x02027AE8

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_tbbg/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_tbbg/jp/offsets.asm
@@ -1,0 +1,13 @@
+; For use with ARMIPS
+; 2021/07/10
+; For Explorers of Sky JP Only
+; ------------------------------------------------------------------------------
+; Provides a way to change the textbox bg
+; ------------------------------------------------------------------------------
+
+
+.relativeinclude on
+.nds
+.arm
+
+.definelabel HookSetBGColor, 0x02027B54

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_tbbg/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_tbbg/na/offsets.asm
@@ -1,0 +1,13 @@
+; For use with ARMIPS
+; 2021/07/10
+; For Explorers of Sky NA Only
+; ------------------------------------------------------------------------------
+; Provides a way to change the textbox bg
+; ------------------------------------------------------------------------------
+
+
+.relativeinclude on
+.nds
+.arm
+
+.definelabel HookSetBGColor, 0x020277F4

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_tbbg/selector_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/change_tbbg/selector_arm9.asm
@@ -1,0 +1,22 @@
+; For use with ARMIPS
+; 2021/03/23
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/offsets.asm"
+	.include "common/patch.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/offsets.asm"
+	.include "common/patch.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/offsets.asm"
+	.include "common/patch.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -965,6 +965,13 @@
 	  </OpenBin>
         </Patch>
         
+        <!-- A patch to provide support for changing the textbox color -->
+        <Patch id="ChangeTextBoxBackground" >
+          <OpenBin filepath="arm9.bin">
+	  	<Include filename ="irdkwia_asm_mods/change_tbbg/selector_arm9.asm"/>
+	  </OpenBin>
+        </Patch>
+        
         <!-- A patch to externalize waza_p/waza_p2 files -->
         <Patch id="ExternalizeWazaFile" >
           <OpenBin filepath="arm9.bin">

--- a/skytemple_files/patch/handler/change_tbbg.py
+++ b/skytemple_files/patch/handler/change_tbbg.py
@@ -1,0 +1,75 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable, Dict, List, Set
+
+import os
+
+from skytemple_files.patch.category import PatchCategory
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU, GAME_REGION_JP
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler
+from skytemple_files.common.i18n_util import _
+
+PATCH_CHECK_ADDR_APPLIED_US = 0x277F4
+PATCH_CHECK_ADDR_APPLIED_EU = 0x27AE8
+PATCH_CHECK_ADDR_APPLIED_JP = 0x27B54
+PATCH_CHECK_INSTR_APPLIED = 0xE3A00020
+
+class ChangeTextBoxColorPatchHandler(AbstractPatchHandler):
+
+    @property
+    def name(self) -> str:
+        return 'ChangeTextBoxBackground'
+
+    @property
+    def description(self) -> str:
+        return _("""Provides support for editing textbox background color.""")
+
+    @property
+    def author(self) -> str:
+        return 'irdkwia'
+
+    @property
+    def version(self) -> str:
+        return '0.0.1'
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.UTILITY
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_US, 4)!=PATCH_CHECK_INSTR_APPLIED
+            if config.game_region == GAME_REGION_EU:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_EU, 4)!=PATCH_CHECK_INSTR_APPLIED
+            if config.game_region == GAME_REGION_JP:
+                return read_uintle(rom.arm9, PATCH_CHECK_ADDR_APPLIED_JP, 4)!=PATCH_CHECK_INSTR_APPLIED
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        try:
+            apply()
+        except RuntimeError as ex:
+            raise ex
+
+    
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -57,6 +57,7 @@ from skytemple_files.patch.handler.extract_item_code import ExtractItemCodePatch
 from skytemple_files.patch.handler.extract_sp_code import ExtractSPCodePatchHandler
 from skytemple_files.patch.handler.move_growth import MoveGrowthPatchHandler
 from skytemple_files.patch.handler.stat_disp import ChangeMoveStatDisplayPatchHandler
+from skytemple_files.patch.handler.change_tbbg import ChangeTextBoxColorPatchHandler
 from skytemple_files.patch.handler.change_evo import ChangeEvoSystemPatchHandler
 from skytemple_files.patch.handler.externalize_mappa import ExternalizeMappaPatchHandler
 from skytemple_files.patch.handler.expand_poke_list import ExpandPokeListPatchHandler
@@ -89,6 +90,7 @@ class PatchType(Enum):
     EXTRACT_ITEM_CODE = ExtractItemCodePatchHandler
     EXTRACT_SP_CODE = ExtractSPCodePatchHandler
     MOVE_GROWTH = MoveGrowthPatchHandler
+    CHANGE_TBBG = ChangeTextBoxColorPatchHandler
     STAT_DISP = ChangeMoveStatDisplayPatchHandler
     CHANGE_EVO_SYSTEM = ChangeEvoSystemPatchHandler
     EXTERNALIZE_MAPPA = ExternalizeMappaPatchHandler


### PR DESCRIPTION
This patch changes the instructions that set the textbox background color to make textbox color editing easier.
Once applied, color will be at arm9:0x27800 [US], 0x27AF4 [EU], 0x27B60 [JP] in that format: R,G,B,A with 1 byte for each component (default color should be 0x20,0x20,0x20,0x90).