### PR TITLE
fix double flipping metaframepieces

### DIFF
--- a/skytemple_files/graphics/chara_wan/sheets.py
+++ b/skytemple_files/graphics/chara_wan/sheets.py
@@ -917,7 +917,7 @@ def addFlippedImgData(flipMode: FlipMode, frameData, metaFrame, old_frame, new_f
     for piece in metaFrame:
         newPiece = MetaFramePiece(piece.imgIndex, piece.attr0, piece.attr1, piece.attr2)
         if flipMode == FlipMode.FLIP:
-            newPiece.setHFlip(True)
+            newPiece.setHFlip(not piece.isHFlip())
             # move the piece in the reflected position.
             range = newPiece.GetBounds()
             endX = range[2]


### PR DESCRIPTION
if the previous piece is already flipped, then hflip should be set to false on the new piece to flip it again