### PR TITLE
Move Sprite Size elements to another patch

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_poke_list/common/patch_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_poke_list/common/patch_arm9.asm
@@ -508,35 +508,6 @@ CheckSecondPartRead:
 	nop
 .endarea
 
-; Sprite Size in monster.md (0x2C)
-.org HookMdAccess7
-.area 0x38
-	ldr r2,=MonsterFilePtr
-	mov  r1,#0x44
-	ldr r2,[r2, #+0x0]
-	smlabb r0,r0,r1,r2
-	ldrb r0,[r0, #+0x2C]
-	cmp r0,#0x0
-	ldmeqia  r13!,{r3,r15}
-	cmp r0,#0x6
-	movls  r0,#0x6
-	ldmia  r13!,{r3,r15}
-	.pool
-.endarea
-
-; Sprite File Size in monster.md (0x2D)
-.org HookMdAccess8
-.area 0x20
-	ldr r2,=MonsterFilePtr
-	mov  r1,#0x44
-	ldr r2,[r2, #+0x0]
-	smlabb r0,r0,r1,r2
-	ldrb r0,[r0, #+0x2D]
-	mov  r0,r0,lsl #0x9
-	bx r14
-	.pool
-.endarea
-
 .org HookMdAccess9
 .area 0xC
 	mov r1,r0

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_poke_list/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_poke_list/eu/offsets.asm
@@ -131,8 +131,6 @@
 .definelabel HookMdAccess4, 0x020529C0
 .definelabel HookMdAccess5, 0x02052A04
 .definelabel HookMdAccess6, 0x02052AA8
-.definelabel HookMdAccess7, 0x02052B1C
-.definelabel HookMdAccess8, 0x02052B54
 .definelabel HookMdAccess9, 0x02053B2C
 .definelabel HookMdAccess10, 0x02053B4C
 

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_poke_list/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_poke_list/jp/offsets.asm
@@ -133,8 +133,6 @@
 .definelabel HookMdAccess4, 0x020529C4
 .definelabel HookMdAccess5, 0x02052A08
 .definelabel HookMdAccess6, 0x02052AAC
-.definelabel HookMdAccess7, 0x02052B1C
-.definelabel HookMdAccess8, 0x02052B54
 .definelabel HookMdAccess9, 0x02053Ae8
 .definelabel HookMdAccess10, 0x02053B08
 

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_poke_list/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_poke_list/na/offsets.asm
@@ -131,8 +131,6 @@
 .definelabel HookMdAccess4, 0x02052688
 .definelabel HookMdAccess5, 0x020526CC
 .definelabel HookMdAccess6, 0x02052770
-.definelabel HookMdAccess7, 0x020527E4
-.definelabel HookMdAccess8, 0x0205281C
 .definelabel HookMdAccess9, 0x020537B0
 .definelabel HookMdAccess10, 0x020537D0
 

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/sprite_size/common/patch_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/sprite_size/common/patch_arm9.asm
@@ -1,0 +1,28 @@
+; Sprite Size in monster.md (0x2C)
+.org HookMdAccess7
+.area 0x38
+	ldr r2,=MonsterFilePtr
+	mov  r1,#0x44
+	ldr r2,[r2, #+0x0]
+	smlabb r0,r0,r1,r2
+	ldrb r0,[r0, #+0x2C]
+	cmp r0,#0x0
+	ldmeqia  r13!,{r3,r15}
+	cmp r0,#0x6
+	movls  r0,#0x6
+	ldmia  r13!,{r3,r15}
+	.pool
+.endarea
+
+; Sprite File Size in monster.md (0x2D)
+.org HookMdAccess8
+.area 0x20
+	ldr r2,=MonsterFilePtr
+	mov  r1,#0x44
+	ldr r2,[r2, #+0x0]
+	smlabb r0,r0,r1,r2
+	ldrb r0,[r0, #+0x2D]
+	mov  r0,r0,lsl #0x9
+	bx r14
+	.pool
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/sprite_size/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/sprite_size/eu/offsets.asm
@@ -1,0 +1,15 @@
+; For use with ARMIPS
+; 2024/07/27
+; For Explorers of Sky EU Only
+; ------------------------------------------------------------------------------
+; Use filestreams to partially load mappa files instead of loading entirely
+; ------------------------------------------------------------------------------
+
+
+.relativeinclude on
+.nds
+.arm
+
+.definelabel MonsterFilePtr, 0x020B12D0
+.definelabel HookMdAccess7, 0x02052B1C
+.definelabel HookMdAccess8, 0x02052B54

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/sprite_size/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/sprite_size/jp/offsets.asm
@@ -1,0 +1,15 @@
+; For use with ARMIPS
+; 2024/07/27
+; For Explorers of Sky JP Only
+; ------------------------------------------------------------------------------
+; Use filestreams to partially load mappa files instead of loading entirely
+; ------------------------------------------------------------------------------
+
+
+.relativeinclude on
+.nds
+.arm
+
+.definelabel MonsterFilePtr, 0x020B2228
+.definelabel HookMdAccess7, 0x02052B1C
+.definelabel HookMdAccess8, 0x02052B54

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/sprite_size/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/sprite_size/na/offsets.asm
@@ -1,0 +1,15 @@
+; For use with ARMIPS
+; 2024/07/27
+; For Explorers of Sky NA Only
+; ------------------------------------------------------------------------------
+; Use filestreams to partially load mappa files instead of loading entirely
+; ------------------------------------------------------------------------------
+
+
+.relativeinclude on
+.nds
+.arm
+
+.definelabel MonsterFilePtr, 0x020B09B4
+.definelabel HookMdAccess7, 0x020527E4
+.definelabel HookMdAccess8, 0x0205281C

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/sprite_size/selector_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/sprite_size/selector_arm9.asm
@@ -1,0 +1,22 @@
+; For use with ARMIPS
+; 2024/07/27
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/offsets.asm"
+	.include "common/patch_arm9.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/offsets.asm"
+	.include "common/patch_arm9.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/offsets.asm"
+	.include "common/patch_arm9.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -1067,22 +1067,28 @@
 
         <Patch id="ExpandPokeList" >
           <OpenBin filepath="arm9.bin">
-		  <Include filename ="anonymous_asm_mods/expand_poke_list/selector_arm9.asm"/>
+		        <Include filename ="anonymous_asm_mods/expand_poke_list/selector_arm9.asm"/>
           </OpenBin>
           <OpenBin filepath="overlay/overlay_0010.bin">
-		  <Include filename ="anonymous_asm_mods/expand_poke_list/selector_overlay10.asm"/>
+		        <Include filename ="anonymous_asm_mods/expand_poke_list/selector_overlay10.asm"/>
           </OpenBin>
           <OpenBin filepath="overlay/overlay_0011.bin">
-		  <Include filename ="anonymous_asm_mods/expand_poke_list/selector_overlay11.asm"/>
+		        <Include filename ="anonymous_asm_mods/expand_poke_list/selector_overlay11.asm"/>
           </OpenBin>
           <OpenBin filepath="overlay/overlay_0019.bin">
-		  <Include filename ="anonymous_asm_mods/expand_poke_list/selector_overlay19.asm"/>
+		        <Include filename ="anonymous_asm_mods/expand_poke_list/selector_overlay19.asm"/>
           </OpenBin>
           <OpenBin filepath="overlay/overlay_0029.bin">
-		  <Include filename ="anonymous_asm_mods/expand_poke_list/selector_overlay29.asm"/>
+		        <Include filename ="anonymous_asm_mods/expand_poke_list/selector_overlay29.asm"/>
           </OpenBin>
           <OpenBin filepath="overlay/overlay_0031.bin">
-		  <Include filename ="anonymous_asm_mods/expand_poke_list/selector_overlay31.asm"/>
+		        <Include filename ="anonymous_asm_mods/expand_poke_list/selector_overlay31.asm"/>
+          </OpenBin>
+        </Patch>
+
+        <Patch id="SpriteSizeInMonsterData" >
+          <OpenBin filepath="arm9.bin">
+		        <Include filename ="anonymous_asm_mods/sprite_size/selector_arm9.asm"/>
           </OpenBin>
         </Patch>
 

--- a/skytemple_files/common/sprite_util.py
+++ b/skytemple_files/common/sprite_util.py
@@ -26,6 +26,7 @@ from skytemple_files.data.md.protocol import MdEntryProtocol
 from skytemple_files.hardcoded.monster_sprite_data_table import (
     MonsterSpriteDataTableEntry,
 )
+from skytemple_files.common.i18n_util import _
 
 
 def check_and_correct_monster_sprite_size(
@@ -57,7 +58,7 @@ def check_and_correct_monster_sprite_size(
     - md_target
     - sprite_size_table
     """
-    changed = False
+    changed = []
     effective_base_attr = "md_index_base"
 
     # If ExpandPokeList is applied, unk17 and unk18 are the values used instead
@@ -81,15 +82,14 @@ def check_and_correct_monster_sprite_size(
         else:
             sprite_size_table[getattr(md_gender1, effective_base_attr)].sprite_tile_slots = max_tile_slots_needed
 
-        changed = True
+        changed.append((_("Sprite Size"), check_value, max_tile_slots_needed))
 
     if check_value_file != max_file_size_needed:
         if is_expand_poke_list_patch_applied:
             md_target.unk18 = max_file_size_needed
         else:
             sprite_size_table[getattr(md_gender1, effective_base_attr)].unk1 = max_file_size_needed
-
-        changed = True
+        changed.append((_("Sprite File Size"), check_value, max_file_size_needed))
     return changed
 
 

--- a/skytemple_files/patch/handler/expand_poke_list.py
+++ b/skytemple_files/patch/handler/expand_poke_list.py
@@ -113,7 +113,7 @@ class ExpandPokeListPatchHandler(AbstractPatchHandler, DependantPatch):
     def description(self) -> str:
         return _(
             """Expand the pokemon entries allowed to 2048, and makes all the entries independent.
-Needs ChangeEvoSystem, ExternalizeWazaFile, ExternalizeMappaFile patches to work.
+Needs ChangeEvoSystem, ExternalizeWazaFile, ExternalizeMappaFile, SpriteSizeInMonsterData patches to work.
 It is strongly recommended to fix any dungeon error before applying this patch,
 and to save a backup of your ROM before applying this."""
         )
@@ -131,7 +131,7 @@ and to save a backup of your ROM before applying this."""
         return PatchCategory.IMPROVEMENT_TWEAK
 
     def depends_on(self) -> list[str]:
-        return ["ChangeEvoSystem", "ExternalizeWazaFile", "ExternalizeMappaFile"]
+        return ["ChangeEvoSystem", "ExternalizeWazaFile", "ExternalizeMappaFile", "SpriteSizeInMonsterData"]
 
     def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
         if config.game_version == GAME_VERSION_EOS:
@@ -246,19 +246,11 @@ and to save a backup of your ROM before applying this."""
                     new_entries[NUM_PREVIOUS_ENTRIES + i].entid = NUM_PREVIOUS_ENTRIES + i
                 else:
                     new_entries[NUM_PREVIOUS_ENTRIES + i].entid = i
-            block2 = bincfg.data.MONSTER_SPRITE_DATA
-            data = (
-                binary[block2.address : block2.address + block2.length]
-                + binary[block2.address : block2.address + block2.length]
-            )
-            data += b"\x00\x00" * (NUM_NEW_ENTRIES - (len(data) // 2))
-            for i in range(0, len(data), 2):
-                new_entries[i // 2].unk17 = data[i]
-                new_entries[i // 2].unk18 = data[i + 1]
-                new_entries[i // 2].bitfield1_0 = False
-                new_entries[i // 2].bitfield1_1 = False
-                new_entries[i // 2].bitfield1_2 = False
-                new_entries[i // 2].bitfield1_3 = False
+            for e in new_entries:
+                e.bitfield1_0 = False
+                e.bitfield1_1 = False
+                e.bitfield1_2 = False
+                e.bitfield1_3 = False
 
             x = table_sf
             while read_u16(rom.arm9, x) != 0:

--- a/skytemple_files/patch/handler/sprite_size.py
+++ b/skytemple_files/patch/handler/sprite_size.py
@@ -1,0 +1,98 @@
+#  Copyright 2020-2024 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+from typing import Callable
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.i18n_util import _
+from skytemple_files.common.ppmdu_config.data import (
+    GAME_REGION_EU,
+    GAME_REGION_US,
+    GAME_REGION_JP,
+    GAME_VERSION_EOS,
+    Pmd2Data,
+)
+from skytemple_files.common.types.file_types import FileType
+from skytemple_files.common.util import get_binary_from_rom, read_u32
+from skytemple_files.data.md.handler import MdHandler
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+
+PATCH_CHECK_ADDR_APPLIED_US = 0x527E4
+PATCH_CHECK_ADDR_APPLIED_EU = 0x52B1C
+PATCH_CHECK_ADDR_APPLIED_JP = 0x52B1C
+PATCH_CHECK_INSTR_APPLIED = 0xE3A01F96
+
+
+class SpriteSizePatchHandler(AbstractPatchHandler):
+    @property
+    def name(self) -> str:
+        return "SpriteSizeInMonsterData"
+
+    @property
+    def description(self) -> str:
+        return _(
+            """Changes Sprite Size and Sprite File Size values to be in each Pokémon's data."""
+        )
+
+    @property
+    def author(self) -> str:
+        return "Anonymous"
+
+    @property
+    def version(self) -> str:
+        return "0.8.6"
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.IMPROVEMENT_TWEAK
+    
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_u32(rom.arm9, PATCH_CHECK_ADDR_APPLIED_US) != PATCH_CHECK_INSTR_APPLIED
+            if config.game_region == GAME_REGION_EU:
+                return read_u32(rom.arm9, PATCH_CHECK_ADDR_APPLIED_EU) != PATCH_CHECK_INSTR_APPLIED
+            if config.game_region == GAME_REGION_JP:
+                return read_u32(rom.arm9, PATCH_CHECK_ADDR_APPLIED_JP) != PATCH_CHECK_INSTR_APPLIED
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:
+        if not self.is_applied(rom, config):
+            bincfg = config.bin_sections.arm9
+            binary = bytearray(get_binary_from_rom(rom, bincfg))
+            
+            md_bin = rom.getFileByName("BALANCE/monster.md")
+            md_model = MdHandler.deserialize(md_bin)
+            block2 = bincfg.data.MONSTER_SPRITE_DATA
+            data = (
+                binary[block2.address : block2.address + block2.length]
+                + binary[block2.address : block2.address + block2.length]
+            )
+            for i, e in enumerate(md_model.entries):
+                e.unk17 = data[i*2]
+                e.unk18 = data[i*2 + 1]
+            rom.setFileByName("BALANCE/monster.md", MdHandler.serialize(md_model))
+        try:
+            apply()
+        except RuntimeError as ex:
+            raise ex
+
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:
+        raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -143,6 +143,7 @@ from skytemple_files.patch.handler.remove_body_size_check import (
 from skytemple_files.patch.handler.same_type_partner import SameTypePartnerPatch
 from skytemple_files.patch.handler.skip_quiz import SkipQuizPatchHandler
 from skytemple_files.patch.handler.stat_disp import ChangeMoveStatDisplayPatchHandler
+from skytemple_files.patch.handler.sprite_size import SpriteSizePatchHandler
 from skytemple_files.patch.handler.support_atupx import AtupxSupportPatchHandler
 from skytemple_files.patch.handler.unused_dungeon_chance import UnusedDungeonChancePatch
 
@@ -187,6 +188,7 @@ class PatchType(Enum):
     IMPLEMENT_FAIRY_GUMMIES = ImplementFairyGummiesPatchHandler
     EXTRACT_BAR_LIST = ExtractBarItemListPatchHandler
     EXPAND_POKE_LIST = ExpandPokeListPatchHandler
+    SPRITE_SIZE = SpriteSizePatchHandler
     ALLOW_UNRECRUITABLE_MONS = AllowUnrecruitableMonsPatchHandler
     EDIT_GUEST_POKEMON = EditGuestPokemonPatchHandler
     FIX_MEMORY_SOFTLOCK = FixMemorySoftlockPatchHandler


### PR DESCRIPTION
Sprite Size part of the ExpandPokeList patch is independent an can be extracted to another patch.
This changes ExpandPokeList so that it depends on that new patch, SpriteSizeInMonsterData.