### PR TITLE
Parameters for Patches

### DIFF
--- a/skytemple_files/common/ppmdu_config/data.py
+++ b/skytemple_files/common/ppmdu_config/data.py
@@ -168,12 +168,14 @@ class Pmd2PatchOpenBin(AutoString):
 
 
 class Pmd2PatchParameterType(Enum):
+    STRING = "str"
     INTEGER = "int"
     SELECT = "select"
 
 
 class Pmd2PatchParameterOption(AutoString):
-    def __init__(self, label: str, value: int):
+    def __init__(self, type: Pmd2PatchParameterType, label: str, value: any):
+        self.type = type
         self.label = label
         self.value = value
 

--- a/skytemple_files/common/ppmdu_config/data.py
+++ b/skytemple_files/common/ppmdu_config/data.py
@@ -18,6 +18,7 @@ For now, the documentation of fields is in the pmd2data.xml.
 #
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from enum import Enum
 from typing import List, Dict, Union, Pattern, Optional
 
 from skytemple_files.common.ppmdu_config.dungeon_data import Pmd2DungeonData
@@ -166,11 +167,39 @@ class Pmd2PatchOpenBin(AutoString):
         self.includes = includes
 
 
+class Pmd2PatchParameterType(Enum):
+    INTEGER = "int"
+    SELECT = "select"
+
+
+class Pmd2PatchParameterOption(AutoString):
+    def __init__(self, label: str, value: int):
+        self.label = label
+        self.value = value
+
+
+class Pmd2PatchParameter(AutoString):
+    def __init__(
+            self, name: str, type: Pmd2PatchParameterType, label: str, *,
+            min: Optional[int] = None, max: Optional[int] = None,
+            options: Optional[List[Pmd2PatchParameterOption]] = None):
+        self.name = name
+        self.type = type
+        self.label = label
+        self.min = min
+        self.max = max
+        self.options = options
+
+
 class Pmd2Patch(AutoString):
-    def __init__(self, id: str, includes: List[Pmd2PatchInclude], open_bins: List[Pmd2PatchOpenBin]):
+    def __init__(self, id: str, includes: List[Pmd2PatchInclude], open_bins: List[Pmd2PatchOpenBin], parameters: List[Pmd2PatchParameter]):
         self.id = id
         self.includes = includes
         self.open_bins = open_bins
+        self.parameters: Dict[str, Pmd2PatchParameter] = {param.name: param for param in parameters}
+
+    def has_parameters(self):
+        return len(self.parameters) > 0
 
 
 class Pmd2PatchStringReplacementGame(AutoString):
@@ -187,10 +216,14 @@ class Pmd2PatchStringReplacement(AutoString):
 
 
 class Pmd2SimplePatch(AutoString):
-    def __init__(self, id: str, includes: List[Pmd2PatchInclude], string_replacements: List[Pmd2PatchStringReplacement]):
+    def __init__(self, id: str, includes: List[Pmd2PatchInclude], string_replacements: List[Pmd2PatchStringReplacement], parameters: List[Pmd2PatchParameter]):
         self.id = id
         self.includes = includes
         self.string_replacements = string_replacements
+        self.parameters: Dict[str, Pmd2PatchParameter] = {param.name: param for param in parameters}
+
+    def has_parameters(self):
+        return len(self.parameters) > 0
 
 
 class Pmd2AsmPatchesConstants(AutoString):

--- a/skytemple_files/common/ppmdu_config/xml_reader.py
+++ b/skytemple_files/common/ppmdu_config/xml_reader.py
@@ -563,8 +563,10 @@ class Pmd2AsmPatchesConstantsXmlReader:
                         options = []
                         for e_option in e_param:
                             if e_option.tag == 'Option':
+                                value_type = Pmd2PatchParameterType(e_param.attrib['type'])
                                 options.append(Pmd2PatchParameterOption(
-                                    value=Pmd2XmlReader.xml_int(e_option.text),
+                                    type=value_type,
+                                    value=Pmd2XmlReader.xml_int(e_option.text) if value_type == Pmd2PatchParameterType.INTEGER else e_option.text,
                                     label=e_option.attrib['label'] if 'label' in e_option.attrib else e_option.attrib['value'],
                                 ))
                         params.append(Pmd2PatchParameter(

--- a/skytemple_files/common/ppmdu_config/xml_reader.py
+++ b/skytemple_files/common/ppmdu_config/xml_reader.py
@@ -94,7 +94,7 @@ class Pmd2XmlReader:
                         e_edition.attrib['gamecode'],
                         e_edition.attrib['version'],
                         e_edition.attrib['region'],
-                        self._xml_int(e_edition.attrib['arm9off14']),
+                        self.xml_int(e_edition.attrib['arm9off14']),
                         e_edition.attrib['defaultlang'],
                         self._xml_bool(e_edition.attrib['issupported'])
                     ))
