### PR TITLE
Rename and fix EditGuestPokemon patch

### DIFF
--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -1174,8 +1174,8 @@
           </Replace>
         </SimplePatch>
 
-        <SimplePatch id="EditExtraPokemon">
-          <Include filename="frost_asm_mods/src/EditExtraPokemon.asm"/>
+        <SimplePatch id="EditGuestPokemon">
+          <Include filename="frost_asm_mods/src/EditGuestPokemon.asm"/>
           <Replace filename="frost_asm_mods/src/common/regionSelect.asm" regexp='_REGION equ "(\w+)"'>
             <Game id="EoS_NA" replace='_REGION equ "US"'/>
             <Game id="EoS_EU" replace='_REGION equ "EU"'/>

--- a/skytemple_files/common/ppmdu_config/pmdsky_debug/extras.py
+++ b/skytemple_files/common/ppmdu_config/pmdsky_debug/extras.py
@@ -27,8 +27,8 @@ from pmdsky_debug_py.protocol import Symbol, SectionProtocol
 
 DEBUG_PRINT2_DESC = "Would log a printf format string in the debug binary. A no-op in the final binary."
 COMPRESSED_IQ_GROUP_SKILLS_DESC = "Replaces IQ_GROUPS_SKILLS when the patch 'CompressIQData' is applied."
-GUEST_MONSTER_DATA2_DESC = "Requires EditExtraPokemon patch."
-EXTRA_DUNGEON_DATA_DESC = "Requires EditExtraPokemon patch."
+GUEST_MONSTER_DATA2_DESC = "Requires EditGuestPokemon patch."
+EXTRA_DUNGEON_DATA_DESC = "Requires EditGuestPokemon patch."
 MONSTER_GROUND_IDLE_ANIM_DESC = (
     "This table is added by the 'ChangePokemonGroundAnim' patch. " "See the patch description for details."
 )

--- a/skytemple_files/hardcoded/guest_pokemon.py
+++ b/skytemple_files/hardcoded/guest_pokemon.py
@@ -294,7 +294,7 @@ class GuestPokemonList:
                 break
             lst.append(read_entry)
         if not done:
-            # Read the list added by the EditExtraPokemon patch
+            # Read the list added by the EditGuestPokemon patch
             block = config.extra_bin_sections.arm9.data.GUEST_MONSTER_DATA2
             # Make sure we don't keep reading if there's no space for one more entry, since if we did that
             # we would read out of bounds

--- a/skytemple_files/patch/handler/edit_guest_pokemon.py
+++ b/skytemple_files/patch/handler/edit_guest_pokemon.py
@@ -38,15 +38,15 @@ OFFSET_US = 0x4EBC8
 OFFSET_JP = 0x4EF20
 
 
-class EditExtraPokemonPatchHandler(AbstractPatchHandler):
+class EditGuestPokemonPatchHandler(AbstractPatchHandler):
     @property
     def name(self) -> str:
-        return "EditExtraPokemon"
+        return "EditGuestPokemon"
 
     @property
     def description(self) -> str:
         return _(
-            "Changes the way the game determines when to add additional pokémon to the team so it can be edited more easily"
+            "Changes the way the game determines when to add guest pokémon to the team so it can be edited more easily"
         )
 
     @property

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -89,8 +89,8 @@ from skytemple_files.patch.handler.dungeon_interrupt import DungeonInterruptPatc
 from skytemple_files.patch.handler.dynamic_bosses_everywhere import (
     DynamicBossesEverywherePatchHandler,
 )
-from skytemple_files.patch.handler.edit_extra_pokemon import (
-    EditExtraPokemonPatchHandler,
+from skytemple_files.patch.handler.edit_guest_pokemon import (
+    EditGuestPokemonPatchHandler,
 )
 from skytemple_files.patch.handler.exp_share import ExpSharePatchHandler
 from skytemple_files.patch.handler.expand_poke_list import ExpandPokeListPatchHandler
@@ -188,7 +188,7 @@ class PatchType(Enum):
     EXTRACT_BAR_LIST = ExtractBarItemListPatchHandler
     EXPAND_POKE_LIST = ExpandPokeListPatchHandler
     ALLOW_UNRECRUITABLE_MONS = AllowUnrecruitableMonsPatchHandler
-    EDIT_EXTRA_POKEMON = EditExtraPokemonPatchHandler
+    EDIT_GUEST_POKEMON = EditGuestPokemonPatchHandler
     FIX_MEMORY_SOFTLOCK = FixMemorySoftlockPatchHandler
     COMPRESS_IQ_DATA = CompressIQDataPatchHandler
     DISARM_ONE_ROOM_MH = DisarmOneRoomMHPatchHandler


### PR DESCRIPTION
Fixes the currently bugged EditExtraPokemon patch and renames it to EditGuestPokemon.

Other related PRs:

- https://github.com/SkyTemple/skytemple/pull/780
- https://github.com/SkyTemple/skytemple-randomizer/pull/215