### PR TITLE
fixed issue linked to encoding

### DIFF
--- a/skytemple_files/patch/arm_patcher.py
+++ b/skytemple_files/patch/arm_patcher.py
@@ -76,9 +76,9 @@ class ArmPatcher:
                             if game_candidate.game_id == game_id:
                                 game = game_candidate
                         if game is not None:
-                            with open(os.path.join(tmp, fn), 'r') as fi:
+                            with open(os.path.join(tmp, fn), 'r', encoding="utf-8") as fi:
                                 new_content = replace.regexp.sub(game.replace, fi.read())
-                            with open(os.path.join(tmp, fn), 'w') as fi:
+                            with open(os.path.join(tmp, fn), 'w', encoding="utf-8") as fi:
                                 fi.write(new_content)
 
                     # If it's a simple patch just output and re-import all binaries.


### PR DESCRIPTION
I figured it crashed when applying any patch. After too much time spend looking at what went wrong, it was due to the copyright symbol, which isn't an ASCII character.