### PR TITLE
Fix potential stack overflow on ExternalizeWazaFile + Fix some floor densities being unsigned

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/fs_waza_p/common/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/fs_waza_p/common/patch.asm
@@ -206,7 +206,7 @@ loop_buffer:
 there:
 	ldr r0,=string_mv
 	mov r1,r4
-	bl PrintF
+	;bl PrintF - Can cause a stack overflow
 	bl FStreamAlloc
 	mov r0,r7
 	mov r1,r8
@@ -252,7 +252,7 @@ buffer_ptr:
 	ldr r0,=string_ms
 	mov r1,r5
 	mov r2,r4
-	bl PrintF
+	;bl PrintF - Can cause a stack overflow
 	bl FStreamAlloc
 	ldr r3,=CurrentWazaInfo
 	ldr r1,=WazaFileInfo

--- a/skytemple_files/dungeon_data/mappa_bin/floor_layout.py
+++ b/skytemple_files/dungeon_data/mappa_bin/floor_layout.py
@@ -223,12 +223,12 @@ class MappaFloorLayout(AutoString, XmlSerializable):
         )
         return cls(
             structure=MappaFloorStructureType(read_uintle(read.data, pointer + 0x00)),
-            room_density=read_uintle(read.data, pointer + 0x01),
+            room_density=read_sintle(read.data, pointer + 0x01),
             tileset_id=read_uintle(read.data, pointer + 0x02),
             music_id=read_uintle(read.data, pointer + 0x03),
             weather=MappaFloorWeather(read_uintle(read.data, pointer + 0x04)),
             floor_connectivity=read_uintle(read.data, pointer + 0x05),
-            initial_enemy_density=read_uintle(read.data, pointer + 0x06),
+            initial_enemy_density=read_sintle(read.data, pointer + 0x06),
             kecleon_shop_chance=read_uintle(read.data, pointer + 0x07),
             monster_house_chance=read_uintle(read.data, pointer + 0x08),
             unusued_chance=read_uintle(read.data, pointer + 0x09),
@@ -257,12 +257,12 @@ class MappaFloorLayout(AutoString, XmlSerializable):
     def to_mappa(self) -> bytes:
         data = bytearray(32)
         write_uintle(data, self.structure.value, 0x00, 1)
-        write_uintle(data, self.room_density, 0x01, 1)
+        write_sintle(data, self.room_density, 0x01, 1)
         write_uintle(data, self.tileset_id, 0x02, 1)
         write_uintle(data, self.music_id, 0x03, 1)
         write_uintle(data, self.weather.value, 0x04, 1)
         write_uintle(data, self.floor_connectivity, 0x05, 1)
-        write_uintle(data, self.initial_enemy_density, 0x06, 1)
+        write_sintle(data, self.initial_enemy_density, 0x06, 1)
         write_uintle(data, self.kecleon_shop_chance, 0x07, 1)
         write_uintle(data, self.monster_house_chance, 0x08, 1)
         write_uintle(data, self.unusued_chance, 0x09, 1)

--- a/skytemple_files/patch/handler/externalize_waza.py
+++ b/skytemple_files/patch/handler/externalize_waza.py
@@ -48,7 +48,7 @@ Depends on the ActorAndLevelLoader patch, as it needs some space provided by thi
 
     @property
     def version(self) -> str:
-        return '0.0.1'
+        return '0.0.2'
 
     @property
     def category(self) -> PatchCategory:


### PR DESCRIPTION
For details see https://discord.com/channels/710190644152369162/975860892057088090/975915088676548660
There's been a report of a case where these PrintF calls cause a stack overflow, so I've removed them.