### PR TITLE
Fix Orb oversight with Complete Team Control

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsEU.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsEU.asm
@@ -29,7 +29,7 @@ CTC_MANUAL_STRINGID equ 129h
 .definelabel NA_0230506C, 02305A98h	;Operation - partner direction setter 2
 .definelabel NA_02305160, 02305B8Ch	;Operation - some line at the end of the partner direction setter
 .definelabel NA_0230579C, 023061C8h	;Operation - prevents partners from triggering hidden traps
-.definelabel NA_0231AACC, 0231B52Ch ;Operation - checks leader byte during orb use
+.definelabel NA_0231AACC, 0231B52Ch	;Operation - checks leader byte during orb use
 .definelabel NA_0234B714, 0234C314h	;Function - puts a message in the dialogue
 .definelabel NA_02352284, 02352E90h	;Variable - used in turn verification algorithm
 .definelabel NA_02353538, 02354138h	;Variable - pointer to beginning of dungeon data. beginning of dungeon data +12B28 is the beginning of the list of pokemon entity addresses.

--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsEU.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsEU.asm
@@ -29,6 +29,7 @@ CTC_MANUAL_STRINGID equ 129h
 .definelabel NA_0230506C, 02305A98h	;Operation - partner direction setter 2
 .definelabel NA_02305160, 02305B8Ch	;Operation - some line at the end of the partner direction setter
 .definelabel NA_0230579C, 023061C8h	;Operation - prevents partners from triggering hidden traps
+.definelabel NA_0231AACC, 0231B52Ch ;Operation - checks leader byte during orb use
 .definelabel NA_0234B714, 0234C314h	;Function - puts a message in the dialogue
 .definelabel NA_02352284, 02352E90h	;Variable - used in turn verification algorithm
 .definelabel NA_02353538, 02354138h	;Variable - pointer to beginning of dungeon data. beginning of dungeon data +12B28 is the beginning of the list of pokemon entity addresses.

--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsJP.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsJP.asm
@@ -29,6 +29,7 @@ CTC_MANUAL_STRINGID equ 25AFh
 .definelabel NA_0230506C, 023065BCh	;Operation - partner direction setter 2
 .definelabel NA_02305160, 023066B0h	;Operation - some line at the end of the partner direction setter
 .definelabel NA_0230579C, 02306CECh	;Operation - prevents partners from triggering hidden traps
+.definelabel NA_0231AACC, 0231BF9Ch ;Operation - checks leader byte during orb use
 .definelabel NA_0234B714, 0234C984h	;Function - puts a message in the dialogue
 .definelabel NA_02352284, 02353504h	;Variable - used in turn verification algorithm
 .definelabel NA_02353538, 023547B8h	;Variable - pointer to beginning of dungeon data. beginning of dungeon data +12B28 is the beginning of the list of pokemon entity addresses.

--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsJP.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsJP.asm
@@ -29,7 +29,7 @@ CTC_MANUAL_STRINGID equ 25AFh
 .definelabel NA_0230506C, 023065BCh	;Operation - partner direction setter 2
 .definelabel NA_02305160, 023066B0h	;Operation - some line at the end of the partner direction setter
 .definelabel NA_0230579C, 02306CECh	;Operation - prevents partners from triggering hidden traps
-.definelabel NA_0231AACC, 0231BF9Ch ;Operation - checks leader byte during orb use
+.definelabel NA_0231AACC, 0231BF9Ch	;Operation - checks leader byte during orb use
 .definelabel NA_0234B714, 0234C984h	;Function - puts a message in the dialogue
 .definelabel NA_02352284, 02353504h	;Variable - used in turn verification algorithm
 .definelabel NA_02353538, 023547B8h	;Variable - pointer to beginning of dungeon data. beginning of dungeon data +12B28 is the beginning of the list of pokemon entity addresses.

--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsUS.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsUS.asm
@@ -29,6 +29,7 @@ CTC_MANUAL_STRINGID equ 129h
 .definelabel NA_0230506C, 0230506Ch	;Operation - partner direction setter 2
 .definelabel NA_02305160, 02305160h	;Operation - some line at the end of the partner direction setter
 .definelabel NA_0230579C, 0230579Ch	;Operation - prevents partners from triggering hidden traps
