### PR TITLE
fix glaceon transparency bug

### DIFF
--- a/skytemple_files/graphics/chara_wan/sheets.py
+++ b/skytemple_files/graphics/chara_wan/sheets.py
@@ -499,7 +499,7 @@ def ImportSheets(inDir, strict=False):
     # and that no palettes have over 16 colors (transparency included)
 
     # then, run through simple_quant
-    reducedImg = simple_quant(combinedImg).convert("RGBA")
+    reducedImg = simple_quant(combinedImg, False).convert("RGBA")
 
     datas = reducedImg.getdata()
     for idx in range(len(datas)):


### PR DESCRIPTION
should fix https://github.com/SkyTemple/skytemple-files/issues/103

essentially, running quantize on an RGBA image can reduce the amount of colours in the palette even below the number passed into it (see https://github.com/python-pillow/Pillow/issues/5204 for further details). this poses a problem for glaceon specifically because one of its colours (0, 127, 159) is *really* close to the one defined as transparent.

since the actual transparent pixels have already been replaced with "transparent" pixels at this point, we can just convert it to RGB before running quantize to avoid this