### PR TITLE
Minor improvements to BoldText and ChangeTextSound

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/common/bold_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/common/bold_arm9.asm
@@ -7,3 +7,8 @@
 .area 0x4
 	bl RepeatRender
 .endarea
+
+.org ReturnCharWidth
+.area 0x4
+	bne TryIncreaseBoldCharWidth
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/common/bold_ov36.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/common/bold_ov36.asm
@@ -1,5 +1,5 @@
 .org 0x023A7080+0xA70
-.area 0xAEC-0xA70
+.area 0xAF8-0xA70
 
 HookBLetter:
 	ldr r0,[r13, StackThing]
@@ -7,9 +7,8 @@ HookBLetter:
 	bl TagCheck
 	cmp r0,#0
 	beq check_BR ; If not [BS], check for [BR].
-	add r1,=bold
 	mov r0,#1
-	strb r0,[r1]
+	str r0,[bold]
 	b AfterTagIsFound
 check_BR:
 	ldr r0,[r13, StackThing]
@@ -17,16 +16,14 @@ check_BR:
 	bl TagCheck
 	cmp r0,#0
 	beq TagCodeError ; If neither [BS] nor [BR], this is an invalid tag!
-	add r1,=bold
 	mov r0,#0
-	strb r0,[r1]
+	str r0,[bold]
 	b AfterTagIsFound
 RepeatRender:
 	; r7 contains the address to a function that displays a character.
 	push r14,r0-r3
 	blx r7
-	add r0,=bold
-	ldrb r0,[r0]
+	ldr r0,[bold]
 	cmp r0,#0
 	pop r0-r3
 	popeq r15
@@ -34,9 +31,19 @@ RepeatRender:
 	movmi r1,#0
 	blx r7
 	pop r15
