### PR TITLE
Make ExtraSpace reapplyable

### DIFF
--- a/skytemple_files/patch/handler/extra_space.py
+++ b/skytemple_files/patch/handler/extra_space.py
@@ -67,22 +67,20 @@ class ExtraSpacePatch(AbstractPatchHandler):
     def apply(
         self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
     ) -> None:
-        # Put the overlay file into the ROM
+        # Put the overlay file into the ROM if it doesn't exist already
         folder: Folder = rom.filenames
         folder_first_file_id = folder.firstID
-        assert (
-            folder_first_file_id == OV_FILE_IDX
-        ), "The overlay already exists or the ROM FAT is an unexpected state."
-        with open(OV_FILE_PATH, "rb") as f:
-            rom.files.insert(OV_FILE_IDX, f.read())
+        if folder_first_file_id == OV_FILE_IDX:
+            with open(OV_FILE_PATH, "rb") as f:
+                rom.files.insert(OV_FILE_IDX, f.read())
 
-        def recursive_increment_folder_start_idx(rfolder: Folder, if_bigger_than):
-            if rfolder.firstID > if_bigger_than:
-                rfolder.firstID += 1
-            for _, sfolder in rfolder.folders:
-                recursive_increment_folder_start_idx(sfolder, if_bigger_than)
+            def recursive_increment_folder_start_idx(rfolder: Folder, if_bigger_than):
+                if rfolder.firstID > if_bigger_than:
+                    rfolder.firstID += 1
+                for _, sfolder in rfolder.folders:
+                    recursive_increment_folder_start_idx(sfolder, if_bigger_than)
 
-        recursive_increment_folder_start_idx(rom.filenames, folder_first_file_id - 1)
+            recursive_increment_folder_start_idx(rom.filenames, folder_first_file_id - 1)
 
         apply()
 

--- a/skytemple_files/patch/handler/extra_space.py
+++ b/skytemple_files/patch/handler/extra_space.py
@@ -80,7 +80,9 @@ class ExtraSpacePatch(AbstractPatchHandler):
                 for _, sfolder in rfolder.folders:
                     recursive_increment_folder_start_idx(sfolder, if_bigger_than)
 
-            recursive_increment_folder_start_idx(rom.filenames, folder_first_file_id - 1)
+            recursive_increment_folder_start_idx(
+                rom.filenames, folder_first_file_id - 1
+            )
 
         apply()
 


### PR DESCRIPTION
ExtraSpace needs to be reapplyable so it can get updated to v0.2, which is needed to make CoT work.
This PR assumes #312 got merged, so that one should be merged first.
@theCapypara I'm guessing you'll make a hotfix release after #312 gets fixed, it would be good to include this as well.