### PR TITLE
Add BoldText and ChangeTextSound patches

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/common/bold_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/common/bold_arm9.asm
@@ -1,0 +1,9 @@
+.org NoBARFound
+.area 0x4
+	beq HookBLetter
+.endarea
+
+.org CallDisplayChar
+.area 0x4
+	bl RepeatRender
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/common/bold_ov36.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/common/bold_ov36.asm
@@ -1,0 +1,44 @@
+.org 0x023A7080+0xA70
+.area 0xAEC-0xA70
+
+HookBLetter:
+	ldr r0,[r13, StackThing]
+	add r1,=char_BS
+	bl TagCheck
+	cmp r0,#0
+	beq check_BR ; If not [BS], check for [BR].
+	add r1,=bold
+	mov r0,#1
+	strb r0,[r1]
+	b AfterTagIsFound
+check_BR:
+	ldr r0,[r13, StackThing]
+	add r1,=char_BR
+	bl TagCheck
+	cmp r0,#0
+	beq TagCodeError ; If neither [BS] nor [BR], this is an invalid tag!
+	add r1,=bold
+	mov r0,#0
+	strb r0,[r1]
+	b AfterTagIsFound
+RepeatRender:
+	; r7 contains the address to a function that displays a character.
+	push r14,r0-r3
+	blx r7
+	add r0,=bold
+	ldrb r0,[r0]
+	cmp r0,#0
+	pop r0-r3
+	popeq r15
+	subs r1,r1,#1 ; r1 = X-coordinate of character to display
+	movmi r1,#0
+	blx r7
+	pop r15
+.pool
+	bold:
+		.byte 0x0
+	char_BS:
+		.asciiz "BS"
+	char_BR:
+		.asciiz "BR"
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/eu/offsets.asm
@@ -1,0 +1,10 @@
+.relativeinclude on
+.nds
+.arm
+
+.definelabel NoBARFound, 0x02021138
+.definelabel CallDisplayChar, 0x02021D68
+.definelabel TagCheck, 0x02020A20
+.definelabel TagCodeError, 0x02021BD4
+.definelabel AfterTagIsFound, 0x02021C64
+.definelabel StackThing, 0x78

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/na/offsets.asm
@@ -1,0 +1,10 @@
+.relativeinclude on
+.nds
+.arm
+
+.definelabel NoBARFound, 0x02020FE0
+.definelabel CallDisplayChar, 0x02021BA4
+.definelabel TagCheck, 0x020208C8
+.definelabel TagCodeError, 0x02021A10
+.definelabel AfterTagIsFound, 0x02021AA0
+.definelabel StackThing, 0x70

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/selector_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/selector_arm9.asm
@@ -1,0 +1,11 @@
+.relativeinclude on
+
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/offsets.asm"
+	.include "common/bold_arm9.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/offsets.asm"
+	.include "common/bold_arm9.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/selector_overlay36.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/selector_overlay36.asm
@@ -1,0 +1,9 @@
+.relativeinclude on
+
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "common/bold_ov36.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "common/bold_ov36.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/common/sound_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/common/sound_arm9.asm
@@ -1,0 +1,4 @@
+.org CaseT
+.area 0x4
+	b HookTLetter
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/common/sound_ov36.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/common/sound_ov36.asm
@@ -1,0 +1,30 @@
+.org 0x023A7080+0xB20
+.area 0xB7C-0xB20
+
+HookTLetter:
+	ldr r0,[r13, StackThing]
+	add r1,=char_TS
+	bl TagCheck
+	cmp r0,#0
+	beq check_TR ; If not [TS], check for [TR].
+	ldr r0,[r13, StackThing+4]
+	bl GetTagParameter
+	ldr r1,=TextboxSE
+	str r0,[r1] ; Change the text sound to ID X from [TS:X]
+	b AfterTagIsFound
+check_TR:
+	ldr r0,[r13, StackThing]
+	add r1,=char_TR
+	bl TagCheck
+	cmp r0,#0
+	beq TagCodeError ; If neither [TS] nor [TR], this is an invalid tag!
+	ldr r1,=TextboxSE
+	ldr r0,=#16133
+	str r0,[r1] ; Restore the default textbox sound effect.
+	b AfterTagIsFound
+.pool
+	char_TS:
+		.asciiz "TS"
+	char_TR:
+		.asciiz "TR"
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/eu/offsets.asm
@@ -1,0 +1,11 @@
+.relativeinclude on
+.nds
+.arm
+
+.definelabel CaseT, 0x0202111C
+.definelabel TextboxSE, 0x02017DB8
+.definelabel TagCheck, 0x02020A20
+.definelabel GetTagParameter, 0x02020A64
+.definelabel TagCodeError, 0x02021BD4
+.definelabel AfterTagIsFound, 0x02021C64
+.definelabel StackThing, 0x78

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/na/offsets.asm
@@ -1,0 +1,11 @@
+.relativeinclude on
+.nds
+.arm
+
+.definelabel CaseT, 0x02020FC4
+.definelabel TextboxSE, 0x02017D1C
+.definelabel TagCheck, 0x020208C8
+.definelabel GetTagParameter, 0x0202090C
+.definelabel TagCodeError, 0x02021A10
+.definelabel AfterTagIsFound, 0x02021AA0
+.definelabel StackThing, 0x70

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/selector_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/selector_arm9.asm
@@ -1,0 +1,11 @@
+.relativeinclude on
+
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/offsets.asm"
+	.include "common/sound_arm9.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/offsets.asm"
+	.include "common/sound_arm9.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/selector_overlay36.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/selector_overlay36.asm
@@ -1,0 +1,9 @@
+.relativeinclude on
+
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "common/sound_ov36.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "common/sound_ov36.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -1,4 +1,4 @@
-﻿<PMD2>
+<PMD2>
   <!--=======================================================================-->
   <!--PPMDU Configuration File-->
   <!--=======================================================================-->
