### PR TITLE
Add string interning for const SSB strings

### DIFF
--- a/skytemple_files/script/ssb/script_compiler.py
+++ b/skytemple_files/script/ssb/script_compiler.py
@@ -377,9 +377,12 @@ class ScriptCompiler:
                 raise SsbCompilerError(str(err)) from err
 
         if isinstance(param, SsbOpParamConstString):
-            i = len(built_constants)
-            built_constants.append(param.name)
-            return i
+            try:
+                return build_constants.index(param.name)
+            except:
+                i = len(built_constants)
+                built_constants.append(param.name)
+                return i
 
         if isinstance(param, SsbOpParamLanguageString):
             i = len(built_strings[next(iter(built_strings.keys()))])

--- a/skytemple_files/script/ssb/script_compiler.py
+++ b/skytemple_files/script/ssb/script_compiler.py
@@ -378,7 +378,7 @@ class ScriptCompiler:
 
         if isinstance(param, SsbOpParamConstString):
             try:
-                return build_constants.index(param.name)
+                return built_constants.index(param.name)
             except:
                 i = len(built_constants)
                 built_constants.append(param.name)


### PR DESCRIPTION
Interns (de-duplicates) strings during SSB compilation to save space (there are no ulterior motives).

This is completely untested since I couldn't be bothered to update and fix my development setup right now. I'm not deep enough into SSB internals to tell if this change could break anything.