### PR TITLE
Add DisarmOneRoomMonsterHouses patch

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/disarm_one_room_mh.asm
+++ b/skytemple_files/_resources/patches/asm_patches/disarm_one_room_mh.asm
@@ -1,0 +1,11 @@
+.if PPMD_GameVer == GameVer_EoS_NA
+    .definelabel GenerateMHCall, 0x233C834
+.elseif PPMD_GameVer == GameVer_EoS_EU
+    .definelabel GenerateMHCall, 0x233D418
+.endif
+
+; The giant room will exist by this point, just don't make it a monster house
+.org GenerateMHCall
+.area 4
+    nop
+.endarea

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -1237,6 +1237,13 @@
           </OpenBin>
         </Patch>
 
+        <!-- A patch to pacify one-room monster houses -->
+        <Patch id="DisarmOneRoomMonsterHouses">
+          <OpenBin filepath="overlay/overlay_0029.bin">
+            <Include filename="disarm_one_room_mh.asm"/>
+          </OpenBin>
+        </Patch>
+
         <SimplePatch id="MoveShortcuts" >
           <Include filename="end_asm_mods/src/moveShortcuts.asm"/>
           <Replace filename="end_asm_mods/src/common/regionSelect.asm" regexp='_REGION equ "(\w+)"'>

--- a/skytemple_files/patch/handler/disarm_one_room_mh.py
+++ b/skytemple_files/patch/handler/disarm_one_room_mh.py
@@ -1,0 +1,67 @@
+#  Copyright 2020-2021 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU
+from skytemple_files.common.util import get_binary_from_rom_ppmdu
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler
+from skytemple_files.common.i18n_util import _
+
+
+class DisarmOneRoomMHPatchHandler(AbstractPatchHandler):
+
+    @property
+    def name(self) -> str:
+        return "DisarmOneRoomMonsterHouses"
+
+    @property
+    def description(self) -> str:
+        return _("Disarms one-room Monster House floors, which can appear in cases like a layout generation failure. These floors will still be one giant room, but will no longer be Monster Houses.")
+
+    @property
+    def author(self) -> str:
+        return "UsernameFodder"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.IMPROVEMENT_TWEAK
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            ORIGINAL_BYTES = bytes([0xD8, 0x0D, 0x00, 0xEB])
+            OFFSETS = {
+                GAME_REGION_US: 0x605F4,
+                GAME_REGION_EU: 0x60898,
+            }
+            offset = OFFSETS.get(config.game_region)
+            if offset is not None:
+                overlay29 = get_binary_from_rom_ppmdu(rom, config.binaries["overlay/overlay_0029.bin"])
+                return overlay29[offset:offset+len(ORIGINAL_BYTES)] != ORIGINAL_BYTES
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        apply()
+
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -70,6 +70,7 @@ from skytemple_files.patch.handler.allow_unrecruitable_mons import AllowUnrecrui
 from skytemple_files.patch.handler.edit_extra_pokemon import EditExtraPokemonPatchHandler
 from skytemple_files.patch.handler.fix_memory_softlock import FixMemorySoftlockPatchHandler
 from skytemple_files.patch.handler.compress_iq_data import CompressIQDataPatchHandler
+from skytemple_files.patch.handler.disarm_one_room_mh import DisarmOneRoomMHPatchHandler
 from skytemple_files.common.i18n_util import f, _
 
 CORE_PATCHES_BASE_DIR = os.path.join(get_resources_dir(), 'patches')
@@ -113,6 +114,7 @@ class PatchType(Enum):
     EDIT_EXTRA_POKEMON = EditExtraPokemonPatchHandler
     FIX_MEMORY_SOFTLOCK = FixMemorySoftlockPatchHandler
     COMPRESS_IQ_DATA = CompressIQDataPatchHandler
+    DISARM_ONE_ROOM_MH = DisarmOneRoomMHPatchHandler
 
 
 class Patcher:


### PR DESCRIPTION
Patch to de-Monster-House-ify the one-room Monster House default layout that appears when the dungeon generation algorithm fails. The speedrunners wanted this.