+.definelabel NA_0231AACC, 0231AACCh ;Operation - checks leader byte during orb use
 .definelabel NA_0234B714, 0234B714h	;Function - puts a message in the dialogue
 .definelabel NA_02352284, 02352284h	;Variable - used in turn verification algorithm
 .definelabel NA_02353538, 02353538h	;Variable - pointer to beginning of dungeon data. beginning of dungeon data +12B28 is the beginning of the list of pokemon entity addresses.

--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsUS.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/common/offsetsUS.asm
@@ -29,7 +29,7 @@ CTC_MANUAL_STRINGID equ 129h
 .definelabel NA_0230506C, 0230506Ch	;Operation - partner direction setter 2
 .definelabel NA_02305160, 02305160h	;Operation - some line at the end of the partner direction setter
 .definelabel NA_0230579C, 0230579Ch	;Operation - prevents partners from triggering hidden traps
-.definelabel NA_0231AACC, 0231AACCh ;Operation - checks leader byte during orb use
+.definelabel NA_0231AACC, 0231AACCh	;Operation - checks leader byte during orb use
 .definelabel NA_0234B714, 0234B714h	;Function - puts a message in the dialogue
 .definelabel NA_02352284, 02352284h	;Variable - used in turn verification algorithm
 .definelabel NA_02353538, 02353538h	;Variable - pointer to beginning of dungeon data. beginning of dungeon data +12B28 is the beginning of the list of pokemon entity addresses.

--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/completeteamcontrol.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/completeteamcontrol.asm
@@ -56,8 +56,8 @@
 	mov r0,1h
 	pop r4,r15
 
-.org NA_0231AACC
-	bl @SpecialOrbCheck ; Prevent allies from recalculating a target when using orbs in Manual Mode!
+.org NA_0231AACC	;Prevent allies from recalculating a target when using orbs in manual mode!
+	bl @SpecialOrbCheck	;original: ldrb r0,[r5,7h]
 
 .close
 
@@ -350,7 +350,7 @@ roundover:
 	mov r3,0h
 	b NA_022EC094		;skipping the turns of partners
 
-@SpecialOrbCheck:
+@SpecialOrbCheck: ;Non-leader party members update their target upon using an orb, so we check for manual mode to ensure allies use the orb in the direction we want.
 	ldrb r0,[r5,7h]
 	ldr r1,=@ManualModeOn
 	ldrb r1,[r1]

--- a/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/completeteamcontrol.asm
+++ b/skytemple_files/_resources/patches/asm_patches/cipnit_asm_mods/completeteamcontrol.asm
@@ -56,6 +56,9 @@
 	mov r0,1h
 	pop r4,r15
 
+.org NA_0231AACC
+	bl @SpecialOrbCheck ; Prevent allies from recalculating a target when using orbs in Manual Mode!
+
 .close
 
 
@@ -346,6 +349,14 @@ roundover:
 	add r13,r13,4h
 	mov r3,0h
 	b NA_022EC094		;skipping the turns of partners
+
+@SpecialOrbCheck:
+	ldrb r0,[r5,7h]
+	ldr r1,=@ManualModeOn
+	ldrb r1,[r1]
+	orr r0,r0,r1
+	bx r14
+
 .pool
 
 	.endarea

--- a/skytemple_files/patch/handler/complete_team_control.py
+++ b/skytemple_files/patch/handler/complete_team_control.py
@@ -127,7 +127,7 @@ class CompleteTeamControl(AbstractPatchHandler, DependantPatch):
 
     @property
     def version(self) -> str:
-        return "1.2.4"
+        return "1.2.5"
 
     def depends_on(self) -> list[str]:
         return ["ExtraSpace"]


### PR DESCRIPTION
When using Complete Team Control, if you attempted to use an Orb with an ally who wasn't originally the leader, the game would still recalculate the potential targets surrounding them. This has the noticeable impact of an ally using an Orb in an unintended direction from where they're currently facing. 
This should fix that behavior to make it so allies won't recalculate their targets.