### PR TITLE
Fix obj_table breaking weather on EU rom

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/obj_table/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/obj_table/eu/offsets.asm
@@ -16,5 +16,5 @@
 .definelabel HookGetObjectData4, 0x022F7818
 .definelabel HookGetObjectData5, 0x022F7890
 
-.definelabel ObjectData, 0x0231DE40
+.definelabel ObjectData, 0x0231E820
 .definelabel SizeObjectData, 0x2B68


### PR DESCRIPTION
I figured that the screen turned black except for dialogue in a cutscene of an hack I'm working on when applying this patch. After a bit of reverse-engineering, I found it was due to the padding overwriting some table that is used to check the ID of the of the background (in bg_list.dat) to load for the weather layer with 0xCC.

This patch fix some offset. The change itself was made by the original patch creator. (I got permission from them to upstream it).

It quickly tested it (as in, it didn't worked before, it work now. Didn't tried to add new object thought).