### PR TITLE
Add various ASM patches

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/add_key_check/common/key_ov29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/add_key_check/common/key_ov29.asm
@@ -1,0 +1,4 @@
+.org CanUseItemActionBranch
+.area 0x4
+	b NewKeyCheck
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/add_key_check/common/key_ov36.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/add_key_check/common/key_ov36.asm
@@ -1,0 +1,18 @@
+.org 0x023A7080+0x18B0
+.area 0x18E0-0x18B0
+
+NewKeyCheck:
+	beq CanUseItemReturnTrue ; Original instruction
+	ldrsh r0,[r4,#+0x4]
+	cmp r0,#182 ; Key Item ID
+	bne CanUseItemActionBranch+0x4
+	; The following code is the same way the game checks if a Key Door should be opened!
+	ldrsh r1,[r5,#+0x6]
+	ldrsh r0,[r5,#+0x4]
+	sub r1,r1,#0x1
+	bl GetTileSafe
+	ldrh r0,[r0]
+	tst r0,#0x1000
+	beq CanUseItemReturnFalse
+	b CanUseItemActionBranch+0x4
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/add_key_check/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/add_key_check/eu/offsets.asm
@@ -1,0 +1,8 @@
+.relativeinclude on
+.nds
+.arm
+
+.definelabel CanUseItemActionBranch, 0x02347D40
+.definelabel CanUseItemReturnTrue, 0x02347D7C
+.definelabel CanUseItemReturnFalse, 0x02347D60
+.definelabel GetTileSafe, 0x02336D34

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/add_key_check/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/add_key_check/jp/offsets.asm
@@ -1,0 +1,8 @@
+.relativeinclude on
+.nds
+.arm
+
+.definelabel CanUseItemActionBranch, 0x02348500
+.definelabel CanUseItemReturnTrue, 0x0234853C
+.definelabel CanUseItemReturnFalse, 0x02348520
+.definelabel GetTileSafe, 0x02337534

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/add_key_check/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/add_key_check/na/offsets.asm
@@ -1,0 +1,8 @@
+.relativeinclude on
+.nds
+.arm
+
+.definelabel CanUseItemActionBranch, 0x02347140
+.definelabel CanUseItemReturnTrue, 0x0234717C
+.definelabel CanUseItemReturnFalse, 0x02347160
+.definelabel GetTileSafe, 0x02336164

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/add_key_check/selector_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/add_key_check/selector_overlay29.asm
@@ -1,0 +1,14 @@
+.relativeinclude on
+
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/offsets.asm"
+	.include "common/key_ov29.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/offsets.asm"
+	.include "common/key_ov29.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/offsets.asm"
+	.include "common/key_ov29.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/add_key_check/selector_overlay36.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/add_key_check/selector_overlay36.asm
@@ -1,0 +1,11 @@
+.relativeinclude on
+
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "common/key_ov36.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "common/key_ov36.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "common/key_ov36.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/common/portrait_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/common/portrait_arm9.asm
@@ -1,0 +1,9 @@
+.org NoValidFTagFound
+.area 0x4
+	beq FaceTagHook
+.endarea
+
+.org LoadPortraitDBoxID
+.area 0x4
+	bl DBoxHook
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/common/portrait_ov29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/common/portrait_ov29.asm
@@ -1,0 +1,4 @@
+.org InitDungeonPortraitData
+.area 0x4
+	bl DungeonHook
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/common/portrait_ov36.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/common/portrait_ov36.asm
@@ -1,0 +1,58 @@
+.org 0x023A7080+0x1970
+.area 0x1A2C-0x1970
+
+FaceTagHook:
+	push r5
+	ldr r0,[r13, StackThing+4]
+	ldr r1,=FACE_TAG
+	bl TagCheck
+	cmp r0,#0
+	popeq r5
+	beq TagCodeError
+	mov r0,#13
+	bl OverlayIsLoaded
+	cmp r0,#1
+	ldreq r5,=ScriptPortraitPointer
+	beq change_face
+	mov r0,#14
+	bl OverlayIsLoaded
+	ldr r5,[DUNGEON_PORTRAIT_PTR]
+	cmp r0,#0
+	cmpne r5,#0
+	beq ret
+change_face:
+	ldr r0,[r13, StackThing+8]
+ 	bl GetTagParameter
+	mov r1,r0
+	mov r0,r5
+	bl SetPortraitExpressionID
+	mov r0,r5
+	mov r1,#1
+	bl AllowPortraitDefault
+	add r0,=PORTRAIT_DBOX_ID
+	ldrb r0,[r0]
+	mov r1,r5
+	bl ShowPortrait
+ret:
+	pop r5
+	b AfterTagIsFound
+
+DBoxHook:
+	ldrsb r0,[r5,#0x0] ; Original instruction
+	add r1,=PORTRAIT_DBOX_ID
+	strb r0,[r1]
+	bx r14
+
+DungeonHook:
+	mov r4,r2 ; Original instruction
+	str r6,[DUNGEON_PORTRAIT_PTR]
+	bx r14
+
+.pool
+	DUNGEON_PORTRAIT_PTR:
+		.word 0x0
+	PORTRAIT_DBOX_ID:
+		.byte 0x0
+	FACE_TAG:
+		.asciiz "FACE"
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/eu/offsets.asm
@@ -1,0 +1,17 @@
+.relativeinclude on
+.nds
+.arm
+
+.definelabel NoValidFTagFound, 0x02021510
+.definelabel InitDungeonPortraitData, 0x0234C6CC
+.definelabel LoadPortraitDBoxID, 0x0202F930
+.definelabel TagCheck, 0x02020A20
+.definelabel GetTagParameter, 0x02020A64
+.definelabel TagCodeError, 0x02021524
+.definelabel AfterTagIsFound, 0x02021C64
+.definelabel StackThing, 0x78
+.definelabel ScriptPortraitPointer, 0x023259E4
+.definelabel ShowPortrait, 0x0202F984
+.definelabel SetPortraitExpressionID, 0x0204DB2C
+.definelabel OverlayIsLoaded, 0x02003ED0
+.definelabel AllowPortraitDefault, 0x0204DBCC

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/jp/offsets.asm
@@ -1,0 +1,17 @@
+.relativeinclude on
+.nds
+.arm
+
+.definelabel NoValidFTagFound, 0x02021408
+.definelabel InitDungeonPortraitData, 0x0234CD30
+.definelabel LoadPortraitDBoxID, 0x0202F980
+.definelabel TagCheck, 0x02020918
+.definelabel GetTagParameter, 0x0202095C
+.definelabel TagCodeError, 0x0202141C
+.definelabel AfterTagIsFound, 0x02021AF0
+.definelabel StackThing, 0x70
+.definelabel ScriptPortraitPointer, 0x02326404
+.definelabel ShowPortrait, 0x0202F9D4
+.definelabel SetPortraitExpressionID, 0x0204DB54
+.definelabel OverlayIsLoaded, 0x02003ED0
+.definelabel AllowPortraitDefault, 0x0204DBF4

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/na/offsets.asm
@@ -1,0 +1,17 @@
+.relativeinclude on
+.nds
+.arm
+
+.definelabel NoValidFTagFound, 0x020213B8
+.definelabel InitDungeonPortraitData, 0x0234BACC
+.definelabel LoadPortraitDBoxID, 0x0202F63C
+.definelabel TagCheck, 0x020208C8
+.definelabel GetTagParameter, 0x0202090C
+.definelabel TagCodeError, 0x020213CC
+.definelabel AfterTagIsFound, 0x02021AA0
+.definelabel StackThing, 0x70
+.definelabel ScriptPortraitPointer, 0x02324EA4
+.definelabel ShowPortrait, 0x0202F690
+.definelabel SetPortraitExpressionID, 0x0204D7F4
+.definelabel OverlayIsLoaded, 0x02003ED0
+.definelabel AllowPortraitDefault, 0x0204D894

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/selector_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/selector_arm9.asm
@@ -1,0 +1,14 @@
+.relativeinclude on
+
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/offsets.asm"
+	.include "common/portrait_arm9.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/offsets.asm"
+	.include "common/portrait_arm9.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/offsets.asm"
+	.include "common/portrait_arm9.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/selector_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/selector_overlay29.asm
@@ -1,0 +1,11 @@
+.relativeinclude on
+
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "common/portrait_ov36.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "common/portrait_ov36.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "common/portrait_ov36.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/selector_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/selector_overlay29.asm
@@ -1,11 +1,11 @@
 .relativeinclude on
 
 .if PPMD_GameVer == GameVer_EoS_NA
-	.include "common/portrait_ov36.asm"
+	.include "common/portrait_ov29.asm"
 .elseif PPMD_GameVer == GameVer_EoS_EU
-	.include "common/portrait_ov36.asm"
+	.include "common/portrait_ov29.asm"
 .elseif PPMD_GameVer == GameVer_EoS_JP
-	.include "common/portrait_ov36.asm"
+	.include "common/portrait_ov29.asm"
 .endif
 
 .relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/selector_overlay36.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_portrait/selector_overlay36.asm
@@ -1,0 +1,11 @@
+.relativeinclude on
+
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "common/portrait_ov36.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "common/portrait_ov36.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "common/portrait_ov36.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/display_script_var/common/var_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/display_script_var/common/var_arm9.asm
@@ -1,0 +1,4 @@
+.org NoVTagFound
+.area 0x4
+	beq HookVLetter
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/display_script_var/common/var_ov36.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/display_script_var/common/var_ov36.asm
@@ -1,0 +1,30 @@
+.org 0x023A7080+0x18F0
+.area 0x1958-0x18F0
+
+HookVLetter:
+	ldr r0,[r13, StackThing]
+	ldr r1,=VAR_TAG
+	bl TagCheck
+	cmp r0,#0
+	beq TagCodeError
+	ldr r0,[r13, StackThing+4]
+	bl GetTagParameter
+	mov r5,r0
+	ldr r0,[r13, StackThing+8]
+	bl GetTagParameter
+	mov r2,r0
+	mov r1,r5
+	mov r0,#0
+	bl GetGameVarIndexed
+	mov r2,r0
+	add r0,r13,#0x1C8
+	ldr r1,=FORMAT
+	bl SprintfStatic
+	add r7,r13,#0x1C8
+	b AfterTagIsFound
+.pool
+	VAR_TAG:
+		.asciiz "var"
+	FORMAT:
+		.asciiz "%d"
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/display_script_var/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/display_script_var/eu/offsets.asm
@@ -1,0 +1,12 @@
+.relativeinclude on
+.nds
+.arm
+
+.definelabel NoVTagFound, 0x020233E4
+.definelabel TagCheck, 0x02020A20
+.definelabel GetTagParameter, 0x02020A64
+.definelabel TagCodeError, 0x02023410
+.definelabel AfterTagIsFound, 0x020234EC
+.definelabel GetGameVarIndexed, 0x0204B9B0
+.definelabel SprintfStatic, 0x0202378C
+.definelabel StackThing, 0xB4

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/display_script_var/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/display_script_var/jp/offsets.asm
@@ -1,0 +1,12 @@
+.relativeinclude on
+.nds
+.arm
+
+.definelabel NoVTagFound, 0x02023238
+.definelabel TagCheck, 0x02020918
+.definelabel GetTagParameter, 0x0202095C
+.definelabel TagCodeError, 0x02023264
+.definelabel AfterTagIsFound, 0x02023340
+.definelabel GetGameVarIndexed, 0x0204B9D8
+.definelabel SprintfStatic, 0x020235E0
+.definelabel StackThing, 0xB4

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/display_script_var/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/display_script_var/na/offsets.asm
@@ -1,0 +1,12 @@
+.relativeinclude on
+.nds
+.arm
+
+.definelabel NoVTagFound, 0x020231E8
+.definelabel TagCheck, 0x020208C8
+.definelabel GetTagParameter, 0x0202090C
+.definelabel TagCodeError, 0x02023214
+.definelabel AfterTagIsFound, 0x020232F0
+.definelabel GetGameVarIndexed, 0x0204B678
+.definelabel SprintfStatic, 0x02023590
+.definelabel StackThing, 0xB4

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/display_script_var/selector_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/display_script_var/selector_arm9.asm
@@ -1,0 +1,14 @@
+.relativeinclude on
+
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/offsets.asm"
+	.include "common/var_arm9.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/offsets.asm"
+	.include "common/var_arm9.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/offsets.asm"
+	.include "common/var_arm9.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/display_script_var/selector_overlay36.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/display_script_var/selector_overlay36.asm
@@ -1,0 +1,11 @@
+.relativeinclude on
+
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "common/var_ov36.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "common/var_ov36.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "common/var_ov36.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -1014,6 +1014,36 @@
           </Replace>
         </SimplePatch>
 
+        <Patch id="AddKeyCheck">
+          <OpenBin filepath="overlay/overlay_0029.bin">
+	  	      <Include filename ="adex_asm_mods/add_key_check/selector_overlay29.asm"/>
+	        </OpenBin>
+	        <OpenBin filepath="overlay/overlay_0036.bin">
+	  	      <Include filename ="adex_asm_mods/add_key_check/selector_overlay36.asm"/>
+          </OpenBin>
+        </Patch>
+
+        <Patch id="DisplayScriptVariable">
+          <OpenBin filepath="arm9.bin">
+	  	      <Include filename ="adex_asm_mods/display_script_var/selector_arm9.asm"/>
+	        </OpenBin>
+	        <OpenBin filepath="overlay/overlay_0036.bin">
+	  	      <Include filename ="adex_asm_mods/display_script_var/selector_overlay36.asm"/>
+          </OpenBin>
+        </Patch>
+
+        <Patch id="ChangePortraitMidText">
+          <OpenBin filepath="arm9.bin">
+	  	      <Include filename ="adex_asm_mods/change_portrait/selector_arm9.asm"/>
+	        </OpenBin>
+          <OpenBin filepath="overlay/overlay_0029.bin">
+	  	      <Include filename ="adex_asm_mods/change_portrait/selector_overlay29.asm"/>
+	        </OpenBin>
+	        <OpenBin filepath="overlay/overlay_0036.bin">
+	  	      <Include filename ="adex_asm_mods/change_portrait/selector_overlay36.asm"/>
+          </OpenBin>
+        </Patch>
+
       </Game>
     </Patches>
 

--- a/skytemple_files/patch/handler/add_key_check.py
+++ b/skytemple_files/patch/handler/add_key_check.py
@@ -1,0 +1,84 @@
+# Copyright 2020-2023 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+from typing import Callable
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.ppmdu_config.data import (
+    GAME_REGION_EU,
+    GAME_REGION_US,
+    GAME_REGION_JP,
+    GAME_VERSION_EOS,
+    Pmd2Data,
+)
+from skytemple_files.common.util import get_binary_from_rom, read_u32
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+
+ORIGINAL_INSTRUCTION = 0x0A00000D
+OFFSET_EU = 0x6B1C0
+OFFSET_JP = 0x6AC20
+OFFSET_US = 0x6AF00
+
+
+class AddKeyCheckPatchHandler(AbstractPatchHandler, DependantPatch):
+    @property
+    def name(self) -> str:
+        return "AddKeyCheck"
+
+    @property
+    def description(self) -> str:
+        return "Prevents Keys from being used on party members that are not below a Key Door!"
+
+    @property
+    def author(self) -> str:
+        return "Adex"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    def depends_on(self) -> list[str]:
+        return ["ExtraSpace"]
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.IMPROVEMENT_TWEAK
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        overlay29 = get_binary_from_rom(rom, config.bin_sections.overlay29)
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_u32(overlay29, OFFSET_US) != ORIGINAL_INSTRUCTION
+            if config.game_region == GAME_REGION_EU:
+                return read_u32(overlay29, OFFSET_EU) != ORIGINAL_INSTRUCTION
+            if config.game_region == GAME_REGION_JP:
+                return read_u32(overlay29, OFFSET_JP) != ORIGINAL_INSTRUCTION
+        raise NotImplementedError()
+
+    def apply(
+        self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ) -> None:
+        # Apply the patch
+        apply()
+
+    def unapply(
+        self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ):
+        raise NotImplementedError()

--- a/skytemple_files/patch/handler/change_portrait.py
+++ b/skytemple_files/patch/handler/change_portrait.py
@@ -1,0 +1,83 @@
+# Copyright 2020-2023 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+from typing import Callable
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.ppmdu_config.data import (
+    GAME_REGION_EU,
+    GAME_REGION_US,
+    GAME_REGION_JP,
+    GAME_VERSION_EOS,
+    Pmd2Data,
+)
+from skytemple_files.common.util import read_u32
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+
+ORIGINAL_INSTRUCTION = 0xE1D500D0
+OFFSET_EU = 0x2F930
+OFFSET_JP = 0x2F980
+OFFSET_US = 0x2F63C
+
+
+class ChangePortraitPatchHandler(AbstractPatchHandler, DependantPatch):
+    @property
+    def name(self) -> str:
+        return "ChangePortraitMidText"
+
+    @property
+    def description(self) -> str:
+        return "Implements the text tag [FACE:X], which sets the current portrait to use the Xth portrait emotion (e.g. 0 = FACE_NORMAL).\nThis allows for changing portrait emotions during dialogue!"
+
+    @property
+    def author(self) -> str:
+        return "Adex"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    def depends_on(self) -> list[str]:
+        return ["ExtraSpace"]
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.NEW_MECHANIC
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_u32(rom.arm9, OFFSET_US) != ORIGINAL_INSTRUCTION
+            if config.game_region == GAME_REGION_EU:
+                return read_u32(rom.arm9, OFFSET_EU) != ORIGINAL_INSTRUCTION
+            if config.game_region == GAME_REGION_JP:
+                return read_u32(rom.arm9, OFFSET_JP) != ORIGINAL_INSTRUCTION
+        raise NotImplementedError()
+
+    def apply(
+        self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ) -> None:
+        # Apply the patch
+        apply()
+
+    def unapply(
+        self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ):
+        raise NotImplementedError()

--- a/skytemple_files/patch/handler/display_script_var.py
+++ b/skytemple_files/patch/handler/display_script_var.py
@@ -1,0 +1,83 @@
+# Copyright 2020-2023 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+from typing import Callable
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.ppmdu_config.data import (
+    GAME_REGION_EU,
+    GAME_REGION_US,
+    GAME_REGION_JP,
+    GAME_VERSION_EOS,
+    Pmd2Data,
+)
+from skytemple_files.common.util import read_u32
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+
+ORIGINAL_INSTRUCTION = 0x0A000009
+OFFSET_EU = 0x233E4
+OFFSET_JP = 0x23238
+OFFSET_US = 0x231E8
+
+
+class DisplayScriptVarPatchHandler(AbstractPatchHandler, DependantPatch):
+    @property
+    def name(self) -> str:
+        return "DisplayScriptVariable"
+
+    @property
+    def description(self) -> str:
+        return 'Displays a script variable in a string with the text tag [var:x:y], where "x" is the variable ID and "y" is the index!'
+
+    @property
+    def author(self) -> str:
+        return "Adex"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    def depends_on(self) -> list[str]:
+        return ["ExtraSpace"]
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.NEW_MECHANIC
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_u32(rom.arm9, OFFSET_US) != ORIGINAL_INSTRUCTION
+            if config.game_region == GAME_REGION_EU:
+                return read_u32(rom.arm9, OFFSET_EU) != ORIGINAL_INSTRUCTION
+            if config.game_region == GAME_REGION_JP:
+                return read_u32(rom.arm9, OFFSET_JP) != ORIGINAL_INSTRUCTION
+        raise NotImplementedError()
+
+    def apply(
+        self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ) -> None:
+        # Apply the patch
+        apply()
+
+    def unapply(
+        self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ):
+        raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -52,6 +52,9 @@ from skytemple_files.patch.handler.actor_and_level_loader import (
     ActorAndLevelListLoaderPatchHandler,
 )
 from skytemple_files.patch.handler.add_type import AddTypePatchHandler
+from skytemple_files.patch.handler.add_key_check import (
+    AddKeyCheckPatchHandler,
+)
 from skytemple_files.patch.handler.allow_unrecruitable_mons import (
     AllowUnrecruitableMonsPatchHandler,
 )
@@ -67,6 +70,9 @@ from skytemple_files.patch.handler.change_evo import ChangeEvoSystemPatchHandler
 from skytemple_files.patch.handler.change_ff_prop import (
     ChangeFixedFloorPropertiesPatchHandler,
 )
+from skytemple_files.patch.handler.change_portrait import (
+    ChangePortraitPatchHandler,
+)
 from skytemple_files.patch.handler.change_tbbg import ChangeTextBoxColorPatchHandler
 from skytemple_files.patch.handler.change_text_sound import (
     ChangeTextSoundPatchHandler,
@@ -76,6 +82,9 @@ from skytemple_files.patch.handler.complete_team_control import CompleteTeamCont
 from skytemple_files.patch.handler.compress_iq_data import CompressIQDataPatchHandler
 from skytemple_files.patch.handler.disable_tips import DisableTipsPatch
 from skytemple_files.patch.handler.disarm_one_room_mh import DisarmOneRoomMHPatchHandler
+from skytemple_files.patch.handler.display_script_var import (
+    DisplayScriptVarPatchHandler,
+)
 from skytemple_files.patch.handler.dungeon_interrupt import DungeonInterruptPatchHandler
 from skytemple_files.patch.handler.dynamic_bosses_everywhere import (
     DynamicBossesEverywherePatchHandler,
@@ -185,6 +194,9 @@ class PatchType(Enum):
     ANTI_SOFTLOCK = AntiSoftlockPatchHandler
     BETTER_ENEMY_EVOLUTION = BetterEnemyEvolutionPatchHandler
     NO_WEATHER_STOP = NoWeatherStopPatchHandler
+    ADD_KEY_CHECK = AddKeyCheckPatchHandler
+    DISPLAY_SCRIPT_VAR = DisplayScriptVarPatchHandler
+    CHANGE_PORTRAIT = ChangePortraitPatchHandler
 
 
 class Patcher:


### PR DESCRIPTION
Adds three ASM patches:
- `AddKeyCheck`
  - Disallows a party member from using a Key (Item ID 182) in the dungeon menu unless they're standing right below a Key Door.
- `ChangePortraitMidText`
  - Implements the text tag `[FACE:X]`, where "X" is the new portrait emotion ID to change the currently-loaded portrait to. This works in ground and dungeon mode, and will default to the default (FACE_NORMAL) portrait if the specified portrait emotion cannot be found.
  - ~~@AlliterativeAlias are you proud of me~~
- `DisplayScriptVariable`
  - Implements the text tag `[var:x:y]`, where "x" is a script variable ID and "y" (optional; will default to 0 if not present) is an index. The text tag will be replaced with the value of the specified script variable.