### PR TITLE
Rename outdated paths

### DIFF
--- a/skytemple_files/patch/handler/move_growth.py
+++ b/skytemple_files/patch/handler/move_growth.py
@@ -30,7 +30,7 @@ from skytemple_files.data.waza_p.model import WazaMoveCategory
 from skytemple_files.common.i18n_util import _
 
 
-SRC_DIR = os.path.join(get_resources_dir(), 'patches', 'asm_patches', 'irdkwia_asm_mods', 'move_growth', 'src')
+SRC_DIR = os.path.join(get_resources_dir(), 'patches', 'asm_patches', 'anonymous_asm_mods', 'move_growth', 'src')
 
 PATCH_CHECK_ADDR_APPLIED_US = 0x14A74
 PATCH_CHECK_ADDR_APPLIED_EU = 0x14B1C

--- a/skytemple_files/patch/handler/stat_disp.py
+++ b/skytemple_files/patch/handler/stat_disp.py
@@ -37,7 +37,7 @@ PATCH_CHECK_ADDR_APPLIED_EU = 0x24600
 PATCH_CHECK_ADDR_APPLIED_JP = 0x0
 PATCH_CHECK_INSTR_APPLIED = 0xEA000004
 
-SRC_DIR = os.path.join(get_resources_dir(), 'patches', 'asm_patches', 'irdkwia_asm_mods', 'stat_disp', 'src')
+SRC_DIR = os.path.join(get_resources_dir(), 'patches', 'asm_patches', 'anonymous_asm_mods', 'stat_disp', 'src')
 
 OLD_STAT = "[M:S3]"*8
 


### PR DESCRIPTION
Rename a couple of outdated paths that were causing an error when trying to apply the move growth or stat display patches.