### PR TITLE
Add FixNo$GbaSaves patch

### DIFF
--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -871,6 +871,14 @@
 	  </OpenBin>
         </Patch>
 
+        <SimplePatch id="FixNo$GbaSaves">
+          <Include filename="end_asm_mods/src/FixNo$GbaSaves.asm"/>
+          <Replace filename="end_asm_mods/src/common/regionSelect.asm" regexp='_REGION equ "(\w+)"'>
+            <Game id="EoS_NA" replace='_REGION equ "US"'/>
+            <Game id="EoS_EU" replace='_REGION equ "EU"'/>
+          </Replace>
+        </SimplePatch>
+
       </Game>
     </Patches>
 

--- a/skytemple_files/patch/handler/fix_nocash_saves.py
+++ b/skytemple_files/patch/handler/fix_nocash_saves.py
@@ -1,0 +1,79 @@
+#  Copyright 2020-2022 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+from typing import Callable, List
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.i18n_util import _
+from skytemple_files.common.ppmdu_config.data import (
+    GAME_REGION_EU,
+    GAME_REGION_US,
+    GAME_VERSION_EOS,
+    Pmd2Data,
+)
+from skytemple_files.common.util import *
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler
+
+ORIGINAL_INSTRUCTION = 0xE3A00008
+OFFSET_EU = 0x4ADD0
+OFFSET_US = 0x4AA98
+
+
+class FixNocashSavesPatchHandler(AbstractPatchHandler):
+    @property
+    def name(self) -> str:
+        return "FixNo$GbaSaves"
+
+    @property
+    def description(self) -> str:
+        return _(
+            "Fixes an issue that causes saving to fail on the No$GBA emulator."
+        )
+
+    @property
+    def author(self) -> str:
+        return "End45"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.BUGFIXES
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_u32(rom.arm9, OFFSET_US) != ORIGINAL_INSTRUCTION
+            if config.game_region == GAME_REGION_EU:
+                return read_u32(rom.arm9, OFFSET_EU) != ORIGINAL_INSTRUCTION
+        raise NotImplementedError()
+
+    def apply(
+        self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ) -> None:
+        # Apply the patch
+        apply()
+
+    def unapply(
+        self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ) -> None:
+        raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -96,6 +96,7 @@ from skytemple_files.patch.handler.fix_evolution import FixEvolutionPatchHandler
 from skytemple_files.patch.handler.fix_memory_softlock import (
     FixMemorySoftlockPatchHandler,
 )
+from skytemple_files.patch.handler.fix_nocash_saves import FixNocashSavesPatchHandler
 from skytemple_files.patch.handler.move_growth import MoveGrowthPatchHandler
 from skytemple_files.patch.handler.move_shortcuts import MoveShortcutsPatch
 from skytemple_files.patch.handler.obj_table import ExtractObjectTablePatchHandler
@@ -161,6 +162,7 @@ class PatchType(Enum):
     DISARM_ONE_ROOM_MH = DisarmOneRoomMHPatchHandler
     DYNAMIC_BOSSES_EVERYWHERE = DynamicBossesEverywherePatchHandler
     PITFALL_TRAP_TWEAK = PitfallTrapTweakPatchHandler
+    FIX_NOCASH_SAVES = FixNocashSavesPatchHandler
 
 
 class Patcher:


### PR DESCRIPTION
Adds a patch that fixes saving in the No$GBA emulator, which allows playing the game without having to enable a cheat every time the emulator is opened.

I haven't been able to test this in SkyTemple since the latest dev version freezes when trying to load the ROM. The ASM patch itself is tested on both EU and US.