@@ -105,7 +105,7 @@ class Pmd2XmlReader:
                        ('version2' in e_game.attrib and e_game.attrib['version2'] == self._game_version) or \
                        ('version3' in e_game.attrib and e_game.attrib['version3'] == self._game_version):
                         for e_value in e_game:
-                            game_constants[e_value.attrib['id']] = self._xml_int(e_value.attrib['value'])
+                            game_constants[e_value.attrib['id']] = self.xml_int(e_value.attrib['value'])
             ###########################
             elif e.tag == 'Binaries':
                 for e_game in e:
@@ -118,22 +118,22 @@ class Pmd2XmlReader:
                                 if e_node.tag == 'Block':
                                     blocks.append(Pmd2BinaryBlock(
                                         e_node.attrib['name'],
-                                        self._xml_int(e_node.attrib['beg']),
-                                        self._xml_int(e_node.attrib['end'])
+                                        self.xml_int(e_node.attrib['beg']),
+                                        self.xml_int(e_node.attrib['end'])
                                     ))
                                 elif e_node.tag == 'Fn':
                                     fns.append(Pmd2BinaryFunction(
                                         e_node.attrib['name'],
-                                        self._xml_int(e_node.attrib['beg'])
+                                        self.xml_int(e_node.attrib['beg'])
                                     ))
                                 elif e_node.tag == 'Pointer':
                                     pointers.append(Pmd2BinaryPointer(
                                         e_node.attrib['name'],
-                                        self._xml_int(e_node.attrib['beg'])
+                                        self.xml_int(e_node.attrib['beg'])
                                     ))
                             bin = Pmd2Binary(
                                 e_binary.attrib['filepath'],
-                                self._xml_int(e_binary.attrib['loadaddress']),
+                                self.xml_int(e_binary.attrib['loadaddress']),
                                 blocks,
                                 fns,
                                 pointers
@@ -179,8 +179,8 @@ class Pmd2XmlReader:
                                     string_blocks.append(Pmd2StringBlock(
                                         e_string_block.attrib['name'],
                                         self._(e_string_block.attrib['name']),
-                                        self._xml_int(e_string_block.attrib['beg']),
-                                        self._xml_int(e_string_block.attrib['end'])
+                                        self.xml_int(e_string_block.attrib['beg']),
+                                        self.xml_int(e_string_block.attrib['end'])
                                     ))
                         string_index_data = Pmd2StringIndexData(
                             languages, string_blocks
@@ -204,11 +204,11 @@ class Pmd2XmlReader:
                             indices = {}
                             for e_index in e_sprite:
                                 names = []
-                                idx = self._xml_int(e_index.attrib['id'])
+                                idx = self.xml_int(e_index.attrib['id'])
                                 indices[idx] = Pmd2Index(idx, names)
                                 for e_name in e_index:
                                     names.append(e_name.text)
-                            idx = self._xml_int(e_sprite.attrib['id'])
+                            idx = self.xml_int(e_sprite.attrib['id'])
                             animation_names[idx] = Pmd2Sprite(idx, indices)
 
         game_edition_for_this_rom = None
@@ -254,12 +254,12 @@ class Pmd2XmlReader:
                         for i, e_var in enumerate(e):
                             game_variables_table.append(Pmd2ScriptGameVar(
                                 i if e.tag == 'GameVariablesTable' else i + 0x400,
-                                self._xml_int(e_var.attrib['type']),
-                                self._xml_int(e_var.attrib['unk1']),
-                                self._xml_int(e_var.attrib['memoffset']),
-                                self._xml_int(e_var.attrib['bitshift']),
-                                self._xml_int(e_var.attrib['nbvalues']),
-                                self._xml_int(e_var.attrib['unk4']),
+                                self.xml_int(e_var.attrib['type']),
+                                self.xml_int(e_var.attrib['unk1']),
+                                self.xml_int(e_var.attrib['memoffset']),
+                                self.xml_int(e_var.attrib['bitshift']),
+                                self.xml_int(e_var.attrib['nbvalues']),
+                                self.xml_int(e_var.attrib['unk4']),
                                 e_var.attrib['name'],
                                 e.tag == 'GameVariablesTableExtended'
                             ))
@@ -267,10 +267,10 @@ class Pmd2XmlReader:
                     elif e.tag == 'ObjectsList':
                         for e_obj in e:
                             objects_list.append(Pmd2ScriptObject(
-                                self._xml_int(e_obj.attrib['_id']),
-                                self._xml_int(e_obj.attrib['unk1']),
-                                self._xml_int(e_obj.attrib['unk2']),
-                                self._xml_int(e_obj.attrib['unk3']),
+                                self.xml_int(e_obj.attrib['_id']),
+                                self.xml_int(e_obj.attrib['unk1']),
+                                self.xml_int(e_obj.attrib['unk2']),
+                                self.xml_int(e_obj.attrib['unk3']),
                                 e_obj.attrib['name']
                             ))
                     ###########################
@@ -284,35 +284,35 @@ class Pmd2XmlReader:
                     ###########################
                     elif e.tag == 'Directions':
                         for idx, e_dir in enumerate(e):
-                            i = self._xml_int(e_dir.attrib['_id'])
+                            i = self.xml_int(e_dir.attrib['_id'])
                             directions[i] = Pmd2ScriptDirection(i, e_dir.text, idx)
                     ###########################
                     elif e.tag == 'CommonRoutineInfo':
                         for e_cri in e:
                             common_routine_info.append(Pmd2ScriptRoutine(
-                                self._xml_int(e_cri.attrib['id']),
-                                self._xml_int(e_cri.attrib['unk1']),
+                                self.xml_int(e_cri.attrib['id']),
+                                self.xml_int(e_cri.attrib['unk1']),
                                 e_cri.attrib['name']
                             ))
                     ###########################
                     elif e.tag == 'MenuIds':
                         for e_menu in e:
                             menu_ids.append(Pmd2ScriptMenu(
-                                self._xml_int(e_menu.attrib['id']),
+                                self.xml_int(e_menu.attrib['id']),
                                 e_menu.attrib['name']
                             ))
                     ###########################
                     elif e.tag == 'ProcessSpecialIDs':
                         for e_psid in e:
                             process_specials.append(Pmd2ScriptSpecial(
-                                self._xml_int(e_psid.attrib['id']),
+                                self.xml_int(e_psid.attrib['id']),
                                 e_psid.attrib['name']
                             ))
                     ###########################
                     elif e.tag == 'SpriteEffectIDs':
                         for e_sei in e:
                             sprite_effects.append(Pmd2ScriptSpriteEffect(
-                                self._xml_int(e_sei.attrib['id']),
+                                self.xml_int(e_sei.attrib['id']),
                                 e_sei.attrib['name']
                             ))
                     ###########################
@@ -326,23 +326,23 @@ class Pmd2XmlReader:
                     elif e.tag == 'LevelList':
                         for e_level in e:
                             level_list.append(Pmd2ScriptLevel(
-                                self._xml_int(e_level.attrib['_id']),
-                                self._xml_int(e_level.attrib['mapid']),
+                                self.xml_int(e_level.attrib['_id']),
+                                self.xml_int(e_level.attrib['mapid']),
                                 e_level.attrib['name'],
-                                self._xml_int(e_level.attrib['mapty']) if 'mapty' in e_level.attrib else None,
-                                self._xml_int(e_level.attrib['unk2']),
-                                self._xml_int(e_level.attrib['unk4'])
+                                self.xml_int(e_level.attrib['mapty']) if 'mapty' in e_level.attrib else None,
+                                self.xml_int(e_level.attrib['unk2']),
+                                self.xml_int(e_level.attrib['unk4'])
                             ))
                     ###########################
                     elif e.tag == 'LivesEntityTable':
                         for e_ent in e:
                             lives_entities.append(Pmd2ScriptEntity(
-                                self._xml_int(e_ent.attrib['_id']),
-                                self._xml_int(e_ent.attrib['entid']),
+                                self.xml_int(e_ent.attrib['_id']),
+                                self.xml_int(e_ent.attrib['entid']),
                                 e_ent.attrib['name'],
-                                self._xml_int(e_ent.attrib['type']),
-                                self._xml_int(e_ent.attrib['unk3']),
-                                self._xml_int(e_ent.attrib['unk4'])
+                                self.xml_int(e_ent.attrib['type']),
+                                self.xml_int(e_ent.attrib['unk3']),
+                                self.xml_int(e_ent.attrib['unk4'])
                             ))
                     ###########################
                     elif e.tag == 'OpCodes':
@@ -352,7 +352,7 @@ class Pmd2XmlReader:
                             for e_argument in e_code:
                                 if e_argument.tag == 'Argument':
                                     arguments.append(Pmd2ScriptOpCodeArgument(
-                                        self._xml_int(e_argument.attrib['id']),
+                                        self.xml_int(e_argument.attrib['id']),
                                         e_argument.attrib['type'],
                                         e_argument.attrib['name'],
                                     ))
@@ -367,26 +367,26 @@ class Pmd2XmlReader:
                                             e_arg_group_arg.attrib['name'],
                                         ))
                                     repeating_argument_group = Pmd2ScriptOpCodeRepeatingArgumentGroup(
-                                        self._xml_int(e_argument.attrib['id']),
+                                        self.xml_int(e_argument.attrib['id']),
                                         arg_group_args
                                     )
                             arguments = sorted(arguments, key=lambda a: a.id)
                             op_codes.append(Pmd2ScriptOpCode(
-                                self._xml_int(e_code.attrib['id']),
+                                self.xml_int(e_code.attrib['id']),
                                 e_code.attrib['name'],
-                                self._xml_int(e_code.attrib['params']),
-                                self._xml_int(e_code.attrib['stringidx']),
-                                self._xml_int(e_code.attrib['unk2']),
-                                self._xml_int(e_code.attrib['unk3']),
+                                self.xml_int(e_code.attrib['params']),
+                                self.xml_int(e_code.attrib['stringidx']),
+                                self.xml_int(e_code.attrib['unk2']),
+                                self.xml_int(e_code.attrib['unk3']),
                                 arguments,
                                 repeating_argument_group
                             ))
                     elif e.tag == 'GroundStateStructs':
                         for e_code in e:
                             ground_state_structs[e_code.tag] = Pmd2ScriptGroundStateStruct(
-                                self._xml_int(e_code.attrib['offset']),
-                                self._xml_int(e_code.attrib['entrylength']),
-                                self._xml_int(e_code.attrib['maxentries'])
+                                self.xml_int(e_code.attrib['offset']),
+                                self.xml_int(e_code.attrib['entrylength']),
+                                self.xml_int(e_code.attrib['maxentries'])
                             )
         return Pmd2ScriptData(
             game_variables_table,
@@ -418,8 +418,8 @@ class Pmd2XmlReader:
                         files = []
                         for i, e_var in enumerate(e):
                             files.append(Pmd2BinPackFile(
-                                self._xml_int(e_var.attrib['idxfirst']),
-                                self._xml_int(e_var.attrib['idxlast']) if 'idxlast' in e_var.attrib else None,
+                                self.xml_int(e_var.attrib['idxfirst']),
+                                self.xml_int(e_var.attrib['idxlast']) if 'idxlast' in e_var.attrib else None,
                                 e_var.attrib['type'],
                                 e_var.attrib['name']
                             ))
@@ -441,9 +441,9 @@ class Pmd2XmlReader:
                                     for e_item in e_item_cat:
                                         if e_item.tag != 'Item':
                                             raise ValueError("Excpeted Item as subtag for ItemCategory.")
-                                        citems.append(self._xml_int(e_item.text))
-                                    item_categories[self._xml_int(e_item_cat.attrib['id'])] = Pmd2DungeonItemCategory(
-                                        self._xml_int(e_item_cat.attrib['id']),
+                                        citems.append(self.xml_int(e_item.text))
+                                    item_categories[self.xml_int(e_item_cat.attrib['id'])] = Pmd2DungeonItemCategory(
+                                        self.xml_int(e_item_cat.attrib['id']),
                                         e_item_cat.attrib['name'],
                                         citems
                                     )
@@ -455,7 +455,7 @@ class Pmd2XmlReader:
         )
 
     @staticmethod
-    def _xml_int(s: str):
+    def xml_int(s: str):
         s = s.strip()
         if s.startswith('0x'):
             return int(s, 16)
@@ -501,9 +501,13 @@ class Pmd2AsmPatchesConstantsXmlReader:
                     if id_matches_edition(e_game, self._game_edition):
                         for e_node in e_game:
                             if e_node.tag == 'Patch':
-                                patches.append(self._parse_patch(e_node))
+                                patch = self._parse_patch(e_node)
+                                patch.parameters = {param.name: param for param in self._read_parameter_node(e_node)}
+                                patches.append(patch)
                             if e_node.tag == 'SimplePatch':
-                                patches.append(self._parse_simple_patch(e_node))
+                                patch = self._parse_simple_patch(e_node)
+                                patch.parameters = {param.name: param for param in self._read_parameter_node(e_node)}
+                                patches.append(patch)
         return Pmd2AsmPatchesConstants(
             loose_bin_files,
             patch_dir,
@@ -524,7 +528,8 @@ class Pmd2AsmPatchesConstantsXmlReader:
         return Pmd2Patch(
             e_patch.attrib['id'],
             includes,
-            open_bins
+            open_bins,
+            []
         )
 
     def _parse_simple_patch(self, e_patch) -> Pmd2SimplePatch:
@@ -545,8 +550,32 @@ class Pmd2AsmPatchesConstantsXmlReader:
         return Pmd2SimplePatch(
             e_patch.attrib['id'],
             includes,
-            string_replacements
+            string_replacements,
+            []
         )
+
+    def _read_parameter_node(self, e_patch) -> List[Pmd2PatchParameter]:
+        params = []
+        for e_sub in e_patch:
+            if e_sub.tag == 'Parameters':
+                for e_param in e_sub:
+                    if e_param.tag == 'Param':
+                        options = []
+                        for e_option in e_param:
+                            if e_option.tag == 'Option':
+                                options.append(Pmd2PatchParameterOption(
+                                    value=Pmd2XmlReader.xml_int(e_option.text),
+                                    label=e_option.attrib['label'] if 'label' in e_option.attrib else e_option.attrib['value'],
+                                ))
+                        params.append(Pmd2PatchParameter(
+                            name=e_param.attrib['name'],
+                            type=Pmd2PatchParameterType(e_param.attrib['type']),
+                            label=e_param.attrib['label'] if 'label' in e_param.attrib else e_param.attrib['name'],
+                            min=Pmd2XmlReader.xml_int(e_param.attrib['min']) if 'min' in e_param.attrib else None,
+                            max=Pmd2XmlReader.xml_int(e_param.attrib['max']) if 'max' in e_param.attrib else None,
+                            options=options
+                        ))
+        return params
 
 
 class XmlCombinerMergeConfig:

--- a/skytemple_files/patch/arm_patcher.py
+++ b/skytemple_files/patch/arm_patcher.py
@@ -120,10 +120,10 @@ class ArmPatcher:
                 with open_utf8(os.path.join(tmp, ASM_ENTRYPOINT_FN), 'w') as fi:
                     fi.write(asm_entrypoint)
 
-                # Build parameters for definelabel
+                # Build parameters for equ
                 parameters = []
                 for param_name, param_value in parameter_values.items():
-                    parameters += ['-definelabel', param_name, str(param_value)]
+                    parameters += ['-equ', param_name, f'"{param_value}"' if isinstance(param_value, str) else str(param_value)]
 
                 # Run armips
                 try:

--- a/skytemple_files/patch/dbg/parameter_patches_test.py
+++ b/skytemple_files/patch/dbg/parameter_patches_test.py
@@ -1,0 +1,83 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+#
+import os
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import get_ppmdu_config_for_rom, get_binary_from_rom_ppmdu
+from skytemple_files.patch.patches import Patcher
+from skytemple_files.patch.errors import PatchNotConfiguredError
+
+if __name__ == '__main__':
+    out_dir = os.path.join(os.path.dirname(__file__), 'dbg_output')
+    base_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..')
+    package = os.path.join(os.path.dirname(__file__), 'parameters_test')
+    os.makedirs(out_dir, exist_ok=True)
+    os.environ['SKYTEMPLE_DEBUG_ARMIPS_OUTPUT'] = 'YES'
+
+    in_rom = NintendoDSRom.fromFile(os.path.join(base_dir, 'skyworkcopy.nds'))
+
+    # Load PPMDU config, but remove all data about Patches and LooseBinFiles.
+    config = get_ppmdu_config_for_rom(in_rom)
+    config.asm_patches_constants.patches = {}
+    config.asm_patches_constants.loose_bin_files = {}
+    patcher = Patcher(in_rom, config, skip_core_patches=True)
+
+    # Load the package
+    patcher.add_pkg(package, False)
+    assert not patcher.is_applied('ParametersTest')
+
+    # Missing params
+    try:
+        patcher.apply('ParametersTest')
+    except PatchNotConfiguredError:
+        pass
+    else:
+        assert False, "Must throw PatchNotConfiguredError"
+
+    # Invalid params
+    try:
+        patcher.apply('ParametersTest', config={
+            'int_param': -1,
+            'int_param2': 100,
+            'int_param3': 1234,
+            'select_param': 1
+        })
+    except PatchNotConfiguredError as ex:
+        assert ex.config_parameter == 'int_param', "Must throw PatchNotConfiguredError for int_param, since it's out of range."
+    else:
+        assert False, "Must throw PatchNotConfiguredError for validation"
+    try:
+        patcher.apply('ParametersTest', config={
+            'int_param': 1,
+            'int_param2': 100,
+            'int_param3': 1234,
+            'select_param': 4
+        })
+    except PatchNotConfiguredError as ex:
+        assert ex.config_parameter == 'select_param', "Must throw PatchNotConfiguredError for select_param, since it's an invalid option."
+    else:
+        assert False, "Must throw PatchNotConfiguredError for validation"
+
+    # Check output!:
+    patcher.apply('ParametersTest', config={
+        'int_param': 1,
+        'int_param2': 100,
+        'int_param3': 1234,
+        'select_param': 2
+    })

--- a/skytemple_files/patch/dbg/parameter_patches_test.py
+++ b/skytemple_files/patch/dbg/parameter_patches_test.py
@@ -56,7 +56,8 @@ if __name__ == '__main__':
             'int_param': -1,
             'int_param2': 100,
             'int_param3': 1234,
-            'select_param': 1
+            'select_param': 'HELLO',
+            'string_param': 'World'
         })
     except PatchNotConfiguredError as ex:
         assert ex.config_parameter == 'int_param', "Must throw PatchNotConfiguredError for int_param, since it's out of range."
