### PR TITLE
Update ExtraSpace and fix how it's applied

### DIFF
--- a/skytemple_files/patch/handler/extra_space.py
+++ b/skytemple_files/patch/handler/extra_space.py
@@ -55,7 +55,7 @@ class ExtraSpacePatch(AbstractPatchHandler):
 
     @property
     def version(self) -> str:
-        return "0.1.0"
+        return "0.2.0"
 
     @property
     def category(self) -> PatchCategory:
@@ -67,6 +67,8 @@ class ExtraSpacePatch(AbstractPatchHandler):
     def apply(
         self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
     ) -> None:
+
+        apply()
 
         # Put the overlay file into the ROM
         folder: Folder = rom.filenames
@@ -84,8 +86,6 @@ class ExtraSpacePatch(AbstractPatchHandler):
                 recursive_increment_folder_start_idx(sfolder, if_bigger_than)
 
         recursive_increment_folder_start_idx(rom.filenames, folder_first_file_id - 1)
-
-        apply()
 
     def unapply(
         self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data


### PR DESCRIPTION
This updates ExtraSpace to the latest version, which adds support for static initialization. This allows other projects (like c-of-time) to run initialization code when the overlay is loaded.

I also fixed a bug that caused the overlay to be added as an empty file when applying the patch. Since `apply()` uses the overlay list to export the overlays to the temporary folder where the patch is applied, it skips overlay 36 (because the overlay list hasn't been patched yet at that point), which results in an empty file being written to the temporary folder. This means the overlay that was added to the rom with `rom.files.insert()` gets overwritten by the one on the temporary folder, resulting in an empty file.

This bug hasn't caused any problems until now, so it has gone unnoticed for a long time. Armips supports writing past the end of a file, nobody had to read anything from the file until now and the game doesn't seem to care much about the overlay being empty when it's loaded, so looks like no one noticed.