@@ -878,6 +878,24 @@
             <Game id="EoS_EU" replace='_REGION equ "EU"'/>
           </Replace>
         </SimplePatch>
+
+        <Patch id="BoldText">
+          <OpenBin filepath="arm9.bin">
+	  	<Include filename ="adex_asm_mods/bold_text/selector_arm9.asm"/>
+	  </OpenBin>
+	  <OpenBin filepath="overlay/overlay_0036.bin">
+	  	<Include filename ="adex_asm_mods/bold_text/selector_overlay36.asm"/>
+	  </OpenBin>
+        </Patch>
+
+        <Patch id="ChangeTextSound">
+          <OpenBin filepath="arm9.bin">
+	  	<Include filename ="adex_asm_mods/change_text_sound/selector_arm9.asm"/>
+	  </OpenBin>
+	  <OpenBin filepath="overlay/overlay_0036.bin">
+	  	<Include filename ="adex_asm_mods/change_text_sound/selector_overlay36.asm"/>
+	  </OpenBin>
+        </Patch>
 
       </Game>
     </Patches>

--- a/skytemple_files/patch/handler/bold_text.py
+++ b/skytemple_files/patch/handler/bold_text.py
@@ -1,28 +1,34 @@
- #  Copyright 2020-2022 Capypara and the SkyTemple Contributors
- #
- #  This file is part of SkyTemple.
- #
- #  SkyTemple is free software: you can redistribute it and/or modify
- #  it under the terms of the GNU General Public License as published by
- #  the Free Software Foundation, either version 3 of the License, or
- #  (at your option) any later version.
- #
- #  SkyTemple is distributed in the hope that it will be useful,
- #  but WITHOUT ANY WARRANTY; without even the implied warranty of
- #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- #  GNU General Public License for more details.
- #
- #  You should have received a copy of the GNU General Public License
- #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright 2020-2022 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
 from typing import Callable, List
 
 from ndspy.rom import NintendoDSRom
 
+from skytemple_files.common.ppmdu_config.data import (
+    GAME_REGION_EU,
+    GAME_REGION_US,
+    GAME_VERSION_EOS,
+    Pmd2Data,
+)
 from skytemple_files.common.util import *
-from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU
 from skytemple_files.patch.category import PatchCategory
 from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
