### PR TITLE
Add AntiSoftlock patch

### DIFF
--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -915,6 +915,14 @@
 	  </OpenBin>
         </Patch>
 
+        <SimplePatch id="AntiSoftlock">
+          <Include filename="end_asm_mods/src/AntiSoftlock.asm"/>
+          <Replace filename="end_asm_mods/src/common/regionSelect.asm" regexp='_REGION equ "(\w+)"'>
+            <Game id="EoS_NA" replace='_REGION equ "US"'/>
+            <Game id="EoS_EU" replace='_REGION equ "EU"'/>
+          </Replace>
+        </SimplePatch>
+
       </Game>
     </Patches>
 

--- a/skytemple_files/patch/handler/anti_softlock.py
+++ b/skytemple_files/patch/handler/anti_softlock.py
@@ -1,0 +1,85 @@
+#  Copyright 2020-2022 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+from typing import Callable, List
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.i18n_util import _
+from skytemple_files.common.ppmdu_config.data import (
+    GAME_REGION_EU,
+    GAME_REGION_US,
+    GAME_VERSION_EOS,
+    Pmd2Data,
+)
+from skytemple_files.common.util import *
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+
+ORIGINAL_INSTRUCTION = 0xE59F0080
+OFFSET_EU = 0x8114
+OFFSET_US = 0x8114
+
+
+class AntiSoftlockPatchHandler(AbstractPatchHandler, DependantPatch):
+    @property
+    def name(self) -> str:
+        return "AntiSoftlock"
+
+    @property
+    def description(self) -> str:
+        return _(
+            "Allows the player to press A+B+X+Y during cutscenes to force the game to continue past a softlock "
+            "(this can happen during cutscenes when using custom sprites or the randomizer). Does not work with "
+            "crashes caused due to internal errors (such as the game running out of memory)."
+        )
+
+    @property
+    def author(self) -> str:
+        return "End45"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    def depends_on(self) -> List[str]:
+        return ["ExtraSpace"]
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.NEW_MECHANIC
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        overlay11 = get_binary_from_rom(rom, config.bin_sections.overlay11)
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_u32(overlay11, OFFSET_US) != ORIGINAL_INSTRUCTION
+            if config.game_region == GAME_REGION_EU:
+                return read_u32(overlay11, OFFSET_EU) != ORIGINAL_INSTRUCTION
+        raise NotImplementedError()
+
+    def apply(
+        self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ) -> None:
+        # Apply the patch
+        apply()
+
+    def unapply(
+        self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ) -> None:
+        raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -53,6 +53,7 @@ from skytemple_files.patch.handler.add_type import AddTypePatchHandler
 from skytemple_files.patch.handler.allow_unrecruitable_mons import (
     AllowUnrecruitableMonsPatchHandler,
 )
+from skytemple_files.patch.handler.anti_softlock import AntiSoftlockPatchHandler
 from skytemple_files.patch.handler.appraise_all import AppraiseAllPatchHandler
 from skytemple_files.patch.handler.bold_text import (
     BoldTextPatchHandler,
@@ -173,6 +174,7 @@ class PatchType(Enum):
     FIX_NOCASH_SAVES = FixNocashSavesPatchHandler
     BOLD_TEXT = BoldTextPatchHandler
     CHANGE_TEXT_SOUND = ChangeTextSoundPatchHandler
+    ANTI_SOFTLOCK = AntiSoftlockPatchHandler
 
 
 class Patcher:


### PR DESCRIPTION
Adds a patch that allows the user to press A+B+X+Y during cutscenes to unlock all locks at once. This can be used to fix many of the softlocks caused by changing the starters.

This patch could also be added as a default patch to the randomizer, since these kind of softlocks are common there.