### PR TITLE
Actual fix for ChooseStarter patch

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/choose_starter/common/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/choose_starter/common/patch.asm
@@ -79,7 +79,7 @@
 		add  r0,r13,#0x14
 		bl UnknownFuncCase0
 		ldrb r1,[r13, #+0x19]
-		ldr r0,[r15, #+0xe20]
+		ldr r0,=GlobalStructPointer
 		ldr r0,[r0, #+0x0]
 		and  r1,r1,#0xF
 		b case0_alt2


### PR DESCRIPTION
Invalid pointer only checked 25% of the time because of a call to random(100) and branch to somewhere else if the result is below 75.
So literally 25% of crash on hardware.


...Fun.
#112