### PR TITLE
Fix softlock caused by AntiSoftlock patch

### DIFF
--- a/skytemple_files/patch/handler/anti_softlock.py
+++ b/skytemple_files/patch/handler/anti_softlock.py
@@ -55,7 +55,7 @@ class AntiSoftlockPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def version(self) -> str:
-        return "0.1.0"
+        return "0.1.1"
 
     def depends_on(self) -> List[str]:
         return ["ExtraSpace"]


### PR DESCRIPTION
How ironic. It could prevent others from softlocking, but not itself.

This fixes a bug that causes a softlock in real hardware and some emulators when A+B is pressed.
Since other PRs that update my patches repo haven't been merged yet (#329, #339), those updates are included here as well.