### PR TITLE
Reupload portrait limit patch

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/common/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/common/patch.asm
@@ -1,0 +1,16 @@
+; For use with ARMIPS
+; 2023/03/11
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Expand Portrait Structure Size to accept compressed portraits up to 808 bytes
+; ------------------------------------------------------------------------------
+;
+.relativeinclude on
+.nds
+.arm
+
+.org PatchSize
+.area 0x4
+	mov  r0,#0x388
+.endarea
+

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/eu/offsets.asm
@@ -1,0 +1,13 @@
+; For use with ARMIPS
+; 2021/03/11
+; For Explorers of Sky European ONLY!
+; Should not be used with any other version!
+; ------------------------------------------------------------------------------
+; Expand Portrait Structure Size to accept compressed portraits up to 808 bytes
+; ------------------------------------------------------------------------------
+;
+.relativeinclude on
+.nds
+.arm
+
+.definelabel PatchSize, 0x0202F8B0

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/jp/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/jp/offsets.asm
@@ -1,0 +1,13 @@
+; For use with ARMIPS
+; 2021/03/11
+; For Explorers of Sky Japan ONLY!
+; Should not be used with any other version!
+; ------------------------------------------------------------------------------
+; Expand Portrait Structure Size to accept compressed portraits up to 808 bytes
+; ------------------------------------------------------------------------------
+;
+.relativeinclude on
+.nds
+.arm
+
+.definelabel PatchSize, 0x0202F900

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/na/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/na/offsets.asm
@@ -1,0 +1,13 @@
+; For use with ARMIPS
+; 2021/03/11
+; For Explorers of Sky North American ONLY!
+; Should not be used with any other version!
+; ------------------------------------------------------------------------------
+; Expand Portrait Structure Size to accept compressed portraits up to 808 bytes
+; ------------------------------------------------------------------------------
+;
+.relativeinclude on
+.nds
+.arm
+
+.definelabel PatchSize, 0x0202F5BC

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/selector_arm9.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/expand_portrait/selector_arm9.asm
@@ -1,0 +1,22 @@
+; For use with ARMIPS
+; 2023/03/11
+; For Explorers of Sky All Versions
+; ------------------------------------------------------------------------------
+; Selects the correct version to use
+; ------------------------------------------------------------------------------
+
+.relativeinclude on
+
+; Selects the correct region to apply the patch
+.if PPMD_GameVer == GameVer_EoS_NA
+	.include "na/offsets.asm"
+	.include "common/patch.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+	.include "eu/offsets.asm"
+	.include "common/patch.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/offsets.asm"
+	.include "common/patch.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -775,6 +775,13 @@
           </OpenBin>
         </Patch>
 
+        <!-- A patch to expand Portrait Structure Size -->
+        <Patch id="ExpandPortraitStructs" >
+          <OpenBin filepath="arm9.bin">
+	  	<Include filename ="anonymous_asm_mods/expand_portrait/selector_arm9.asm"/>
+	  </OpenBin>
+        </Patch>
+        
         <!-- A patch to provide support for ATUPX containers -->
         <Patch id="ProvideATUPXSupport" >
           <OpenBin filepath="arm9.bin">