@@ -67,7 +68,8 @@ if __name__ == '__main__':
             'int_param': 1,
             'int_param2': 100,
             'int_param3': 1234,
-            'select_param': 4
+            'select_param': 'INVALID',
+            'string_param': 'World'
         })
     except PatchNotConfiguredError as ex:
         assert ex.config_parameter == 'select_param', "Must throw PatchNotConfiguredError for select_param, since it's an invalid option."
@@ -79,5 +81,6 @@ if __name__ == '__main__':
         'int_param': 1,
         'int_param2': 100,
         'int_param3': 1234,
-        'select_param': 2
+        'select_param': 'HELLO',
+        'string_param': 'World'
     })

--- a/skytemple_files/patch/dbg/parameters_test/asm_patches/header_stub_eu.asm
+++ b/skytemple_files/patch/dbg/parameters_test/asm_patches/header_stub_eu.asm
@@ -1,0 +1,3 @@
+.relativeinclude on
+.nds
+.arm

--- a/skytemple_files/patch/dbg/parameters_test/asm_patches/header_stub_na.asm
+++ b/skytemple_files/patch/dbg/parameters_test/asm_patches/header_stub_na.asm
@@ -1,0 +1,3 @@
+.relativeinclude on
+.nds
+.arm

--- a/skytemple_files/patch/dbg/parameters_test/asm_patches/patch.asm
+++ b/skytemple_files/patch/dbg/parameters_test/asm_patches/patch.asm
@@ -1,0 +1,4 @@
+.notice int_param
+.notice int_param2
+.notice int_param3
+.notice select_param

