### PR TITLE
Add PitfallTrapTweak patch

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/pitfall_trap_tweak/common/pitfall_ov29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/pitfall_trap_tweak/common/pitfall_ov29.asm
@@ -1,0 +1,4 @@
+.org AdvanceFloor
+.area 0x4
+	bl FallenAndCantGetUp ; Was originally strb r1,[r0,6h]
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/pitfall_trap_tweak/common/pitfall_ov36.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/pitfall_trap_tweak/common/pitfall_ov36.asm
@@ -12,7 +12,6 @@ FallenAndCantGetUp:
 	bl DungeonGoesUp
 	cmp r0,#0
 	beq fall_ret ; Dungeon is descending
-dungeon_is_ascending:
 	ldrb r0,[r4,0x749] ; Floor ID
 	subs r0,r0,#2
 	movmi r0,#0 ; Avoiding underflow

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/pitfall_trap_tweak/common/pitfall_ov36.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/pitfall_trap_tweak/common/pitfall_ov36.asm
@@ -1,5 +1,5 @@
-.org 0x023A7080+0x9F0 ; TODO: Ask End for a proper region
-.area 0xA20-0x9F0
+.org 0x023A7080+0xA00
+.area 0xA30-0xA00
 
 FallenAndCantGetUp:
     

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/pitfall_trap_tweak/common/pitfall_ov36.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/pitfall_trap_tweak/common/pitfall_ov36.asm
@@ -1,0 +1,23 @@
+.org 0x023A7080+0x9F0 ; TODO: Ask End for a proper region
+.area 0xA20-0x9F0
+
+FallenAndCantGetUp:
+    
+	; r0 = Dereferenced DungeonBaseStructPtr
+	; r1 = 0x2
+	push r0-r12,r14
+	mov r4,r0
+	strb r1,[r4,6h] ; Advance to the next floor
+	ldrb r0,[r4,0x748] ; Dungeon ID
+	bl DungeonGoesUp
+	cmp r0,#0
+	beq fall_ret ; Dungeon is descending
+dungeon_is_ascending:
+	ldrb r0,[r4,0x749] ; Floor ID
+	subs r0,r0,#2
+	movmi r0,#0 ; Avoiding underflow
+	strb r0,[r4,0x749]
+fall_ret:
+	pop r0-r12,r15
+    .pool
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/pitfall_trap_tweak/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/pitfall_trap_tweak/eu/offsets.asm
@@ -1,0 +1,6 @@
+.relativeinclude on
+.nds
+.arm
+
+.definelabel AdvanceFloor, 0x22EF2B8
+.definelabel DungeonGoesUp, 0x20515C0

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/pitfall_trap_tweak/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/pitfall_trap_tweak/na/offsets.asm
@@ -1,0 +1,6 @@
+.relativeinclude on
+.nds
+.arm
+
+.definelabel AdvanceFloor, 0x22EE904
+.definelabel DungeonGoesUp, 0x2051288

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/pitfall_trap_tweak/selector_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/pitfall_trap_tweak/selector_overlay29.asm
@@ -1,0 +1,11 @@
+.relativeinclude on
+
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/offsets.asm"
+	.include "common/pitfall_ov29.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/offsets.asm"
+	.include "common/pitfall_ov29.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/pitfall_trap_tweak/selector_overlay36.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/pitfall_trap_tweak/selector_overlay36.asm
@@ -1,0 +1,9 @@
+.relativeinclude on
+
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "common/pitfall_ov36.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "common/pitfall_ov36.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -862,6 +862,15 @@
           </Replace>
         </SimplePatch>
 
+        <Patch id="PitfallTrapTweak">
+          <OpenBin filepath="overlay/overlay_0029.bin">
+	  	<Include filename ="adex_asm_mods/pitfall_trap_tweak/selector_overlay29.asm"/>
+	  </OpenBin>
+	<OpenBin filepath="overlay/overlay_0036.bin">
+	  	<Include filename ="adex_asm_mods/pitfall_trap_tweak/selector_overlay36.asm"/>
+	  </OpenBin>
+        </Patch>
+
       </Game>
     </Patches>
 

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -866,7 +866,7 @@
           <OpenBin filepath="overlay/overlay_0029.bin">
 	  	<Include filename ="adex_asm_mods/pitfall_trap_tweak/selector_overlay29.asm"/>
 	  </OpenBin>
