### PR TITLE
Expand Portrait limit property

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/common/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/common/patch.asm
@@ -1,0 +1,16 @@
+; For use with ARMIPS
+; 2023/03/11
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Expand Portrait Structure Size to accept compressed portraits up to 808 bytes
+; ------------------------------------------------------------------------------
+;
+.relativeinclude on
+.nds
+.arm
+
+.org PatchSize
+.area 0x4
+	mov  r0,#0x388
+.endarea
+

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/eu/offsets.asm
@@ -1,0 +1,13 @@
+; For use with ARMIPS
+; 2021/03/11
+; For Explorers of Sky European ONLY!
+; Should not be used with any other version!
+; ------------------------------------------------------------------------------
+; Expand Portrait Structure Size to accept compressed portraits up to 808 bytes
+; ------------------------------------------------------------------------------
+;
+.relativeinclude on
+.nds
+.arm
+
+.definelabel PatchSize, 0x0202F8B0

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/jp/offsets.asm
@@ -1,0 +1,13 @@
+; For use with ARMIPS
+; 2021/03/11
+; For Explorers of Sky Japan ONLY!
+; Should not be used with any other version!
+; ------------------------------------------------------------------------------
+; Expand Portrait Structure Size to accept compressed portraits up to 808 bytes
+; ------------------------------------------------------------------------------
+;
+.relativeinclude on
+.nds
+.arm
+
+.definelabel PatchSize, 0x0202F900

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/na/offsets.asm
@@ -1,0 +1,13 @@
+; For use with ARMIPS
+; 2021/03/11
+; For Explorers of Sky North American ONLY!
+; Should not be used with any other version!
+; ------------------------------------------------------------------------------
+; Expand Portrait Structure Size to accept compressed portraits up to 808 bytes
+; ------------------------------------------------------------------------------
+;
+.relativeinclude on
+.nds
+.arm
+
+.definelabel PatchSize, 0x0202F5BC

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/selector_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/selector_arm9.asm
@@ -1,0 +1,22 @@
+; For use with ARMIPS
+; 2023/03/11
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/offsets.asm"
+	.include "common/patch.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/offsets.asm"
+	.include "common/patch.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/offsets.asm"
+	.include "common/patch.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -488,6 +488,13 @@
           </OpenBin>
         </Patch>
 
+        <!-- A patch to expand Portrait Structure Size -->
+        <Patch id="ExpandPortraitStructs" >
+          <OpenBin filepath="arm9.bin">
+	  	<Include filename ="anonymous_asm_mods/expand_portrait/selector_arm9.asm"/>
+	  </OpenBin>
+        </Patch>
+        
         <!-- A patch to provide support for ATUPX containers -->
         <Patch id="ProvideATUPXSupport" >
           <OpenBin filepath="arm9.bin">

--- a/skytemple_files/graphics/kao/_model.py
+++ b/skytemple_files/graphics/kao/_model.py
@@ -33,7 +33,12 @@ from skytemple_files.graphics.kao import (
     SUBENTRIES,
     SUBENTRY_LEN,
 )
-from skytemple_files.graphics.kao.protocol import _KaoPropertiesProtocol, KaoImageProtocol, KaoProtocol, KAO_IMAGE_LIMIT
+from skytemple_files.graphics.kao.protocol import (
+    _KaoPropertiesProtocol,
+    KaoImageProtocol,
+    KaoProtocol,
+    KAO_IMAGE_LIMIT,
+)
 
 
 class KaoPropertiesState(_KaoPropertiesProtocol):
@@ -46,10 +51,9 @@ class KaoPropertiesState(_KaoPropertiesProtocol):
     @classmethod
     def instance(cls) -> KaoPropertiesState:
         if cls._instance is None:
-            cls._instance = KaoPropertiesState(
-                KAO_IMAGE_LIMIT
-            )
+            cls._instance = KaoPropertiesState(KAO_IMAGE_LIMIT)
         return cls._instance
+
 
 class KaoImage(KaoImageProtocol):
     def __init__(self, whole_kao_data: bytes, start_pnt: int):

--- a/skytemple_files/graphics/kao/handler.py
+++ b/skytemple_files/graphics/kao/handler.py
@@ -24,7 +24,11 @@ from skytemple_files.common.types.hybrid_data_handler import (
     WriterProtocol,
 )
 from skytemple_files.common.util import OptionalKwargs
-from skytemple_files.graphics.kao.protocol import _KaoPropertiesProtocol, KaoImageProtocol, KaoProtocol
+from skytemple_files.graphics.kao.protocol import (
+    _KaoPropertiesProtocol,
+    KaoImageProtocol,
+    KaoProtocol,
+)
 
 if TYPE_CHECKING:
     pass

--- a/skytemple_files/graphics/kao/handler.py
+++ b/skytemple_files/graphics/kao/handler.py
@@ -24,7 +24,7 @@ from skytemple_files.common.types.hybrid_data_handler import (
     WriterProtocol,
 )
 from skytemple_files.common.util import OptionalKwargs
-from skytemple_files.graphics.kao.protocol import KaoImageProtocol, KaoProtocol
+from skytemple_files.graphics.kao.protocol import _KaoPropertiesProtocol, KaoImageProtocol, KaoProtocol
 
 if TYPE_CHECKING:
     pass
@@ -58,6 +58,18 @@ class KaoHandler(HybridDataHandler[KaoProtocol]):
         )  # pylint: disable=no-name-in-module,no-member,import-error
 
         return KaoWriter