+TryIncreaseBoldCharWidth:
+.if PPMD_GameVer == GameVer_EoS_JP
+	ldrsh r0,[r0,#0x6] ; Original instruction, sorta
+.else
+	ldrb r0,[r0,#0x2] ; Original instruction, sorta
+.endif
+	ldr r1,[bold]
+	cmp r1,#0
+	addne r0,r0,#1
+	pop r3,r15
 .pool
 	bold:
-		.byte 0x0
+		.word 0x0
 	char_BS:
 		.asciiz "BS"
 	char_BR:

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/eu/offsets.asm
@@ -7,4 +7,5 @@
 .definelabel TagCheck, 0x02020A20
 .definelabel TagCodeError, 0x02021BD4
 .definelabel AfterTagIsFound, 0x02021C64
+.definelabel ReturnCharWidth, 0x02026868
 .definelabel StackThing, 0x78

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/jp/offsets.asm
@@ -7,4 +7,5 @@
 .definelabel TagCheck, 0x02020918
 .definelabel TagCodeError, 0x02021A60
 .definelabel AfterTagIsFound, 0x02021AF0
+.definelabel ReturnCharWidth, 0x0202665C
 .definelabel StackThing, 0x70

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/bold_text/na/offsets.asm
@@ -7,4 +7,5 @@
 .definelabel TagCheck, 0x020208C8
 .definelabel TagCodeError, 0x02021A10
 .definelabel AfterTagIsFound, 0x02021AA0
+.definelabel ReturnCharWidth, 0x02026584
 .definelabel StackThing, 0x70

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/common/sound_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/common/sound_arm9.asm
@@ -2,3 +2,8 @@
 .area 0x4
 	b HookTLetter
 .endarea
+
+.org PlaySeByIdVolumeCallsite
+.area 0x4
+	bl CustomPlaySeByIdVolume
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/common/sound_ov36.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/common/sound_ov36.asm
@@ -1,5 +1,5 @@
 .org 0x023A7080+0xB20
-.area 0xB7C-0xB20
+.area 0xBA8-0xB20
 
 HookTLetter:
 	ldr r0,[r13, StackThing]
@@ -9,8 +9,12 @@ HookTLetter:
 	beq check_TR ; If not [TS], check for [TR].
 	ldr r0,[r13, StackThing+4]
 	bl GetTagParameter
-	ldr r1,=TextboxSE
-	str r0,[r1] ; Change the text sound to ID X from [TS:X]
+	str r0,[new_sound] ; Change the text sound to ID X from [TS:X:Y].
+	cmp r6,#2
+	moveq r0,#0x100 ; If there is no second parameter, assume a default volume of 0x100.
+	ldrne r0,[r13, StackThing+8]
+	blne GetTagParameter
+	str r0,[new_volume]
 	b AfterTagIsFound
 check_TR:
 	ldr r0,[r13, StackThing]
@@ -18,11 +22,20 @@ check_TR:
 	bl TagCheck
 	cmp r0,#0
 	beq TagCodeError ; If neither [TS] nor [TR], this is an invalid tag!
-	ldr r1,=TextboxSE
 	ldr r0,=#16133
-	str r0,[r1] ; Restore the default textbox sound effect.
+	str r0,[new_sound] ; Restore the default textbox sound effect.
+	mov r0,#0x100
+	str r0,[new_volume] ; Restore the default textbox volume.
 	b AfterTagIsFound
+CustomPlaySeByIdVolume:
+	ldr r0,[new_sound]
+	ldr r1,[new_volume]
+	b PlaySeByIdVolume ; Original instruction, sorta
 .pool
+	new_sound:
+		.word 0x3F05
+	new_volume:
+		.word 0x100
 	char_TS:
 		.asciiz "TS"
 	char_TR:

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/eu/offsets.asm
@@ -3,7 +3,8 @@
 .arm
 
 .definelabel CaseT, 0x0202111C
-.definelabel TextboxSE, 0x02017DB8
+.definelabel PlaySeByIdVolumeCallsite, 0x02017DAC
+.definelabel PlaySeByIdVolume, 0x02018354
 .definelabel TagCheck, 0x02020A20
 .definelabel GetTagParameter, 0x02020A64
 .definelabel TagCodeError, 0x02021BD4

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/jp/offsets.asm
@@ -3,7 +3,8 @@
 .arm
 
 .definelabel CaseT, 0x02021014
-.definelabel TextboxSE, 0x02017D74
+.definelabel PlaySeByIdVolumeCallsite, 0x02017D68
+.definelabel PlaySeByIdVolume, 0x02018310
 .definelabel TagCheck, 0x02020918
 .definelabel GetTagParameter, 0x0202095C
 .definelabel TagCodeError, 0x02021A60

--- a/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/adex_asm_mods/change_text_sound/na/offsets.asm
@@ -3,7 +3,8 @@
 .arm
 
 .definelabel CaseT, 0x02020FC4
-.definelabel TextboxSE, 0x02017D1C
+.definelabel PlaySeByIdVolumeCallsite, 0x02017D10
+.definelabel PlaySeByIdVolume, 0x020182B8
 .definelabel TagCheck, 0x020208C8
 .definelabel GetTagParameter, 0x0202090C
 .definelabel TagCodeError, 0x02021A10

--- a/skytemple_files/patch/handler/change_text_sound.py
+++ b/skytemple_files/patch/handler/change_text_sound.py
@@ -46,7 +46,7 @@ class ChangeTextSoundPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def description(self) -> str:
-        return "Adds new text tags that allow for the textbox sound to be changed. [TS:X] will use the Xth sound effect ID in textboxes. [TR] will revert the sound to default."
+        return "Adds new text tags that allow for the textbox sound to be changed. [TS:X:Y] will use the Xth sound effect ID in textboxes with a volume of Y. [TR] will revert the sound and volume to their default states, sound effect 16133 and volume 256."
 
     @property
     def author(self) -> str:


### PR DESCRIPTION
Some minor improvements to two patches:
- `BoldText`: When characters' widths are read while bold text is active, then it will be increased by 1 to prevent characters from bleeding into one another.
- `ChangeTextSound`: Added an optional second parameter to the text tag specifying the volume. If the text tag is used without a volume parameter, it defaults to 256.