### PR TITLE
Fix FixMemorySoftlock patch

### DIFF
--- a/skytemple_files/patch/handler/fix_memory_softlock.py
+++ b/skytemple_files/patch/handler/fix_memory_softlock.py
@@ -48,7 +48,7 @@ class FixMemorySoftlockPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def version(self) -> str:
-        return '0.1.0'
+        return '0.1.1'
 
     def depends_on(self) -> List[str]:
         return ['ExtraSpace']


### PR DESCRIPTION
Turns out there's 2 different places where the game allocates memory and they look almost the same. I didn't realize this when I created the FixMemorySoftlock patch (I even mixed up the offsets), so right now it doesn't work properly. This should fix it.