### PR TITLE
Add armips to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ venv.bak/
 .idea/
 ### skytemple
 dbg_output
+### armips
+skytemple_files/_resources/armips.exe


### PR DESCRIPTION
Since I can't seem to get env variables to work in my setup I just add the armips executable to _resources to apply patches in the dev version. It would be useful if said executable was in the gitignore to avoid having to add and remove it constantly.