### PR TITLE
Add DynamicBossesEverywhere patch

### DIFF
--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -767,6 +767,14 @@
           </Replace>
         </SimplePatch>
 
+        <SimplePatch id="DynamicBossesEverywhere">
+          <Include filename="end_asm_mods/src/DynamicBossesEverywhere.asm"/>
+          <Replace filename="end_asm_mods/src/common/regionSelect.asm" regexp='_REGION equ "(\w+)"'>
+            <Game id="EoS_NA" replace='_REGION equ "US"'/>
+            <Game id="EoS_EU" replace='_REGION equ "EU"'/>
+          </Replace>
+        </SimplePatch>
+
       </Game>
     </Patches>
 

--- a/skytemple_files/patch/handler/dynamic_bosses_everywhere.py
+++ b/skytemple_files/patch/handler/dynamic_bosses_everywhere.py
@@ -56,11 +56,12 @@ class DynamicBossesEverywherePatchHandler(AbstractPatchHandler, DependantPatch):
         return PatchCategory.UTILITY
 
     def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        overlay29 = get_binary_from_rom_ppmdu(rom, config.binaries['overlay/overlay_0029.bin'])
         if config.game_version == GAME_VERSION_EOS:
             if config.game_region == GAME_REGION_US:
-                return read_uintle(rom.arm9, OFFSET_US, 4) != ORIGINAL_INSTRUCTION
+                return read_uintle(overlay29, OFFSET_US, 4) != ORIGINAL_INSTRUCTION
             if config.game_region == GAME_REGION_EU:
-                return read_uintle(rom.arm9, OFFSET_EU, 4) != ORIGINAL_INSTRUCTION
+                return read_uintle(overlay29, OFFSET_EU, 4) != ORIGINAL_INSTRUCTION
         raise NotImplementedError()
 
     def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:

--- a/skytemple_files/patch/handler/dynamic_bosses_everywhere.py
+++ b/skytemple_files/patch/handler/dynamic_bosses_everywhere.py
@@ -1,0 +1,71 @@
+#  Copyright 2020-2022 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable, List
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+from skytemple_files.common.i18n_util import f, _
+
+ORIGINAL_INSTRUCTION = 0xE1A05009
+OFFSET_EU = 0x67ED4
+OFFSET_US = 0x67C30
+
+
+class DynamicBossesEverywherePatchHandler(AbstractPatchHandler, DependantPatch):
+
+    @property
+    def name(self) -> str:
+        return 'DynamicBossesEverywhere'
+
+    @property
+    def description(self) -> str:
+        return _("Allows placing special fixed room entities #124-127 (Explorer Maze enemies) in any fixed room " \
+                 "without causing the game to crash.")
+
+    @property
+    def author(self) -> str:
+        return 'End45'
+
+    @property
+    def version(self) -> str:
+        return '0.1.0'
+
+    def depends_on(self) -> List[str]:
+        return ['ExtraSpace']
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.UTILITY
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_uintle(rom.arm9, OFFSET_US, 4) != ORIGINAL_INSTRUCTION
+            if config.game_region == GAME_REGION_EU:
+                return read_uintle(rom.arm9, OFFSET_EU, 4) != ORIGINAL_INSTRUCTION
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:
+        # Apply the patch
+        apply()
+
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:
+        raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -72,6 +72,7 @@ from skytemple_files.patch.handler.edit_extra_pokemon import EditExtraPokemonPat
 from skytemple_files.patch.handler.fix_memory_softlock import FixMemorySoftlockPatchHandler
 from skytemple_files.patch.handler.compress_iq_data import CompressIQDataPatchHandler
 from skytemple_files.patch.handler.disarm_one_room_mh import DisarmOneRoomMHPatchHandler
+from skytemple_files.patch.handler.dynamic_bosses_everywhere import DynamicBossesEverywherePatchHandler
 from skytemple_files.common.i18n_util import f, _
 
 CORE_PATCHES_BASE_DIR = os.path.join(get_resources_dir(), 'patches')
@@ -117,6 +118,7 @@ class PatchType(Enum):
     FIX_MEMORY_SOFTLOCK = FixMemorySoftlockPatchHandler
     COMPRESS_IQ_DATA = CompressIQDataPatchHandler
     DISARM_ONE_ROOM_MH = DisarmOneRoomMHPatchHandler
+    DYNAMIC_BOSSES_EVERYWHERE = DynamicBossesEverywherePatchHandler
 
 
 class Patcher:


### PR DESCRIPTION
Adds a patch that allows adding the special fixed pokémon entries used in Explorer Maze to any other fixed room (normally this would softlock the game).

Untested since I still haven't managed to fix my local SkyTemple installation.