### PR TITLE
Support for IQ groups' skills

### DIFF
--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -1319,6 +1319,14 @@
             <Game id="EoS_EU" replace='_REGION equ "EU"'/>
           </Replace>
         </SimplePatch>
+        
+        <SimplePatch id="CompressIQData">
+          <Include filename="end_asm_mods/src/CompressIQData.asm"/>
+          <Replace filename="end_asm_mods/src/common/regionSelect.asm" regexp='_REGION equ "(\w+)"'>
+            <Game id="EoS_NA" replace='_REGION equ "US"'/>
+            <Game id="EoS_EU" replace='_REGION equ "EU"'/>
+          </Replace>
+        </SimplePatch>
 
       </Game>
     </Patches>

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -116,6 +116,9 @@
         <Block name="JuiceBarNectarIqGain" beg="0x11810" end="0x11811"/>
         <Block name="GummiBellyHeal" beg="0xA2538" end="0xA27C0"/>
         <Block name="IqSkills" beg="0xA1C7C" end="0xA1D90"/>
+        <Block name="IqGroupsSkills" beg="0xA1D90" end="0xA1F20"/>
+        <!-- Replaces the block above when the patch "CompressIQData" is applied -->
+        <Block name="CompressedIqGroupsSkills" beg="0xA1D90" end="0xA1E20"/>
         <Pointer name="DebugSpecialEpisodeType" beg="0x2AB4AC"/>
         <!-- RAM values -->
         <!--#TODO: probably not really part of arm9, it's only in memory anyway. -->
@@ -364,6 +367,9 @@
         <Block name="JuiceBarNectarIqGain" beg="0x118B8" end="0x118B9"/>
         <Block name="GummiBellyHeal" beg="0xA2ABC" end="0xA2D44"/>
         <Block name="IqSkills" beg="0xA2200" end="0xA2314"/>
+        <Block name="IqGroupsSkills" beg="0xA2314" end="0xA24A4"/>
+        <!-- Replaces the block above when the patch "CompressIQData" is applied -->
+        <Block name="CompressedIqGroupsSkills" beg="0xA2314" end="0xA23A4"/>
         <Pointer name="DebugSpecialEpisodeType" beg="0x2ABDEC"/>
         <!-- RAM values -->
         <!--#TODO: probably not really part of arm9, it's only in memory anyway. -->

--- a/skytemple_files/hardcoded/dbg/iq_groups_test.py
+++ b/skytemple_files/hardcoded/dbg/iq_groups_test.py
@@ -1,0 +1,60 @@
+#  Copyright 2020-2021 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+import sys
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import get_ppmdu_config_for_rom
+from skytemple_files.hardcoded.iq import IqGroupsSkills
+
+COMPRESSED_GROUPS = bytearray([0x8E, 0x91, 0xF2, 0x8D, 0x60, 0x00, 0x40, 0x42, 0x0E,  # Group A
+                               0x8E, 0x81, 0xFA, 0x49, 0x41, 0x40, 0x9C, 0x40, 0x04,  # Group B
+                               0x8E, 0x03, 0xD2, 0x01, 0x34, 0x91, 0x03, 0x99, 0x04,  # Group C
+                               0xAC, 0x41, 0xFC, 0xA5, 0x80, 0x49, 0x01, 0x90, 0x01,  # Group D
+                               0x9C, 0x85, 0xD1, 0x01, 0xB9, 0xA0, 0xB4, 0x01, 0x00,  # Group E
+                               0x8E, 0x99, 0xD4, 0xB5, 0x40, 0x72, 0x00, 0x02, 0x04,  # Group F
+                               0xAC, 0x43, 0xDC, 0x95, 0x00, 0x0A, 0x60, 0x18, 0x03,  # Group G
+                               0xAC, 0x95, 0xD4, 0x49, 0x41, 0x20, 0xB8, 0x01, 0x01,  # Group H
+                               0x8C, 0x01, 0xD0, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,  # Unused group 1
+                               0x8C, 0x01, 0xD0, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,  # Unused group 2
+                               0xAC, 0x93, 0xD4, 0xA1, 0x34, 0x81, 0xA0, 0x14, 0x00,  # Group I
+                               0x9C, 0xA9, 0xD1, 0x85, 0x18, 0x62, 0x01, 0x12, 0x02,  # Group J
+                               0x8C, 0x01, 0xD0, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,  # Unused group 3
+                               0x8C, 0x01, 0xD0, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,  # Unused group 4
+                               0x8C, 0x01, 0xD0, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,  # Unused group 5
+                               0x8C, 0x01, 0xD0, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00]) # Unused group 6
+
+
+def main():
+    rom_path = sys.argv[1]
+    rom = NintendoDSRom.fromFile(rom_path)
+    config = get_ppmdu_config_for_rom(rom)
+    block_compressed = config.binaries['arm9.bin'].blocks['CompressedIqGroupsSkills']
+    arm9 = rom.arm9
+
+    groups = IqGroupsSkills.read_uncompressed(arm9, config)
+    IqGroupsSkills.write_compressed(arm9, groups, config)
+
+    assert arm9[block_compressed.begin:block_compressed.end] == COMPRESSED_GROUPS
+
+    groups2 = IqGroupsSkills.read_compressed(arm9, config)
+    for i in range(len(groups)):
+        assert sorted(groups[i]) == sorted(groups2[i])
+
+
+if __name__ == '__main__':
+    main()