+
+    @classmethod
+    def properties(cls) -> _KaoPropertiesProtocol:
+        if get_implementation_type() == ImplementationType.NATIVE:
+            from skytemple_rust.st_kao import (
+                KaoPropertiesState as KaoPropertiesNative,
+            )  # pylint: disable=no-name-in-module,no-member,import-error
+
+            return KaoPropertiesNative.instance()
+        from skytemple_files.graphics.kao._model import KaoPropertiesState
+
+        return KaoPropertiesState.instance()
 
     @classmethod
     def get_image_model_cls(cls) -> Type[KaoImageProtocol]:

--- a/skytemple_files/graphics/kao/protocol.py
+++ b/skytemple_files/graphics/kao/protocol.py
@@ -42,6 +42,7 @@ class _KaoPropertiesProtocol(Protocol):
         """This is a singleton."""
         ...
 
+
 class KaoImageProtocol(Protocol):
     @classmethod
     @abstractmethod

--- a/skytemple_files/graphics/kao/protocol.py
+++ b/skytemple_files/graphics/kao/protocol.py
@@ -21,6 +21,26 @@ from typing import Iterator, Optional, Protocol, Tuple, TypeVar
 
 from PIL.Image import Image
 
+KAO_IMAGE_LIMIT = 800
+
+
+class _KaoPropertiesProtocol(Protocol):
+    """
+    Implementations must provide an implementation of this.
+    This keeps track of "changeable" constants.
+
+    The values must default to the values below, users may
+    change it via the MdHandler, if for example a patch to expand
+    the monster list is applied.
+    """
+
+    kao_image_limit: int  # Must default to KAO_IMAGE_LIMIT.
+
+    @classmethod
+    @abstractmethod
+    def instance(cls) -> "_KaoPropertiesProtocol":
+        """This is a singleton."""
+        ...
 
 class KaoImageProtocol(Protocol):
     @classmethod

--- a/skytemple_files/patch/handler/expand_portrait.py
+++ b/skytemple_files/patch/handler/expand_portrait.py
@@ -1,0 +1,92 @@
+#  Copyright 2020-2023 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+from typing import Callable
+
+from skytemple_files.common.i18n_util import _
+from skytemple_files.common.ppmdu_config.data import (
+    GAME_REGION_EU,
+    GAME_REGION_JP,
+    GAME_REGION_US,
+    GAME_VERSION_EOS,
+    Pmd2Data,
+)
+from skytemple_files.common.util import *
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+
+PATCH_CHECK_ADDR_APPLIED_US = 0x2F5BC
+PATCH_CHECK_ADDR_APPLIED_EU = 0x2F8B0
+PATCH_CHECK_ADDR_APPLIED_JP = 0x2F900
+PATCH_CHECK_INSTR_APPLIED = 0xE3A00D0E
+
+
+class ExpandPortraitPatchHandler(AbstractPatchHandler):
+    @property
+    def name(self) -> str:
+        return "ExpandPortraitStructs"
+
+    @property
+    def description(self) -> str:
+        return _(
+            "Expands portraits structure by 8 bytes, which is enough to cover all cases."
+        )
+
+    @property
+    def author(self) -> str:
+        return "Anonymous"
+
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.UTILITY
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return (
+                    read_u32(rom.arm9, PATCH_CHECK_ADDR_APPLIED_US)
+                    != PATCH_CHECK_INSTR_APPLIED
+                )
+            if config.game_region == GAME_REGION_EU:
+                return (
+                    read_u32(rom.arm9, PATCH_CHECK_ADDR_APPLIED_EU)
+                    != PATCH_CHECK_INSTR_APPLIED
+                )
+            if config.game_region == GAME_REGION_JP:
+                return (
+                    read_u32(rom.arm9, PATCH_CHECK_ADDR_APPLIED_JP)
+                    != PATCH_CHECK_INSTR_APPLIED
+                )
+        raise NotImplementedError()
+
+    def apply(
+        self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ) -> None:
+        try:
+            apply()
+        except RuntimeError as ex:
+            raise ex
+
+    def unapply(
+        self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ) -> None:
+        raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -84,6 +84,7 @@ from skytemple_files.patch.handler.edit_extra_pokemon import (
 )
 from skytemple_files.patch.handler.exp_share import ExpSharePatchHandler
 from skytemple_files.patch.handler.expand_poke_list import ExpandPokeListPatchHandler
+from skytemple_files.patch.handler.expand_portrait import ExpandPortraitPatchHandler
 from skytemple_files.patch.handler.externalize_mappa import ExternalizeMappaPatchHandler
 from skytemple_files.patch.handler.externalize_waza import ExternalizeWazaPatchHandler
 from skytemple_files.patch.handler.extra_space import ExtraSpacePatch
@@ -138,6 +139,7 @@ class PatchType(Enum):
     MOVE_SHORTCUTS = MoveShortcutsPatch
     DISABLE_TIPS = DisableTipsPatch
     SAME_TYPE_PARTNER = SameTypePartnerPatch
+    EXPAND_PORTRAIT = ExpandPortraitPatchHandler
     SUPPORT_ATUPX = AtupxSupportPatchHandler
     EXTRACT_ITEM_LISTS = ExtractItemListsPatchHandler
     EXTRACT_DUNGEON_DATA = ExtractDungeonDataPatchHandler


### PR DESCRIPTION
Adds a patch to expand the portrait structure allocated by the game by 8 bytes, which is enough to contain all possible cases of compressed portraits (worst case is an uncompressed ATNPX container which would be 807 bytes, while the expanded structure can contain up to 808 bytes).
Adds a property for Kao Image import to specify that limit.