-from skytemple_files.common.i18n_util import f, _
 
 ORIGINAL_INSTRUCTION = 0xE12FFF37
 OFFSET_EU = 0x21D68
@@ -55,12 +61,11 @@ class BoldTextPatchHandler(AbstractPatchHandler, DependantPatch):
         return PatchCategory.NEW_MECHANIC
 
     def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
-         arm9 = get_binary_from_rom_ppmdu(rom, config.binaries['arm9.bin'])
          if config.game_version == GAME_VERSION_EOS:
              if config.game_region == GAME_REGION_US:
-                 return read_uintle(arm9, OFFSET_US, 4) != ORIGINAL_INSTRUCTION
+                 return read_u32(rom.arm9, OFFSET_US, 4) != ORIGINAL_INSTRUCTION
              if config.game_region == GAME_REGION_EU:
-                 return read_uintle(arm9, OFFSET_EU, 4) != ORIGINAL_INSTRUCTION
+                 return read_u32(rom.arm9, OFFSET_EU, 4) != ORIGINAL_INSTRUCTION
          raise NotImplementedError()
 
     def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:

--- a/skytemple_files/patch/handler/bold_text.py
+++ b/skytemple_files/patch/handler/bold_text.py
@@ -36,10 +36,9 @@ OFFSET_US = 0x21BA4
 
 
 class BoldTextPatchHandler(AbstractPatchHandler, DependantPatch):
-
     @property
     def name(self) -> str:
-        return 'BoldText'
+        return "BoldText"
 
     @property
     def description(self) -> str:
@@ -47,30 +46,34 @@ class BoldTextPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def author(self) -> str:
-        return 'Adex'
+        return "Adex"
 
     @property
     def version(self) -> str:
-        return '0.1.0'
+        return "0.1.0"
 
     def depends_on(self) -> List[str]:
-         return ['ExtraSpace']
+        return ["ExtraSpace"]
 
     @property
     def category(self) -> PatchCategory:
         return PatchCategory.NEW_MECHANIC
 
     def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
-         if config.game_version == GAME_VERSION_EOS:
-             if config.game_region == GAME_REGION_US:
-                 return read_u32(rom.arm9, OFFSET_US) != ORIGINAL_INSTRUCTION
-             if config.game_region == GAME_REGION_EU:
-                 return read_u32(rom.arm9, OFFSET_EU) != ORIGINAL_INSTRUCTION
-         raise NotImplementedError()
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_u32(rom.arm9, OFFSET_US) != ORIGINAL_INSTRUCTION
+            if config.game_region == GAME_REGION_EU:
+                return read_u32(rom.arm9, OFFSET_EU) != ORIGINAL_INSTRUCTION
+        raise NotImplementedError()
 
-    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:
-         # Apply the patch
-         apply()
+    def apply(
+        self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ) -> None:
+        # Apply the patch
+        apply()
 
-    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+    def unapply(
+        self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ):
         raise NotImplementedError()