--- a/skytemple_files/hardcoded/iq.py
+++ b/skytemple_files/hardcoded/iq.py
@@ -174,7 +174,7 @@ class HardcodedIq:
 
 class IqGroupsSkills:
     @staticmethod
-    def read_uncompressed(arm9: bytearray, config: Pmd2Data) -> List[List[int]]:
+    def read_uncompressed(arm9: bytes, config: Pmd2Data) -> List[List[int]]:
         block = config.binaries['arm9.bin'].blocks['IqGroupsSkills']
         ret = []
         for i in range(block.begin, block.end, IQ_GROUP_LIST_LEN):
@@ -188,7 +188,7 @@ class IqGroupsSkills:
         return ret
 
     @staticmethod
-    def read_compressed(arm9: bytearray, config: Pmd2Data) -> List[List[int]]:
+    def read_compressed(arm9: bytes, config: Pmd2Data) -> List[List[int]]:
         block = config.binaries['arm9.bin'].blocks['CompressedIqGroupsSkills']
         ret = []
         for i in range(block.begin, block.end, IQ_GROUP_COMPRESSED_LIST_LEN):

--- a/skytemple_files/patch/handler/compress_iq_data.py
+++ b/skytemple_files/patch/handler/compress_iq_data.py
@@ -1,0 +1,77 @@
+#  Copyright 2020-2021 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU
+from skytemple_files.hardcoded.iq import IqGroupsSkills
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler
+from skytemple_files.common.i18n_util import f, _
+
+ORIGINAL_INSTRUCTION = 0xE92D4010
+OFFSET_EU = 0x591E4
+OFFSET_US = 0x58E68
+
+
+class CompressIQDataPatchHandler(AbstractPatchHandler):
+
+    @property
+    def name(self) -> str:
+        return 'CompressIQData'
+
+    @property
+    def description(self) -> str:
+        return _("Optimizes the way the list of IQ skills learnt by each IQ group is stored, removing the limit of " \
+                 "max 25 skills per group.")
+
+    @property
+    def author(self) -> str:
+        return 'End45'
+
+    @property
+    def version(self) -> str:
+        return '0.1.0'
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.UTILITY
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_uintle(rom.arm9, OFFSET_US, 4) != ORIGINAL_INSTRUCTION
+            if config.game_region == GAME_REGION_EU:
+                return read_uintle(rom.arm9, OFFSET_EU, 4) != ORIGINAL_INSTRUCTION
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        # Copy the list of skills per group and rewrite it after applying the patch to avoid overwriting
+        # it with the default data included in the patch
+        if self.is_applied(rom, config):
+            group_data = IqGroupsSkills.read_compressed(rom.arm9, config)
+        else:
+            group_data = IqGroupsSkills.read_uncompressed(rom.arm9, config)
+        apply()
+        arm9 = bytearray(get_binary_from_rom_ppmdu(rom, config.binaries['arm9.bin']))
+        IqGroupsSkills.write_compressed(arm9, group_data, config)
+        set_binary_in_rom_ppmdu(rom, config.binaries['arm9.bin'], arm9)
+
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -69,6 +69,7 @@ from skytemple_files.patch.handler.expand_poke_list import ExpandPokeListPatchHa
 from skytemple_files.patch.handler.allow_unrecruitable_mons import AllowUnrecruitableMonsPatchHandler
 from skytemple_files.patch.handler.edit_extra_pokemon import EditExtraPokemonPatchHandler
 from skytemple_files.patch.handler.fix_memory_softlock import FixMemorySoftlockPatchHandler
+from skytemple_files.patch.handler.compress_iq_data import CompressIQDataPatchHandler
 from skytemple_files.common.i18n_util import f, _
 
 CORE_PATCHES_BASE_DIR = os.path.join(get_resources_dir(), 'patches')
@@ -111,6 +112,7 @@ class PatchType(Enum):
     ALLOW_UNRECRUITABLE_MONS = AllowUnrecruitableMonsPatchHandler
     EDIT_EXTRA_POKEMON = EditExtraPokemonPatchHandler
     FIX_MEMORY_SOFTLOCK = FixMemorySoftlockPatchHandler
+    COMPRESS_IQ_DATA = CompressIQDataPatchHandler
 
 
 class Patcher:


### PR DESCRIPTION
This code can be used to read/write the list of IQ skills in each group. Reads support the uncompressed (vanilla) format and the compressed (the one used by my CompressIQData patch) format. Writes only support the compressed format since writing data in the original format won't be necessary.

I still have to add the patch to SkyTemple, so I'll keep this as a draft until I do it (probably tomorrow).

Closes #165.