### PR TITLE
fix backup transparent colours

### DIFF
--- a/skytemple_files/graphics/chara_wan/sheets.py
+++ b/skytemple_files/graphics/chara_wan/sheets.py
@@ -480,7 +480,7 @@ def ImportSheets(inDir, strict=False):
         foundTrans = False
         for count, color in colors:
             if color == transparent:
-                transparent = (0, 127, transparent[3] - 1, 255)
+                transparent = (0, 127, transparent[2] - 1, 255)
                 foundTrans = True
                 break
 


### PR DESCRIPTION
this can potentially loop infinitely because `transparent[3] - 1` is always 254. i think this was meant to use the previous colour's blue value, not its alpha value