### PR TITLE
Use Chara Wan model to compute VRAM Size

### DIFF
--- a/skytemple_files/common/sprite_util.py
+++ b/skytemple_files/common/sprite_util.py
@@ -111,7 +111,7 @@ def _get_sprite_properties(monster_bin: BinPack, m_attack_bin: BinPack, entry: M
         return 0, 0
     sprite_bin = monster_bin[entry.sprite_index]
     sprite_bytes = FileType.COMMON_AT.deserialize(sprite_bin).decompress()
-    sprite = FileType.WAN.deserialize(sprite_bytes)
-    max_tile_slots_needed = max(6, sprite.model.frame_store.max_fragment_alloc_count)
+    sprite = FileType.WAN.CHARA.deserialize(sprite_bytes)
+    max_tile_slots_needed = max(6, sprite.get_max_blocks())
     max_file_size_needed = math.ceil(len(sprite_bytes) / 512)
     return max_tile_slots_needed, max_file_size_needed

--- a/skytemple_files/graphics/chara_wan/model.py
+++ b/skytemple_files/graphics/chara_wan/model.py
@@ -114,6 +114,18 @@ class WanFile(Sir0Serializable):
             anim_req.append(len(anim_group) > 0)
         return anim_req
 
+    def get_max_blocks(self):
+        max_blocks = 0
+        for idx, metaFrame in enumerate(self.frameData):
+            cur_tile = 0
+            for piece in metaFrame:
+                if piece.imgIndex != MINUS_FRAME:
+                    twidth, theight = DIM_TABLE[piece.getResolutionType()]
+                    blocks_occupied = max(1, twidth * theight // 4)
+                    cur_tile += blocks_occupied
+            max_blocks = max(max_blocks, cur_tile)
+        return max_blocks
+
     # This will accurately load all sir0 found in m_ground, m_attack, and monster.bin with a few exceptions:
     # m_ground_0546_0xb01840.wan - Armaldo.  Metaframe Unk#0 is a nonzero
     # m_ground_0587_0xbd0a10.wan - Latios.  Unknown difference

--- a/skytemple_files/graphics/chara_wan/writer.py
+++ b/skytemple_files/graphics/chara_wan/writer.py
@@ -19,8 +19,6 @@ from __future__ import annotations
 
 from io import BytesIO
 
-from skytemple_files.graphics.chara_wan.model import DIM_TABLE, MINUS_FRAME
-
 
 def ExportWan(wan):
     out_file = BytesIO()
@@ -169,15 +167,7 @@ def ExportWan(wan):
         write_ptr(out_file, img_ptr, sir0_ptrs)
 
     # compute max block space
-    max_blocks = 0
-    for idx, metaFrame in enumerate(wan.frameData):
-        cur_tile = 0
-        for piece in metaFrame:
-            if piece.imgIndex != MINUS_FRAME:
-                twidth, theight = DIM_TABLE[piece.getResolutionType()]
-                blocks_occupied = max(1, twidth * theight // 4)
-                cur_tile += blocks_occupied
-        max_blocks = max(max_blocks, cur_tile)
+    max_blocks = wan.get_max_blocks()
 
     # AnimInfo
     ptrAnimInfo = out_file.tell()


### PR DESCRIPTION
Add a function to compute max VRAM blocks in chara_wan model, which is now used for sprite size checks