### PR TITLE
Add NoWeatherStop patch

### DIFF
--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -967,6 +967,14 @@
           </Parameters>
         </SimplePatch>
 
+        <SimplePatch id="NoWeatherStop">
+          <Include filename="end_asm_mods/src/NoWeatherStop.asm"/>
+          <Replace filename="end_asm_mods/src/common/regionSelect.asm" regexp='_REGION equ "(\w+)"'>
+            <Game id="EoS_NA" replace='_REGION equ "US"'/>
+            <Game id="EoS_EU" replace='_REGION equ "EU"'/>
+          </Replace>
+        </SimplePatch>
+
       </Game>
     </Patches>
 

--- a/skytemple_files/patch/handler/no_weather_stop.py
+++ b/skytemple_files/patch/handler/no_weather_stop.py
@@ -1,0 +1,84 @@
+#  Copyright 2020-2023 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+from typing import Callable, List
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.i18n_util import _
+from skytemple_files.common.ppmdu_config.data import (
+    GAME_REGION_EU,
+    GAME_REGION_US,
+    GAME_VERSION_EOS,
+    Pmd2Data,
+)
+from skytemple_files.common.util import *
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+
+ORIGINAL_INSTRUCTION_EU = 0xEBFE9DA6
+ORIGINAL_INSTRUCTION_US = 0xEBFE9E38
+OFFSET_EU = 0x6F77C
+OFFSET_US = 0x6F4BC
+
+
+class NoWeatherStopPatchHandler(AbstractPatchHandler, DependantPatch):
+    @property
+    def name(self) -> str:
+        return "NoWeatherStop"
+
+    @property
+    def description(self) -> str:
+        return _(
+            "Changes weather damage messages so they don't make the player stop running."
+        )
+
+    @property
+    def author(self) -> str:
+        return "End45"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    def depends_on(self) -> List[str]:
+        return ["ExtraSpace"]
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.IMPROVEMENT_TWEAK
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        overlay29 = get_binary_from_rom(rom, config.bin_sections.overlay29)
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_u32(overlay29, OFFSET_US) != ORIGINAL_INSTRUCTION_US
+            if config.game_region == GAME_REGION_EU:
+                return read_u32(overlay29, OFFSET_EU) != ORIGINAL_INSTRUCTION_EU
+        raise NotImplementedError()
+
+    def apply(
+        self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ) -> None:
+        # Apply the patch
+        apply()
+
+    def unapply(
+        self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ) -> None:
+        raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -111,6 +111,7 @@ from skytemple_files.patch.handler.fix_memory_softlock import (
 from skytemple_files.patch.handler.fix_nocash_saves import FixNocashSavesPatchHandler
 from skytemple_files.patch.handler.move_growth import MoveGrowthPatchHandler
 from skytemple_files.patch.handler.move_shortcuts import MoveShortcutsPatch
+from skytemple_files.patch.handler.no_weather_stop import NoWeatherStopPatchHandler
 from skytemple_files.patch.handler.obj_table import ExtractObjectTablePatchHandler
 from skytemple_files.patch.handler.partners_trigger_hidden_traps import (
     PartnersTriggerHiddenTraps,
@@ -182,6 +183,7 @@ class PatchType(Enum):
     CHANGE_TEXT_SOUND = ChangeTextSoundPatchHandler
     ANTI_SOFTLOCK = AntiSoftlockPatchHandler
     BETTER_ENEMY_EVOLUTION = BetterEnemyEvolutionPatchHandler
+    NO_WEATHER_STOP = NoWeatherStopPatchHandler
 
 
 class Patcher:


### PR DESCRIPTION
Adds a patch that changes weather damage messages so they don't make the player stop running.
There's still a small delay when the message shows up, but it's no longer necessary to press the button again to keep running.