--- a/skytemple_files/patch/handler/bold_text.py
+++ b/skytemple_files/patch/handler/bold_text.py
@@ -1,0 +1,71 @@
+ #  Copyright 2020-2022 Capypara and the SkyTemple Contributors
+ #
+ #  This file is part of SkyTemple.
+ #
+ #  SkyTemple is free software: you can redistribute it and/or modify
+ #  it under the terms of the GNU General Public License as published by
+ #  the Free Software Foundation, either version 3 of the License, or
+ #  (at your option) any later version.
+ #
+ #  SkyTemple is distributed in the hope that it will be useful,
+ #  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ #  GNU General Public License for more details.
+ #
+ #  You should have received a copy of the GNU General Public License
+ #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable, List
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+from skytemple_files.common.i18n_util import f, _
+
+ORIGINAL_INSTRUCTION = 0xE12FFF37
+OFFSET_EU = 0x21D68
+OFFSET_US = 0x21BA4
+
+
+class BoldTextPatchHandler(AbstractPatchHandler, DependantPatch):
+
+    @property
+    def name(self) -> str:
+        return 'BoldText'
+
+    @property
+    def description(self) -> str:
+        return "Adds new text tags that allow for bold text in strings. Encase the desired text with [BS] and [BR]."
+
+    @property
+    def author(self) -> str:
+        return 'Adex'
+
+    @property
+    def version(self) -> str:
+        return '0.1.0'
+
+    def depends_on(self) -> List[str]:
+         return ['ExtraSpace']
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.NEW_MECHANIC
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+         arm9 = get_binary_from_rom_ppmdu(rom, config.binaries['arm9.bin'])
+         if config.game_version == GAME_VERSION_EOS:
+             if config.game_region == GAME_REGION_US:
+                 return read_uintle(arm9, OFFSET_US, 4) != ORIGINAL_INSTRUCTION
+             if config.game_region == GAME_REGION_EU:
+                 return read_uintle(arm9, OFFSET_EU, 4) != ORIGINAL_INSTRUCTION
+         raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:
+         # Apply the patch
+         apply()
+
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/handler/bold_text.py
+++ b/skytemple_files/patch/handler/bold_text.py
@@ -63,9 +63,9 @@ class BoldTextPatchHandler(AbstractPatchHandler, DependantPatch):
     def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
          if config.game_version == GAME_VERSION_EOS:
              if config.game_region == GAME_REGION_US:
-                 return read_u32(rom.arm9, OFFSET_US, 4) != ORIGINAL_INSTRUCTION
+                 return read_u32(rom.arm9, OFFSET_US) != ORIGINAL_INSTRUCTION
              if config.game_region == GAME_REGION_EU:
-                 return read_u32(rom.arm9, OFFSET_EU, 4) != ORIGINAL_INSTRUCTION
+                 return read_u32(rom.arm9, OFFSET_EU) != ORIGINAL_INSTRUCTION
          raise NotImplementedError()
 
     def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:

--- a/skytemple_files/patch/handler/change_text_sound.py
+++ b/skytemple_files/patch/handler/change_text_sound.py
@@ -1,28 +1,34 @@
- #  Copyright 2020-2022 Capypara and the SkyTemple Contributors
- #
- #  This file is part of SkyTemple.
- #
- #  SkyTemple is free software: you can redistribute it and/or modify
- #  it under the terms of the GNU General Public License as published by
- #  the Free Software Foundation, either version 3 of the License, or
- #  (at your option) any later version.
- #
- #  SkyTemple is distributed in the hope that it will be useful,
- #  but WITHOUT ANY WARRANTY; without even the implied warranty of
- #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- #  GNU General Public License for more details.
- #
- #  You should have received a copy of the GNU General Public License
- #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright 2020-2022 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
 from typing import Callable, List
 
 from ndspy.rom import NintendoDSRom
 
+from skytemple_files.common.ppmdu_config.data import (
+    GAME_REGION_EU,
+    GAME_REGION_US,
+    GAME_VERSION_EOS,
+    Pmd2Data,
+)
 from skytemple_files.common.util import *
-from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU
 from skytemple_files.patch.category import PatchCategory
 from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
-from skytemple_files.common.i18n_util import f, _
 
 ORIGINAL_INSTRUCTION_EU = 0xEA0002AC
 ORIGINAL_INSTRUCTION_US = 0xEA000291
@@ -56,12 +62,11 @@ class ChangeTextSoundPatchHandler(AbstractPatchHandler, DependantPatch):
         return PatchCategory.NEW_MECHANIC
 
     def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
-         arm9 = get_binary_from_rom_ppmdu(rom, config.binaries['arm9.bin'])
          if config.game_version == GAME_VERSION_EOS:
              if config.game_region == GAME_REGION_US:
-                 return read_uintle(arm9, OFFSET_US, 4) != ORIGINAL_INSTRUCTION_US
+                 return read_u32(rom.arm9, OFFSET_US, 4) != ORIGINAL_INSTRUCTION_US
              if config.game_region == GAME_REGION_EU:
-                 return read_uintle(arm9, OFFSET_EU, 4) != ORIGINAL_INSTRUCTION_EU
+                 return read_u32(rom.arm9, OFFSET_EU, 4) != ORIGINAL_INSTRUCTION_EU
          raise NotImplementedError()
 
     def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:

--- a/skytemple_files/patch/handler/change_text_sound.py
+++ b/skytemple_files/patch/handler/change_text_sound.py
@@ -1,0 +1,72 @@
+ #  Copyright 2020-2022 Capypara and the SkyTemple Contributors
+ #
+ #  This file is part of SkyTemple.
+ #
+ #  SkyTemple is free software: you can redistribute it and/or modify
+ #  it under the terms of the GNU General Public License as published by
+ #  the Free Software Foundation, either version 3 of the License, or
+ #  (at your option) any later version.
+ #
+ #  SkyTemple is distributed in the hope that it will be useful,
+ #  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ #  GNU General Public License for more details.
+ #
+ #  You should have received a copy of the GNU General Public License
+ #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Callable, List
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import *
+from skytemple_files.common.ppmdu_config.data import Pmd2Data, GAME_VERSION_EOS, GAME_REGION_US, GAME_REGION_EU
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+from skytemple_files.common.i18n_util import f, _
+
+ORIGINAL_INSTRUCTION_EU = 0xEA0002AC
+ORIGINAL_INSTRUCTION_US = 0xEA000291
+OFFSET_EU = 0x2111C
+OFFSET_US = 0x20FC4
+
+
+class ChangeTextSoundPatchHandler(AbstractPatchHandler, DependantPatch):
+
+    @property
+    def name(self) -> str:
+        return 'ChangeTextSound'
+
+    @property
+    def description(self) -> str:
+        return "Adds new text tags that allow for the textbox sound to be changed. [TS:X] will use the Xth sound effect ID in textboxes. [TR] will revert the sound to default."
+
+    @property
+    def author(self) -> str:
+        return 'Adex'
+
+    @property
+    def version(self) -> str:
+        return '0.1.0'
+
+    def depends_on(self) -> List[str]:
+         return ['ExtraSpace']
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.NEW_MECHANIC
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+         arm9 = get_binary_from_rom_ppmdu(rom, config.binaries['arm9.bin'])
+         if config.game_version == GAME_VERSION_EOS:
+             if config.game_region == GAME_REGION_US:
+                 return read_uintle(arm9, OFFSET_US, 4) != ORIGINAL_INSTRUCTION_US
+             if config.game_region == GAME_REGION_EU:
+                 return read_uintle(arm9, OFFSET_EU, 4) != ORIGINAL_INSTRUCTION_EU
+         raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:
+         # Apply the patch
+         apply()
+
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/handler/change_text_sound.py
+++ b/skytemple_files/patch/handler/change_text_sound.py
@@ -64,9 +64,9 @@ class ChangeTextSoundPatchHandler(AbstractPatchHandler, DependantPatch):
     def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
          if config.game_version == GAME_VERSION_EOS:
              if config.game_region == GAME_REGION_US:
-                 return read_u32(rom.arm9, OFFSET_US, 4) != ORIGINAL_INSTRUCTION_US
+                 return read_u32(rom.arm9, OFFSET_US) != ORIGINAL_INSTRUCTION_US
              if config.game_region == GAME_REGION_EU:
-                 return read_u32(rom.arm9, OFFSET_EU, 4) != ORIGINAL_INSTRUCTION_EU
+                 return read_u32(rom.arm9, OFFSET_EU) != ORIGINAL_INSTRUCTION_EU
          raise NotImplementedError()
 
     def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:

--- a/skytemple_files/patch/handler/change_text_sound.py
+++ b/skytemple_files/patch/handler/change_text_sound.py
@@ -37,10 +37,9 @@ OFFSET_US = 0x20FC4
 
 
 class ChangeTextSoundPatchHandler(AbstractPatchHandler, DependantPatch):
-
     @property
     def name(self) -> str:
-        return 'ChangeTextSound'
+        return "ChangeTextSound"
 
     @property
     def description(self) -> str:
@@ -48,30 +47,34 @@ class ChangeTextSoundPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def author(self) -> str:
-        return 'Adex'
+        return "Adex"
 
     @property
     def version(self) -> str:
-        return '0.1.0'
+        return "0.1.0"
 
     def depends_on(self) -> List[str]:
-         return ['ExtraSpace']
+        return ["ExtraSpace"]
 
     @property
     def category(self) -> PatchCategory:
         return PatchCategory.NEW_MECHANIC
 
     def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
-         if config.game_version == GAME_VERSION_EOS:
-             if config.game_region == GAME_REGION_US:
-                 return read_u32(rom.arm9, OFFSET_US) != ORIGINAL_INSTRUCTION_US
-             if config.game_region == GAME_REGION_EU:
-                 return read_u32(rom.arm9, OFFSET_EU) != ORIGINAL_INSTRUCTION_EU
-         raise NotImplementedError()
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_u32(rom.arm9, OFFSET_US) != ORIGINAL_INSTRUCTION_US
+            if config.game_region == GAME_REGION_EU:
+                return read_u32(rom.arm9, OFFSET_EU) != ORIGINAL_INSTRUCTION_EU
+        raise NotImplementedError()
 
-    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:
-         # Apply the patch
-         apply()
+    def apply(
+        self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ) -> None:
+        # Apply the patch
+        apply()
 
-    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+    def unapply(
+        self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ):
         raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -53,11 +53,17 @@ from skytemple_files.patch.handler.add_type import AddTypePatchHandler
 from skytemple_files.patch.handler.allow_unrecruitable_mons import (
     AllowUnrecruitableMonsPatchHandler,
 )
+from skytemple_files.patch.handler.bold_text import (
+    BoldTextPatchHandler,
+)
 from skytemple_files.patch.handler.change_evo import ChangeEvoSystemPatchHandler
 from skytemple_files.patch.handler.change_ff_prop import (
     ChangeFixedFloorPropertiesPatchHandler,
 )
 from skytemple_files.patch.handler.change_tbbg import ChangeTextBoxColorPatchHandler
+from skytemple_files.patch.handler.change_text_sound import (
+    ChangeTextSoundPatchHandler,
+)
 from skytemple_files.patch.handler.choose_starter import ChooseStarterPatchHandler
 from skytemple_files.patch.handler.complete_team_control import CompleteTeamControl
 from skytemple_files.patch.handler.compress_iq_data import CompressIQDataPatchHandler
@@ -163,6 +169,8 @@ class PatchType(Enum):
     DYNAMIC_BOSSES_EVERYWHERE = DynamicBossesEverywherePatchHandler
     PITFALL_TRAP_TWEAK = PitfallTrapTweakPatchHandler
     FIX_NOCASH_SAVES = FixNocashSavesPatchHandler
+    BOLD_TEXT = BoldTextPatchHandler
+    CHANGE_TEXT_SOUND = ChangeTextSoundPatchHandler
 
 
 class Patcher:

--- a/skytemple_files/script/ssb/model.py
+++ b/skytemple_files/script/ssb/model.py
@@ -324,15 +324,17 @@ class Ssb:
                                 param = -0x10000 + param
                             new_params.append(param)
                         elif argument_spec.type in ENUM_ARGUMENTS:
-                            const_data = getattr(self._scriptdata, ENUM_ARGUMENTS[argument_spec.type])
+                            const_data = getattr(
+                                self._scriptdata, ENUM_ARGUMENTS[argument_spec.type]
+                            )
                             if param in const_data:
                                 new_params.append(
-                                    SsbConstant.create_for(
-                                        const_data[param]
-                                    )
+                                    SsbConstant.create_for(const_data[param])
                                 )
                             else:
-                                logger.warning(f"Unknown {argument_spec.type} id: {param}")
+                                logger.warning(
+                                    f"Unknown {argument_spec.type} id: {param}"
+                                )
                                 new_params.append(param)
                         elif (
                             argument_spec.type == "String"


### PR DESCRIPTION
Adds two ASM patches that implement new text tags to be used in strings.
- BoldText adds the [BS] and [BR] text tags, where any text encased within them will be bolded.
- ChangeTextSound adds the [TS:X] (where X is an integer) and [TR] text tags. [TS:X] sets the textbox to use the Xth sound effect ID, while [TR] reverts the sound to its default.