### PR TITLE
Update MoveShortcuts patch

### DIFF
--- a/skytemple_files/patch/handler/move_shortcuts.py
+++ b/skytemple_files/patch/handler/move_shortcuts.py
@@ -45,7 +45,7 @@ class MoveShortcutsPatch(AbstractPatchHandler, DependantPatch):
 
     @property
     def version(self) -> str:
-        return '0.2.0'
+        return '0.2.1'
 
     def depends_on(self) -> List[str]:
         return ['ExtraSpace']


### PR DESCRIPTION
MoveShortcuts has been updated to prevent the player from passing turn by holding A+B while the move list is shown, which would cause a minor graphical glitch.