### PR TITLE
Sprite fixes and improvements

### DIFF
--- a/skytemple_files/graphics/chara_wan/sheets.py
+++ b/skytemple_files/graphics/chara_wan/sheets.py
@@ -528,8 +528,10 @@ def ImportSheets(inDir, strict=False):
         for copy_idx in copies:
             animGroupData[copy_idx] = exWanUtils.duplicateAnimGroup(animGroupData[idx])
 
+    imgDataMerge = []
+    exWanUtils.mapImgData(imgData, imgDataMerge, frameData)
     wan = WanFile()
-    wan.imgData = imgData
+    wan.imgData = imgDataMerge
     wan.frameData = frameData
     wan.animGroupData = animGroupData
     wan.offsetData = offsetData
@@ -903,8 +905,6 @@ def addImgData(imgData, frameData, palette_map, transparent, frame):
         block_size = (piece.size[0] // TEX_SIZE, piece.size[1] // TEX_SIZE)
         res_type = DIM_TABLE.index(block_size)
         metaFramePiece.setResolutionType(res_type)
-        # set RnS parameter - always true when not disabled; when reading in we are never disabled
-        metaFramePiece.setRotAndScalingOn(True)
         # set tile index
         metaFramePiece.setTileNum(use_tile)
         # priority is ALWAYS 3

--- a/skytemple_files/graphics/chara_wan/split_merge.py
+++ b/skytemple_files/graphics/chara_wan/split_merge.py
@@ -22,7 +22,7 @@ def MergeWan(wan_files):
     # merge all pieces and remap the frames that reference them
     imgData = []
     for wan in wan_files:
-        mapImgData(wan.imgData, imgData, wan.frameData)
+        exWanUtils.mapImgData(wan.imgData, imgData, wan.frameData)
 
     # merge all frames and remap the animations that reference them
     frameData = []
@@ -83,43 +83,6 @@ def SplitWan(wan, anim_presence):
         new_wan.sdwSize = wan.sdwSize
         wan_files.append(new_wan)
     return wan_files
-
-
-def mapImgData(inputImgData, imgData, frameData):
-    mapping = {}
-    for idx, img in enumerate(inputImgData):
-        dupe_idx = -1
-        for check_idx, check_img in enumerate(imgData):
-            imgs_equal = True
-            # perform a check to see if they're equal
-            if len(img.imgPx) == len(check_img.imgPx):
-                for ii in range(len(img.imgPx)):
-                    if len(img.imgPx[ii]) == len(check_img.imgPx[ii]):
-                        for jj in range(len(img.imgPx[ii])):
-                            if img.imgPx[ii][jj] != check_img.imgPx[ii][jj]:
-                                imgs_equal = False
-                                break
-                    else:
-                        imgs_equal = False
-
-                    if not imgs_equal:
-                        break
-            else:
-                imgs_equal = False
-
-            if imgs_equal:
-                dupe_idx = check_idx
-                break
-        if dupe_idx > -1:
-            mapping[idx] = dupe_idx
-        else:
-            mapping[idx] = len(imgData)
-            imgData.append(img)
-
-    for frame in frameData:
-        for piece in frame:
-            if piece.imgIndex != MINUS_FRAME:
-                piece.imgIndex = mapping[piece.imgIndex]
 
 
 def mapFrameData(inputFrameData, frameData, inputOffsetData, offsetData, animGroupData):

--- a/skytemple_files/graphics/chara_wan/wan_utils.py
+++ b/skytemple_files/graphics/chara_wan/wan_utils.py
@@ -16,7 +16,8 @@ from skytemple_files.graphics.chara_wan.model import (
     FrameOffset,
     ImgPiece,
     MetaFramePiece,
-    SequenceFrame, MINUS_FRAME,
+    SequenceFrame,
+    MINUS_FRAME,
 )
 
 

--- a/skytemple_files/graphics/chara_wan/wan_utils.py
+++ b/skytemple_files/graphics/chara_wan/wan_utils.py
@@ -16,7 +16,7 @@ from skytemple_files.graphics.chara_wan.model import (
     FrameOffset,
     ImgPiece,
     MetaFramePiece,
-    SequenceFrame,
+    SequenceFrame, MINUS_FRAME,
 )
 
 
@@ -80,3 +80,40 @@ def duplicateImgData(imgStrip):
         new_img.imgPx.append(new_strip)
 
     return new_img
+
+
+def mapImgData(inputImgData, imgData, frameData):
+    mapping = {}
+    for idx, img in enumerate(inputImgData):
+        dupe_idx = -1
+        for check_idx, check_img in enumerate(imgData):
+            imgs_equal = True
+            # perform a check to see if they're equal
+            if len(img.imgPx) == len(check_img.imgPx):
+                for ii in range(len(img.imgPx)):
+                    if len(img.imgPx[ii]) == len(check_img.imgPx[ii]):
+                        for jj in range(len(img.imgPx[ii])):
+                            if img.imgPx[ii][jj] != check_img.imgPx[ii][jj]:
+                                imgs_equal = False
+                                break
+                    else:
+                        imgs_equal = False
+
+                    if not imgs_equal:
+                        break
+            else:
+                imgs_equal = False
+
+            if imgs_equal:
+                dupe_idx = check_idx
+                break
+        if dupe_idx > -1:
+            mapping[idx] = dupe_idx
+        else:
+            mapping[idx] = len(imgData)
+            imgData.append(img)
+
+    for frame in frameData:
+        for piece in frame:
+            if piece.imgIndex != MINUS_FRAME:
+                piece.imgIndex = mapping[piece.imgIndex]


### PR DESCRIPTION
- Fix sprite with missing chunks in frame
  - This is due to the Y offset being misinterpreted in chunks (Y offset is actually a signed 10-bit integer)
- Slightly improve sprite file size reduction
  - Reuses the same algorithm that merges chunks with same image data, which can slightly improve file size especially if two frames are similar in the sprite