--- a/skytemple_files/graphics/kao/_model.py
+++ b/skytemple_files/graphics/kao/_model.py
@@ -53,7 +53,7 @@ from skytemple_files.graphics.kao.protocol import (
 
 
 class KaoPropertiesState(_KaoPropertiesProtocol):
-    _instance: Optional[KaoPropertiesState] = None
+    _instance: KaoPropertiesState | None = None
     kao_image_limit: int
 
     def __init__(self, kao_image_limit: int):
@@ -450,9 +450,7 @@ def pil_to_kao(pil: Image.Image, allowed_compressions: list[CommonAtType] | None
     # correct image again:
     # >>> uncompressed_kao_to_pil(new_palette, new_img).show()
 
-    new_img_compressed = FileType.COMMON_AT.serialize(
-        FileType.COMMON_AT.compress(new_img, allowed_compressions)
-    )
+    new_img_compressed = FileType.COMMON_AT.serialize(FileType.COMMON_AT.compress(new_img, allowed_compressions))
     limit = KaoPropertiesState.instance().kao_image_limit
     if len(new_img_compressed) > limit:
         raise AttributeError(

--- a/skytemple_files/graphics/kao/_model.py
+++ b/skytemple_files/graphics/kao/_model.py
@@ -34,7 +34,7 @@ from skytemple_files.common.util import (
     read_u32,
 )
 from skytemple_files.compression_container.common_at.handler import (
-    COMMON_AT_MUST_COMPRESS_3,
+    COMMON_AT_BEST_3,
     CommonAtType,
 )
 from skytemple_files.graphics.kao import (
@@ -44,7 +44,26 @@ from skytemple_files.graphics.kao import (
     SUBENTRIES,
     SUBENTRY_LEN,
 )
-from skytemple_files.graphics.kao.protocol import KaoImageProtocol, KaoProtocol
+from skytemple_files.graphics.kao.protocol import (
+    _KaoPropertiesProtocol,
+    KaoImageProtocol,
+    KaoProtocol,
+    KAO_IMAGE_LIMIT,
+)
+
+
+class KaoPropertiesState(_KaoPropertiesProtocol):
+    _instance: Optional[KaoPropertiesState] = None
+    kao_image_limit: int
+
+    def __init__(self, kao_image_limit: int):
+        self.kao_image_limit = kao_image_limit
+
+    @classmethod
+    def instance(cls) -> KaoPropertiesState:
+        if cls._instance is None:
+            cls._instance = KaoPropertiesState(KAO_IMAGE_LIMIT)
+        return cls._instance
 
 
 class KaoImage(KaoImageProtocol):
@@ -326,7 +345,7 @@ def pil_to_kao(pil: Image.Image, allowed_compressions: list[CommonAtType] | None
     from skytemple_files.common.types.file_types import FileType
 
     if allowed_compressions is None:
-        allowed_compressions = COMMON_AT_MUST_COMPRESS_3
+        allowed_compressions = COMMON_AT_BEST_3
 
     img_dim = KAO_IMG_METAPIXELS_DIM * KAO_IMG_IMG_DIM
     if pil.width != img_dim or pil.height != img_dim:
@@ -431,14 +450,18 @@ def pil_to_kao(pil: Image.Image, allowed_compressions: list[CommonAtType] | None
     # correct image again:
     # >>> uncompressed_kao_to_pil(new_palette, new_img).show()
 
-    new_img_compressed = FileType.COMMON_AT.serialize(FileType.COMMON_AT.compress(new_img, allowed_compressions))
-    if len(new_img_compressed) > 800:
+    new_img_compressed = FileType.COMMON_AT.serialize(
+        FileType.COMMON_AT.compress(new_img, allowed_compressions)
+    )
+    limit = KaoPropertiesState.instance().kao_image_limit
+    if len(new_img_compressed) > limit:
         raise AttributeError(
             f(
                 _(
-                    "This portrait does not compress well, the result size is greater than 800 bytes ({len(new_img_compressed)} bytes total).\n"
-                    "If you haven't done already, try applying the 'ProvideATUPXSupport' to install an optimized compression algorithm, "
+                    "This portrait does not compress well, the result size is greater than {limit} bytes ({len(new_img_compressed)} bytes total).\n"
+                    "If you haven't done already, try applying the 'ProvideATUPXSupport' ASM patch to install an optimized compression algorithm, "
                     "which might be able to better compress this image."
+                    "If this still doesn't work, try the 'ExpandPortraitStructs' instead."
                 )
             )
         )

--- a/skytemple_files/graphics/kao/handler.py
+++ b/skytemple_files/graphics/kao/handler.py
@@ -24,7 +24,11 @@ from skytemple_files.common.types.hybrid_data_handler import (
     WriterProtocol,
 )
 from skytemple_files.common.util import OptionalKwargs
-from skytemple_files.graphics.kao.protocol import KaoImageProtocol, KaoProtocol
+from skytemple_files.graphics.kao.protocol import (
+    _KaoPropertiesProtocol,
+    KaoImageProtocol,
+    KaoProtocol,
+)
 
 if TYPE_CHECKING:
     from skytemple_files.graphics.kao._model import Kao as PyKao
@@ -59,6 +63,18 @@ class KaoHandler(HybridDataHandler[KaoProtocol]):
         )  # pylint: disable=no-name-in-module,no-member,import-error
 
         return KaoWriter
+
+    @classmethod
+    def properties(cls) -> _KaoPropertiesProtocol:
+        if get_implementation_type() == ImplementationType.NATIVE:
+            from skytemple_rust.st_kao import (
+                KaoPropertiesState as KaoPropertiesNative,
+            )  # pylint: disable=no-name-in-module,no-member,import-error
+
+            return KaoPropertiesNative.instance()
+        from skytemple_files.graphics.kao._model import KaoPropertiesState
+
+        return KaoPropertiesState.instance()
 
     @classmethod
     def get_image_model_cls(cls) -> type[KaoImageProtocol]:

--- a/skytemple_files/graphics/kao/protocol.py
+++ b/skytemple_files/graphics/kao/protocol.py
@@ -22,6 +22,27 @@ from collections.abc import Iterator
 
 from PIL.Image import Image
 
+KAO_IMAGE_LIMIT = 800
+
+
+class _KaoPropertiesProtocol(Protocol):
+    """
+    Implementations must provide an implementation of this.
+    This keeps track of "changeable" constants.
+
+    The values must default to the values below, users may
+    change it via the MdHandler, if for example a patch to expand
+    the monster list is applied.
+    """
+
+    kao_image_limit: int  # Must default to KAO_IMAGE_LIMIT.
+
+    @classmethod
+    @abstractmethod
+    def instance(cls) -> "_KaoPropertiesProtocol":
+        """This is a singleton."""
+        ...
+
 
 class KaoImageProtocol(Protocol):
     @classmethod

--- a/skytemple_files/patch/handler/expand_portrait.py
+++ b/skytemple_files/patch/handler/expand_portrait.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from typing import Callable
 
+from ndspy.rom import NintendoDSRom
+
 from skytemple_files.common.i18n_util import _
 from skytemple_files.common.ppmdu_config.data import (
     GAME_REGION_EU,
@@ -26,9 +28,9 @@ from skytemple_files.common.ppmdu_config.data import (
     GAME_VERSION_EOS,
     Pmd2Data,
 )
-from skytemple_files.common.util import *
+from skytemple_files.common.util import read_u32
 from skytemple_files.patch.category import PatchCategory
-from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler
 
 PATCH_CHECK_ADDR_APPLIED_US = 0x2F5BC
 PATCH_CHECK_ADDR_APPLIED_EU = 0x2F8B0
@@ -43,9 +45,7 @@ class ExpandPortraitPatchHandler(AbstractPatchHandler):
 
     @property
     def description(self) -> str:
-        return _(
-            "Expands portraits structure by 8 bytes, which is enough to cover all cases."
-        )
+        return _("Expands portraits structure by 8 bytes, which is enough to cover all cases.")
 
     @property
     def author(self) -> str:
@@ -62,31 +62,18 @@ class ExpandPortraitPatchHandler(AbstractPatchHandler):
     def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
         if config.game_version == GAME_VERSION_EOS:
             if config.game_region == GAME_REGION_US:
-                return (
-                    read_u32(rom.arm9, PATCH_CHECK_ADDR_APPLIED_US)
-                    != PATCH_CHECK_INSTR_APPLIED
-                )
+                return read_u32(rom.arm9, PATCH_CHECK_ADDR_APPLIED_US) != PATCH_CHECK_INSTR_APPLIED
             if config.game_region == GAME_REGION_EU:
-                return (
-                    read_u32(rom.arm9, PATCH_CHECK_ADDR_APPLIED_EU)
-                    != PATCH_CHECK_INSTR_APPLIED
-                )
+                return read_u32(rom.arm9, PATCH_CHECK_ADDR_APPLIED_EU) != PATCH_CHECK_INSTR_APPLIED
             if config.game_region == GAME_REGION_JP:
-                return (
-                    read_u32(rom.arm9, PATCH_CHECK_ADDR_APPLIED_JP)
-                    != PATCH_CHECK_INSTR_APPLIED
-                )
+                return read_u32(rom.arm9, PATCH_CHECK_ADDR_APPLIED_JP) != PATCH_CHECK_INSTR_APPLIED
         raise NotImplementedError()
 
-    def apply(
-        self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
-    ) -> None:
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:
         try:
             apply()
         except RuntimeError as ex:
             raise ex
 
-    def unapply(
-        self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
-    ) -> None:
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:
         raise NotImplementedError()

--- a/skytemple_files/patch/handler/expand_portrait.py
+++ b/skytemple_files/patch/handler/expand_portrait.py
@@ -1,0 +1,92 @@
+#  Copyright 2020-2023 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+from typing import Callable
+
+from skytemple_files.common.i18n_util import _
+from skytemple_files.common.ppmdu_config.data import (
+    GAME_REGION_EU,
+    GAME_REGION_JP,
+    GAME_REGION_US,
+    GAME_VERSION_EOS,
+    Pmd2Data,
+)
+from skytemple_files.common.util import *
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+
+PATCH_CHECK_ADDR_APPLIED_US = 0x2F5BC
+PATCH_CHECK_ADDR_APPLIED_EU = 0x2F8B0
+PATCH_CHECK_ADDR_APPLIED_JP = 0x2F900
+PATCH_CHECK_INSTR_APPLIED = 0xE3A00D0E
+
+
+class ExpandPortraitPatchHandler(AbstractPatchHandler):
+    @property
+    def name(self) -> str:
+        return "ExpandPortraitStructs"
+
+    @property
+    def description(self) -> str:
+        return _(
+            "Expands portraits structure by 8 bytes, which is enough to cover all cases."
+        )
+
+    @property
+    def author(self) -> str:
+        return "Anonymous"
+
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.UTILITY
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return (
+                    read_u32(rom.arm9, PATCH_CHECK_ADDR_APPLIED_US)
+                    != PATCH_CHECK_INSTR_APPLIED
+                )
+            if config.game_region == GAME_REGION_EU:
+                return (
+                    read_u32(rom.arm9, PATCH_CHECK_ADDR_APPLIED_EU)
+                    != PATCH_CHECK_INSTR_APPLIED
+                )
+            if config.game_region == GAME_REGION_JP:
+                return (
+                    read_u32(rom.arm9, PATCH_CHECK_ADDR_APPLIED_JP)
+                    != PATCH_CHECK_INSTR_APPLIED
+                )
+        raise NotImplementedError()
+
+    def apply(
+        self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ) -> None:
+        try:
+            apply()
+        except RuntimeError as ex:
+            raise ex
+
+    def unapply(
+        self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data
+    ) -> None:
+        raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -94,6 +94,7 @@ from skytemple_files.patch.handler.edit_guest_pokemon import (
 )
 from skytemple_files.patch.handler.exp_share import ExpSharePatchHandler
 from skytemple_files.patch.handler.expand_poke_list import ExpandPokeListPatchHandler
+from skytemple_files.patch.handler.expand_portrait import ExpandPortraitPatchHandler
 from skytemple_files.patch.handler.externalize_mappa import ExternalizeMappaPatchHandler
 from skytemple_files.patch.handler.externalize_waza import ExternalizeWazaPatchHandler
 from skytemple_files.patch.handler.extra_space import ExtraSpacePatch
@@ -157,6 +158,7 @@ class PatchType(Enum):
     MOVE_SHORTCUTS = MoveShortcutsPatch
     DISABLE_TIPS = DisableTipsPatch
     SAME_TYPE_PARTNER = SameTypePartnerPatch
+    EXPAND_PORTRAIT = ExpandPortraitPatchHandler
     SUPPORT_ATUPX = AtupxSupportPatchHandler
     EXTRACT_ITEM_LISTS = ExtractItemListsPatchHandler
     EXTRACT_DUNGEON_DATA = ExtractDungeonDataPatchHandler


### PR DESCRIPTION
Reuploads that patch
> Adds a patch to expand the portrait structure allocated by the game by 8 bytes, which is enough to contain all possible cases of compressed portraits (worst case is an uncompressed ATNPX container which would be 807 bytes, while the expanded structure can contain up to 808 bytes).
Adds a property for Kao Image import to specify that limit.

See:
Skytemple/skytemple#803
Skytemple/skytemple-rust#123