### PR TITLE
Add EditExtraPokemon patch

### DIFF
--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -1208,6 +1208,14 @@
           </Replace>
         </SimplePatch>
 
+        <SimplePatch id="EditExtraPokemon">
+          <Include filename="end_asm_mods/src/EditExtraPokemon.asm"/>
+          <Replace filename="end_asm_mods/src/common/regionSelect.asm" regexp='_REGION equ "(\w+)"'>
+            <Game id="EoS_NA" replace='_REGION equ "US"'/>
+            <Game id="EoS_EU" replace='_REGION equ "EU"'/>
+          </Replace>
+        </SimplePatch>
+
       </Game>
     </Patches>
 

--- a/skytemple_files/patch/handler/edit_extra_pokemon.py
+++ b/skytemple_files/patch/handler/edit_extra_pokemon.py
@@ -1,0 +1,67 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler
+from skytemple_files.common.i18n_util import f, _
+
+ORIGINAL_INSTRUCTION = 0xE3560044
+OFFSET_EU = 0x4EF00
+OFFSET_US = 0x4EBC8
+
+
+class EditExtraPokemonPatchHandler(AbstractPatchHandler):
+
+    @property
+    def name(self) -> str:
+        return 'EditExtraPokemon'
+
+    @property
+    def description(self) -> str:
+        return _("Changes the way the game determines when to add additional pokémon to the team so it can be edited more easily")
+
+    @property
+    def author(self) -> str:
+        return 'End45'
+
+    @property
+    def version(self) -> str:
+        return '0.1.0'
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.UTILITY
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_uintle(rom.arm9, OFFSET_US, 4) != ORIGINAL_INSTRUCTION
+            if config.game_region == GAME_REGION_EU:
+                return read_uintle(rom.arm9, OFFSET_EU, 4) != ORIGINAL_INSTRUCTION
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        # Apply the patch
+        apply()
+
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -62,6 +62,7 @@ from skytemple_files.patch.handler.change_evo import ChangeEvoSystemPatchHandler
 from skytemple_files.patch.handler.externalize_mappa import ExternalizeMappaPatchHandler
 from skytemple_files.patch.handler.expand_poke_list import ExpandPokeListPatchHandler
 from skytemple_files.patch.handler.allow_unrecruitable_mons import AllowUnrecruitableMonsPatchHandler
+from skytemple_files.patch.handler.edit_extra_pokemon import EditExtraPokemonPatchHandler
 from skytemple_files.common.i18n_util import f, _
 
 CORE_PATCHES_BASE_DIR = os.path.join(get_resources_dir(), 'patches')
@@ -99,6 +100,7 @@ class PatchType(Enum):
     EXTRACT_BAR_LIST = ExtractBarItemListPatchHandler
     EXPAND_POKE_LIST = ExpandPokeListPatchHandler
     ALLOW_UNRECRUITABLE_MONS = AllowUnrecruitableMonsPatchHandler
+    EDIT_EXTRA_POKEMON = EditExtraPokemonPatchHandler
 
 
 class PatchPackageError(RuntimeError):


### PR DESCRIPTION
Adds a patch that un-hardcodes the way the game adds additional pokémon to the team when entering uncleared dungeons. This data will now be part of a table inside arm9.bin, making it possible to edit it with a hex editor.