--- a/skytemple_files/patch/dbg/parameters_test/config.xml
+++ b/skytemple_files/patch/dbg/parameters_test/config.xml
@@ -1,0 +1,24 @@
+<PMD2>
+  <ASMPatchesConstants>
+    <Patches>
+      <Game id="EoS_NA" id2="EoS_EU">
+        <!-- Also works with SimplePatch -->
+        <Patch id="ParametersTest" >
+          <OpenBin filepath="overlay/overlay_0029.bin">
+            <Include filename ="patch.asm"/>
+          </OpenBin>
+          <Parameters>
+            <Param name="int_param" label="Integer Param with 0 min, 100 max" type="int" min="0" max="100"/>
+            <Param name="int_param2" label="Integer Param with 100 max" type="int" max="100"/>
+            <Param name="int_param3" label="Integer Param no restrictions but a default" default="200" type="int"/>
+            <Param name="select_param" label="Select" type="select">
+              <Option label="HELLO" >1</Option>
+              <Option label="WORLD">2</Option>
+              <Option label="FOOBAR">3</Option>
+            </Param>
+          </Parameters>
+        </Patch>
+      </Game>
+    </Patches>
+  </ASMPatchesConstants>
+</PMD2>

--- a/skytemple_files/patch/dbg/parameters_test/config.xml
+++ b/skytemple_files/patch/dbg/parameters_test/config.xml
@@ -12,10 +12,11 @@
             <Param name="int_param2" label="Integer Param with 100 max" type="int" max="100"/>
             <Param name="int_param3" label="Integer Param no restrictions but a default" default="200" type="int"/>
             <Param name="select_param" label="Select" type="select">
