### PR TITLE
Extend DungeonInterrupt to disable music fadeout

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/dungeon_interrupt/common/patch_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/dungeon_interrupt/common/patch_overlay29.asm
@@ -26,3 +26,18 @@ EndExecution:
 	bl FillIfNotInterrupted
 .endarea
 
+.org HookInterrupt5
+.area 0x10
+	b MusicFadeOut
+	nop
+	nop
+	nop
+EndMusicFadeOut:
+.endarea
+
+.org HookInterrupt6
+.area 0x8
+	b MusicInterrupt
+	nop
+EndMusicInterrupt:
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/dungeon_interrupt/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/dungeon_interrupt/eu/offsets.asm
@@ -36,4 +36,12 @@
 .definelabel HookInterrupt2, 0x022E0C0C
 .definelabel HookInterrupt3, 0x022FD2D0
 .definelabel HookInterrupt4, 0x022FE064
+.definelabel HookInterrupt5, 0x022E0BB0
+.definelabel HookInterrupt6, 0x0234CD60
+
+.definelabel FuncFadeOut1, 0x022EB85C
+.definelabel FuncFadeOut2, 0x022DE740
+.definelabel FuncStop1, 0x02017C0C
+.definelabel FuncStop2, 0x02017C88
+
 .definelabel DungeonBaseStructurePtr, 0x02354138

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/dungeon_interrupt/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/dungeon_interrupt/jp/offsets.asm
@@ -38,4 +38,12 @@
 .definelabel HookInterrupt2, 0x022E02CC
 .definelabel HookInterrupt3, 0x022FC8D4
 .definelabel HookInterrupt4, 0x022FD668
+.definelabel HookInterrupt5, 0x022E0270
+.definelabel HookInterrupt6, 0x0234C160
+
+.definelabel FuncFadeOut1, 0x022EAEAC
+.definelabel FuncFadeOut2, 0x022DDE00
+.definelabel FuncStop1, 0x02017B70
+.definelabel FuncStop2, 0x02017BEC
+
 .definelabel DungeonBaseStructurePtr, 0x02353538

--- a/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/dungeon_interrupt/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/irdkwia_asm_mods/dungeon_interrupt/na/offsets.asm
@@ -36,4 +36,13 @@
 .definelabel HookInterrupt2, 0x022E02CC
 .definelabel HookInterrupt3, 0x022FC8D4
 .definelabel HookInterrupt4, 0x022FD668
+.definelabel HookInterrupt5, 0x022E0270
+.definelabel HookInterrupt6, 0x0234C160
+
+.definelabel FuncFadeOut1, 0x022EAEAC
+.definelabel FuncFadeOut2, 0x022DDE00
+.definelabel FuncStop1, 0x02017B70
+.definelabel FuncStop2, 0x02017BEC
+
+
 .definelabel DungeonBaseStructurePtr, 0x02353538

--- a/skytemple_files/data/inter_d/model.py
+++ b/skytemple_files/data/inter_d/model.py
@@ -43,7 +43,9 @@ class InterDEntryType(Enum):
 
 class InterDEntry(AutoString):
     def __init__(self, data: bytes = bytes(6)):
-        self.floor = read_uintle(data, 0, 1)
+        floor_attrib = read_uintle(data, 0, 1)
+        self.floor = floor_attrib & 0x7F
+        self.continue_music = bool(floor_attrib & 0x80)
         self.ent_type = InterDEntryType(read_uintle(data, 1, 1))  # type: ignore
         self.game_var_id = read_uintle(data, 2, 2)
         self.param1 = read_uintle(data, 4, 1)
@@ -51,7 +53,7 @@ class InterDEntry(AutoString):
 
     def to_bytes(self) -> bytes:
         data = bytearray(6)
-        write_uintle(data, self.floor, 0, 1)
+        write_uintle(data, (self.floor & 0x7F) + (int(self.continue_music)<<7), 0, 1)
         write_uintle(data, self.ent_type.value, 1, 1)
         write_uintle(data, self.game_var_id, 2, 2)
         write_uintle(data, self.param1, 4, 1)


### PR DESCRIPTION
Adds an option to continue the music after exiting the floor.
Needs testing.