### PR TITLE
Update pmdsky-debug to `c0fc599`

### DIFF
--- a/.github/workflows/check-pmdsky-debug.yml
+++ b/.github/workflows/check-pmdsky-debug.yml
@@ -18,5 +18,5 @@ jobs:
       - name: Install resymgen
         run: cargo install resymgen
       - name: Test
-        run: resymgen check --complete-version-list --explicit-versions --in-bounds-symbols --no-function-overlap --nonempty-maps --unique-symbols --data-names SCREAMING_SNAKE_CASE --function-names PascalCase symbols/*.yml
+        run: resymgen check --complete-version-list --explicit-versions --in-bounds-symbols --no-overlap --nonempty-maps --unique-symbols --data-names SCREAMING_SNAKE_CASE --function-names PascalCase symbols/*.yml
         working-directory: ./skytemple_files/_resources/pmdsky-debug/


### PR DESCRIPTION
The `--no-function-overlap` option for `resymgen check` was renamed to `--no-overlap`, so check-pmdsky-debug.yml needs to be updated accordingly.

I'm not sure when this submodule was last updated...I'm hoping there were no other breaking changes introduced since then.