-              <Option label="HELLO" >1</Option>
-              <Option label="WORLD">2</Option>
-              <Option label="FOOBAR">3</Option>
+              <Option label="HELLO" type="str">HELLO</Option>
+              <Option label="WORLD" type="str">WORLD</Option>
+              <Option label="Number" type="int">3</Option>
             </Param>
+            <Param name="string_param" type="str"/> <!-- No label for testing -->
           </Parameters>
         </Patch>
       </Game>

--- a/skytemple_files/patch/dbg/parameters_test/patch.py
+++ b/skytemple_files/patch/dbg/parameters_test/patch.py
@@ -50,6 +50,7 @@ class PatchHandler(AbstractPatchHandler):
         self._debug("int_param2")
         self._debug("int_param3")
         self._debug("select_param")
+        self._debug("string_param")
         try:
             self._debug("doesntexist")
         except PatchNotConfiguredError:

--- a/skytemple_files/patch/dbg/parameters_test/patch.py
+++ b/skytemple_files/patch/dbg/parameters_test/patch.py
@@ -1,0 +1,67 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.ppmdu_config.data import Pmd2Data
+from skytemple_files.patch.errors import PatchNotConfiguredError
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler
+
+
+class PatchHandler(AbstractPatchHandler):
+
+    @property
+    def name(self) -> str:
+        return 'ParametersTest'
+
+    @property
+    def description(self) -> str:
+        return "Tests patch parameters."
+
+    @property
+    def author(self) -> str:
+        return 'End45'
+
+    @property
+    def version(self) -> str:
+        return '0.1.0'
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        return False
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        print("DEBUGGING PATCH PARAMETERS:")
+        self._debug("int_param")
+        self._debug("int_param2")
+        self._debug("int_param3")
+        self._debug("select_param")
+        try:
+            self._debug("doesntexist")
+        except PatchNotConfiguredError:
+            pass
+        else:
+            assert False, "Quering a non-existent variable must raise an error."
+        # Apply the patch
+        apply()
+
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()
+
+    def _debug(self, name: str):
+        val = self.get_parameter(name)
+        print(name, type(val), val)