-	<OpenBin filepath="overlay/overlay_0036.bin">
+	  <OpenBin filepath="overlay/overlay_0036.bin">
 	  	<Include filename ="adex_asm_mods/pitfall_trap_tweak/selector_overlay36.asm"/>
 	  </OpenBin>
         </Patch>

--- a/skytemple_files/patch/handler/pitfall_trap_tweak.py
+++ b/skytemple_files/patch/handler/pitfall_trap_tweak.py
@@ -1,0 +1,71 @@
+ #  Copyright 2020-2022 Capypara and the SkyTemple Contributors
+ #
+ #  This file is part of SkyTemple.
+ #
+ #  SkyTemple is free software: you can redistribute it and/or modify
+ #  it under the terms of the GNU General Public License as published by
+ #  the Free Software Foundation, either version 3 of the License, or
+ #  (at your option) any later version.
+ #
+ #  SkyTemple is distributed in the hope that it will be useful,
+ #  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ #  GNU General Public License for more details.
+ #
+ #  You should have received a copy of the GNU General Public License
+ #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable, List
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+from skytemple_files.common.i18n_util import f, _
+
+ORIGINAL_INSTRUCTION = 0xE5C01006
+OFFSET_EU = 0x12738
+OFFSET_US = 0x126C4
+
+
+class PatchHandler(AbstractPatchHandler):
+
+    @property
+    def name(self) -> str:
+        return 'PitfallTrapTweak'
+
+    @property
+    def description(self) -> str:
+        return "Makes Pitfall Traps send the leader back by one floor in ascending dungeons. If the leader activates a Pitfall Trap on 1F, they will restart 1F with a different seed."
+
+    @property
+    def author(self) -> str:
+        return 'Adex'
+
+    @property
+    def version(self) -> str:
+        return '0.1.0'
+
+    def depends_on(self) -> List[str]:
+         return ['ExtraSpace']
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.IMPROVEMENT_TWEAK
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+         overlay29 = get_binary_from_rom_ppmdu(rom, config.binaries['overlay/overlay_0029.bin'])
+         if config.game_version == GAME_VERSION_EOS:
+             if config.game_region == GAME_REGION_US:
+                 return read_uintle(overlay29, OFFSET_US, 4) != ORIGINAL_INSTRUCTION
+             if config.game_region == GAME_REGION_EU:
+                 return read_uintle(overlay29, OFFSET_EU, 4) != ORIGINAL_INSTRUCTION
+         raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:
+         # Apply the patch
+         apply()
+
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/handler/pitfall_trap_tweak.py
+++ b/skytemple_files/patch/handler/pitfall_trap_tweak.py
@@ -29,7 +29,7 @@ OFFSET_EU = 0x12738
 OFFSET_US = 0x126C4
 
 
-class PatchHandler(AbstractPatchHandler):
+class PitfallTrapTweakPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def name(self) -> str:

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -74,6 +74,7 @@ from skytemple_files.patch.handler.fix_memory_softlock import FixMemorySoftlockP
 from skytemple_files.patch.handler.compress_iq_data import CompressIQDataPatchHandler
 from skytemple_files.patch.handler.disarm_one_room_mh import DisarmOneRoomMHPatchHandler
 from skytemple_files.patch.handler.dynamic_bosses_everywhere import DynamicBossesEverywherePatchHandler
+from skytemple_files.patch.handler.pitfall_trap_tweak import PitfallTrapTweakPatchHandler
 from skytemple_files.common.i18n_util import f, _
 
 CORE_PATCHES_BASE_DIR = os.path.join(get_resources_dir(), 'patches')
@@ -121,6 +122,7 @@ class PatchType(Enum):
     COMPRESS_IQ_DATA = CompressIQDataPatchHandler
     DISARM_ONE_ROOM_MH = DisarmOneRoomMHPatchHandler
     DYNAMIC_BOSSES_EVERYWHERE = DynamicBossesEverywherePatchHandler
+    PITFALL_TRAP_TWEAK = PitfallTrapTweakPatchHandler
 
 
 class Patcher:


### PR DESCRIPTION
Adds a small ASM patch that slightly edits the behavior of Pitfall Traps. When the leader activates a Pitfall Trap in ascending dungeons, they now will descend a floor. Also, if the leader steps on a Pitfall Trap in 1F, they will restart 1F with a different seed.

I don't have a dev environment set up yet, so aside from having tried this out with patch packages, I'm unable to test if anything breaks while doing all of this.