### PR TITLE
Update FixMemorySoftlock to v2.1

### DIFF
--- a/skytemple_files/patch/handler/fix_memory_softlock.py
+++ b/skytemple_files/patch/handler/fix_memory_softlock.py
@@ -53,7 +53,7 @@ class FixMemorySoftlockPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def version(self) -> str:
-        return "2.0.0"
+        return "2.1.0"
 
     def depends_on(self) -> List[str]:
         return ["ExtraSpace"]


### PR DESCRIPTION
Minor update to FixMemorySoftlock. Should fix some of the crashes people are having while playing the randomizer.