--- a/skytemple_files/patch/errors.py
+++ b/skytemple_files/patch/errors.py
@@ -1,0 +1,33 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+
+class PatchPackageError(RuntimeError):
+    pass
+
+
+class PatchDependencyError(RuntimeError):
+    pass
+
+
+class PatchNotConfiguredError(RuntimeError):
+    def __init__(self, message: str, config_parameter: str, error: str):
+        super().__init__(message)
+        self.config_parameter = config_parameter
+        self.error = error
+
+    def __str__(self):
+        return f'{super().__str__()} - Param: {self.config_parameter} - Error: {self.error}'

--- a/skytemple_files/patch/handler/abstract.py
+++ b/skytemple_files/patch/handler/abstract.py
@@ -15,12 +15,13 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 from abc import ABC, abstractmethod
-from typing import Callable, List
+from typing import Callable, List, Dict, Union
 
 from ndspy.rom import NintendoDSRom
 
 from skytemple_files.common.ppmdu_config.data import Pmd2Data
 from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.errors import PatchNotConfiguredError
 
 
 class AbstractPatchHandler(ABC):
@@ -88,6 +89,32 @@ class AbstractPatchHandler(ABC):
         See apply method for info on how it will work.
         May raise NotImplementedError, if not supported.
         """
+
+    def get_parameter(self, name: str) -> Union[int, str]:
+        """
+        Returns the given configuration parameter. Make sure it is defined.
+        :param name: name of the parameter
+        """
+        try:
+            if name in self.__parameters:
+                return self.__parameters[name]
+            raise PatchNotConfiguredError("No configuration provided.", name, "No configuration provided.")
+        except AttributeError:
+            raise PatchNotConfiguredError("No configuration provided.", "*", "No configuration provided.")
+
+    def get_parameters(self) -> Dict[str, Union[int, str]]:
+        """
+        Returns all given configuration parameters or an empty dict of nothing was given.
+        """
+        try:
+            return self.__parameters
+        except AttributeError:
+            return dict()
+
+    # noinspection PyAttributeOutsideInit
+    def supply_parameters(self, parameters: Dict[str, Union[int, str]]):
+        """Only to be called by the patch handler: Sets the configuration parameters."""
+        self.__parameters = parameters
 
 
 class DependantPatch(ABC):

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -15,10 +15,11 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 import os
+import shutil
 from enum import Enum
 from functools import partial
 from tempfile import TemporaryDirectory
-from typing import Type, Dict, List, Generator
+from typing import Dict, List, Generator, Optional
 from xml.etree import ElementTree
 from xml.etree.ElementTree import ParseError
 from zipfile import ZipFile
@@ -26,10 +27,11 @@ import importlib.util
 
 from ndspy.rom import NintendoDSRom
 
-from skytemple_files.common.ppmdu_config.data import Pmd2Data, Pmd2AsmPatchesConstants
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, Pmd2AsmPatchesConstants, Pmd2PatchParameterType
 from skytemple_files.common.ppmdu_config.xml_reader import Pmd2AsmPatchesConstantsXmlReader
 from skytemple_files.common.util import get_resources_dir
 from skytemple_files.patch.arm_patcher import ArmPatcher
+from skytemple_files.patch.errors import PatchPackageError, PatchDependencyError, PatchNotConfiguredError
 from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
 from skytemple_files.patch.handler.actor_and_level_loader import ActorAndLevelListLoaderPatchHandler
 from skytemple_files.patch.handler.disable_tips import DisableTipsPatch
@@ -101,14 +103,6 @@ class PatchType(Enum):
     ALLOW_UNRECRUITABLE_MONS = AllowUnrecruitableMonsPatchHandler
 
 
-class PatchPackageError(RuntimeError):
-    pass
-
-
-class PatchDependencyError(RuntimeError):
-    pass
-
-
 class Patcher:
     def __init__(self, rom: NintendoDSRom, config: Pmd2Data, skip_core_patches=False):
         self._rom = rom
@@ -134,7 +128,12 @@ class Patcher:
             raise ValueError(f(_("The patch '{name}' was not found.")))
         return self._loaded_patches[name].is_applied(self._rom, self._config)
 
-    def apply(self, name: str):
+    def apply(self, name: str, config: Optional[Dict] = None):
+        """
+        Apply a patch.
+        If the patch requires parameters, values for ALL of them must be in the dict `config` (even if default values
+        are specified in the XML config).
+        """
         if name not in self._loaded_patches:
             raise ValueError(f(_("The patch '{name}' was not found.")))
         patch = self._loaded_patches[name]
@@ -148,26 +147,59 @@ class Patcher:
                     raise PatchDependencyError(f(_("The patch '{patch_name}' needs to be applied before you can "
                                                    "apply '{name}'. "
                                                    "This patch could not be found."))) from err
+        # Check config
+        patch_data = self._config.asm_patches_constants.patches[name]
+        if patch_data.has_parameters():
+            if config is None:
+                raise PatchNotConfiguredError("No configuration was given.", "*", "No configuration was given.")
+            for param in patch_data.parameters.values():
+                if param.name not in config:
+                    raise PatchNotConfiguredError("Missing configuration value.", param.name, "Not given.")
+                if param.type == Pmd2PatchParameterType.INTEGER:
+                    val = config[param.name]
+                    if not isinstance(val, int):
+                        raise PatchNotConfiguredError("Invalid configuration value.", param.name, "Must be int.")
+                    if param.min is not None and val < param.min:
+                        raise PatchNotConfiguredError("Invalid configuration value.", param.name, f"Must be >= {param.min}.")
+                    if param.max is not None and val > param.max:
+                        raise PatchNotConfiguredError("Invalid configuration value.", param.name, f"Must be <= {param.max}.")
+                if param.type == Pmd2PatchParameterType.SELECT:
+                    val = config[param.name]
+                    found = False
+                    for option in param.options:
+                        if not isinstance(val, type(option.value)) or option.value != val:
+                            continue
+                        found = True
+                        break
+                    if not found:
+                        raise PatchNotConfiguredError("Invalid configuration value.", param.name, "Must be one of the options.")
+            patch.supply_parameters(config)
         patch.apply(
-            partial(self._apply_armips, name),
+            partial(self._apply_armips, name, patch),
             self._rom, self._config
         )
 
-    def _apply_armips(self, name: str):
+    def _apply_armips(self, name: str, calling_patch: AbstractPatchHandler):
         patch = self._config.asm_patches_constants.patches[name]
         patch_dir_for_version = self._config.asm_patches_constants.patch_dir.filepath
         stub_path_for_version = self._config.asm_patches_constants.patch_dir.stubpath
+        parameter_values = calling_patch.get_parameters()
+
         self._arm_patcher.apply(patch, self._config.binaries,
                                 os.path.join(self._patch_dirs[name], patch_dir_for_version),
-                                stub_path_for_version, self._config.game_edition)
+                                stub_path_for_version, self._config.game_edition, parameter_values)
 
-    def add_pkg(self, zip_path: str):
+    def add_pkg(self, path: str, is_zipped=True):
         """Loads a skypatch file. Raises PatchPackageError on error."""
         tmpdir = TemporaryDirectory()
         self._created_tmpdirs.append(tmpdir)
-        with ZipFile(zip_path, 'r') as zip:
-            zip.extractall(tmpdir.name)
-            zip_id = id(zip)
+        if is_zipped:
+            with ZipFile(path, 'r') as zip:
+                zip.extractall(tmpdir.name)
+                f_id = id(zip)
+        else:
+            shutil.copytree(os.path.join(path, '.'), os.path.join(tmpdir.name, '.'), dirs_exist_ok=True)
+            f_id = id(tmpdir)
 
         # Load the configuration
         try:
@@ -180,7 +212,7 @@ class Patcher:
 
         # Evalulate the module
         try:
-            module_name = f"skytemple_files.__patches.p{zip_id}"
+            module_name = f"skytemple_files.__patches.p{f_id}"
             spec = importlib.util.spec_from_file_location(module_name,
                                                           os.path.join(tmpdir.name, 'patch.py'))
             patch = importlib.util.module_from_spec(spec)

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -163,6 +163,10 @@ class Patcher:
                         raise PatchNotConfiguredError("Invalid configuration value.", param.name, f"Must be >= {param.min}.")
                     if param.max is not None and val > param.max:
                         raise PatchNotConfiguredError("Invalid configuration value.", param.name, f"Must be <= {param.max}.")
+                if param.type == Pmd2PatchParameterType.STRING:
+                    val = config[param.name]
+                    if not isinstance(val, str):
+                        raise PatchNotConfiguredError("Invalid configuration value.", param.name, "Must be str.")
                 if param.type == Pmd2PatchParameterType.SELECT:
                     val = config[param.name]
                     found = False


### PR DESCRIPTION
This adds parameters for patches to the patches.
They can be used both in the Python handler and also in the armips source code (will be set as a label there).

See the example path in `skytemple_files/patch/dbg/parameters_test` for an example on how to use it.

The script `skytemple_files/patch/dbg/parameter_patches_test.py` runs a test apply of this dummy patch.
Here's the output when you run that script:
```
DEBUGGING PATCH PARAMETERS:
int_param <class 'int'> 1
int_param2 <class 'int'> 100
int_param3 <class 'int'> 1234
select_param <class 'str'> HELLO
string_param <class 'str'> World
ARMIPS CMDLINE:
['armips', '__main.asm', '-equ', 'int_param', '1', '-equ', 'int_param2', '100', '-equ', 'int_param3', '1234', '-equ', 'select_param', '"HELLO"', '-equ', 'string_param', '"World"']
ARMIPS OUTPUT:
/tmp/tmpwwf0na0v/patch.asm(1) notice: 1
/tmp/tmpwwf0na0v/patch.asm(2) notice: 100
/tmp/tmpwwf0na0v/patch.asm(3) notice: 1234
/tmp/tmpwwf0na0v/patch.asm(4) notice: HELLO
```

@psyCommando: If you want you can also have a look.

This will close #141.