### PR TITLE
Fix minor MoveShortcuts bug

### DIFF
--- a/skytemple_files/patch/handler/move_shortcuts.py
+++ b/skytemple_files/patch/handler/move_shortcuts.py
@@ -53,7 +53,7 @@ class MoveShortcutsPatch(AbstractPatchHandler, DependantPatch):
 
     @property
     def version(self) -> str:
-        return "0.2.1"
+        return "0.2.2"
 
     def depends_on(self) -> List[str]:
         return ["ExtraSpace"]


### PR DESCRIPTION
MoveShortcuts 0.2.1 has a minor bug that prevents the player from passing their turn with A+B if their belly is less than 1.0. It only occurs if the leader pokémon struct is not aligned to 4 bytes, and probably only on real hardware and some emulators.

I don't think this can cause a crash, but it triggers a warning on No$GBA if they are enabled every time A+B is pressed.

The submodule commit includes the BetterEnemyEvolution patch too since #329 hasn't been merged yet.