### PR TITLE
Fix Dungeon Interrupt HP bug

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/dungeon_interrupt/common/patch_overlay11.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/dungeon_interrupt/common/patch_overlay11.asm
@@ -25,7 +25,7 @@
 	mov  r1,r7
 	str r3,[r13]
 	str r9,[r13, #+0x8]
-	ldrsh r9,[r8, #+0xe]
+	nop
 	nop
 	ldr r3,[r15, #+0x80]
 	str r9,[r13, #+0x4]


### PR DESCRIPTION
Since I worked on it, I wanted to submit a fix to the (old) bug of DungeonInterrupt patch where the entity HP is not synchronized with the tabulated new max HP value.