### PR TITLE
Add FixMemorySoftlock patch

### DIFF
--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -1284,6 +1284,14 @@
             <Game id="EoS_EU" replace='_REGION equ "EU"'/>
           </Replace>
         </SimplePatch>
+        
+        <SimplePatch id="FixMemorySoftlock">
+          <Include filename="end_asm_mods/src/FixMemorySoftlock.asm"/>
+          <Replace filename="end_asm_mods/src/common/regionSelect.asm" regexp='_REGION equ "(\w+)"'>
+            <Game id="EoS_NA" replace='_REGION equ "US"'/>
+            <Game id="EoS_EU" replace='_REGION equ "EU"'/>
+          </Replace>
+        </SimplePatch>
 
       </Game>
     </Patches>

--- a/skytemple_files/patch/handler/fix_memory_softlock.py
+++ b/skytemple_files/patch/handler/fix_memory_softlock.py
@@ -1,0 +1,73 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable, List
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+from skytemple_files.common.i18n_util import f, _
+
+ORIGINAL_INSTRUCTION_EU = 0xE59F002C
+OFFSET_EU = 0x1238
+ORIGINAL_INSTRUCTION_US = 0xE59F0038
+OFFSET_US = 0x15DC
+
+
+class FixMemorySoftlockPatchHandler(AbstractPatchHandler, DependantPatch):
+
+    @property
+    def name(self) -> str:
+        return 'FixMemorySoftlock'
+
+    @property
+    def description(self) -> str:
+        return _("Prevents the game from crashing if it runs out of memory when trying to display a sprite (this can " \
+                 "happen during cutscenes when using custom sprites or the randomizer). Instead, the game will be " \
+                 "forced to continue, which will most likely prevent the crash but could cause glitches.")
+
+    @property
+    def author(self) -> str:
+        return 'End45'
+
+    @property
+    def version(self) -> str:
+        return '0.1.0'
+
+    def depends_on(self) -> List[str]:
+        return ['ExtraSpace']
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.UTILITY
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_uintle(rom.arm9, OFFSET_US, 4) != ORIGINAL_INSTRUCTION_US
+            if config.game_region == GAME_REGION_EU:
+                return read_uintle(rom.arm9, OFFSET_EU, 4) != ORIGINAL_INSTRUCTION_EU
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        # Apply the patch
+        apply()
+
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -67,6 +67,7 @@ from skytemple_files.patch.handler.externalize_mappa import ExternalizeMappaPatc
 from skytemple_files.patch.handler.expand_poke_list import ExpandPokeListPatchHandler
 from skytemple_files.patch.handler.allow_unrecruitable_mons import AllowUnrecruitableMonsPatchHandler
 from skytemple_files.patch.handler.edit_extra_pokemon import EditExtraPokemonPatchHandler
+from skytemple_files.patch.handler.fix_memory_softlock import FixMemorySoftlockPatchHandler
 from skytemple_files.common.i18n_util import f, _
 
 CORE_PATCHES_BASE_DIR = os.path.join(get_resources_dir(), 'patches')
@@ -107,6 +108,7 @@ class PatchType(Enum):
     EXPAND_POKE_LIST = ExpandPokeListPatchHandler
     ALLOW_UNRECRUITABLE_MONS = AllowUnrecruitableMonsPatchHandler
     EDIT_EXTRA_POKEMON = EditExtraPokemonPatchHandler
+    FIX_MEMORY_SOFTLOCK = FixMemorySoftlockPatchHandler
 
 
 class Patcher:


### PR DESCRIPTION
Adds a patch that can help prevent the crashes that happen when the game runs out of memory when displaying sprites in cutscenes (this has been observed in roms that had custom sprites or had used the randomizer). Other glitches could happen instead, but it will probably stop the softlock.
The patch has no effect in the normal behaviour of the game, as long as it doesn't run out of memory the patch will not trigger.
In the only test I've done so far, the game went from a softlock to running with no apparent side effects after applying the patch.