### PR TITLE
Add description translatability for some patches

### DIFF
--- a/skytemple_files/patch/handler/add_key_check.py
+++ b/skytemple_files/patch/handler/add_key_check.py
@@ -20,6 +20,7 @@ from typing import Callable
 
 from ndspy.rom import NintendoDSRom
 
+from skytemple_files.common.i18n_util import _
 from skytemple_files.common.ppmdu_config.data import (
     GAME_REGION_EU,
     GAME_REGION_US,
@@ -44,7 +45,7 @@ class AddKeyCheckPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def description(self) -> str:
-        return "Prevents Keys from being used on party members that are not below a Key Door!"
+        return _("Prevents Keys from being used on party members that are not below a Key Door!")
 
     @property
     def author(self) -> str:

--- a/skytemple_files/patch/handler/better_enemy_evolution.py
+++ b/skytemple_files/patch/handler/better_enemy_evolution.py
@@ -45,7 +45,9 @@ class BetterEnemyEvolutionPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def description(self) -> str:
-        return _("Allows changing how enemy evolution works. In particular, it allows you to choose if the evolved enemy will get the stats and/or moves from its new species, add extra stats after evolving, heal the enemy after evolving or choosing if the evolution will take place even if the target is revived.")
+        return _(
+            "Allows changing how enemy evolution works. In particular, it allows you to choose if the evolved enemy will get the stats and/or moves from its new species, add extra stats after evolving, heal the enemy after evolving or choosing if the evolution will take place even if the target is revived."
+        )
 
     @property
     def author(self) -> str:

--- a/skytemple_files/patch/handler/better_enemy_evolution.py
+++ b/skytemple_files/patch/handler/better_enemy_evolution.py
@@ -20,6 +20,7 @@ from typing import Callable
 
 from ndspy.rom import NintendoDSRom
 
+from skytemple_files.common.i18n_util import _
 from skytemple_files.common.util import get_binary_from_rom, read_u32
 from skytemple_files.common.ppmdu_config.data import (
     Pmd2Data,
@@ -44,7 +45,7 @@ class BetterEnemyEvolutionPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def description(self) -> str:
-        return "Allows changing how enemy evolution works. In particular, it allows you to choose if the evolved enemy will get the stats and/or moves from its new species, add extra stats after evolving, heal the enemy after evolving or choosing if the evolution will take place even if the target is revived."
+        return _("Allows changing how enemy evolution works. In particular, it allows you to choose if the evolved enemy will get the stats and/or moves from its new species, add extra stats after evolving, heal the enemy after evolving or choosing if the evolution will take place even if the target is revived.")
 
     @property
     def author(self) -> str:

--- a/skytemple_files/patch/handler/bold_text.py
+++ b/skytemple_files/patch/handler/bold_text.py
@@ -20,6 +20,7 @@ from typing import Callable
 
 from ndspy.rom import NintendoDSRom
 
+from skytemple_files.common.i18n_util import _
 from skytemple_files.common.ppmdu_config.data import (
     GAME_REGION_EU,
     GAME_REGION_US,
@@ -44,7 +45,7 @@ class BoldTextPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def description(self) -> str:
-        return "Adds new text tags that allow for bold text in strings. Encase the desired text with [BS] and [BR]."
+        return _("Adds new text tags that allow for bold text in strings. Encase the desired text with [BS] and [BR].")
 
     @property
     def author(self) -> str:

--- a/skytemple_files/patch/handler/change_portrait.py
+++ b/skytemple_files/patch/handler/change_portrait.py
@@ -45,7 +45,9 @@ class ChangePortraitPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def description(self) -> str:
-        return _("Implements the text tag [FACE:X], which sets the current portrait to use the Xth portrait emotion (e.g. 0 = FACE_NORMAL).\nThis allows for changing portrait emotions during dialogue!")
+        return _(
+            "Implements the text tag [FACE:X], which sets the current portrait to use the Xth portrait emotion (e.g. 0 = FACE_NORMAL).\nThis allows for changing portrait emotions during dialogue!"
+        )
 
     @property
     def author(self) -> str:

--- a/skytemple_files/patch/handler/change_portrait.py
+++ b/skytemple_files/patch/handler/change_portrait.py
@@ -20,6 +20,7 @@ from typing import Callable
 
 from ndspy.rom import NintendoDSRom
 
+from skytemple_files.common.i18n_util import _
 from skytemple_files.common.ppmdu_config.data import (
     GAME_REGION_EU,
     GAME_REGION_US,
@@ -44,7 +45,7 @@ class ChangePortraitPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def description(self) -> str:
-        return "Implements the text tag [FACE:X], which sets the current portrait to use the Xth portrait emotion (e.g. 0 = FACE_NORMAL).\nThis allows for changing portrait emotions during dialogue!"
+        return _("Implements the text tag [FACE:X], which sets the current portrait to use the Xth portrait emotion (e.g. 0 = FACE_NORMAL).\nThis allows for changing portrait emotions during dialogue!")
 
     @property
     def author(self) -> str:

--- a/skytemple_files/patch/handler/change_text_sound.py
+++ b/skytemple_files/patch/handler/change_text_sound.py
@@ -20,6 +20,7 @@ from typing import Callable
 
 from ndspy.rom import NintendoDSRom
 
+from skytemple_files.common.i18n_util import _
 from skytemple_files.common.ppmdu_config.data import (
     GAME_REGION_EU,
     GAME_REGION_US,
@@ -46,7 +47,7 @@ class ChangeTextSoundPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def description(self) -> str:
-        return "Adds new text tags that allow for the textbox sound to be changed. [TS:X:Y] will use the Xth sound effect ID in textboxes with a volume of Y. [TR] will revert the sound and volume to their default states, sound effect 16133 and volume 256."
+        return _("Adds new text tags that allow for the textbox sound to be changed. [TS:X:Y] will use the Xth sound effect ID in textboxes with a volume of Y. [TR] will revert the sound and volume to their default states, sound effect 16133 and volume 256.")
 
     @property
     def author(self) -> str:

--- a/skytemple_files/patch/handler/change_text_sound.py
+++ b/skytemple_files/patch/handler/change_text_sound.py
@@ -47,7 +47,9 @@ class ChangeTextSoundPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def description(self) -> str:
-        return _("Adds new text tags that allow for the textbox sound to be changed. [TS:X:Y] will use the Xth sound effect ID in textboxes with a volume of Y. [TR] will revert the sound and volume to their default states, sound effect 16133 and volume 256.")
+        return _(
+            "Adds new text tags that allow for the textbox sound to be changed. [TS:X:Y] will use the Xth sound effect ID in textboxes with a volume of Y. [TR] will revert the sound and volume to their default states, sound effect 16133 and volume 256."
+        )
 
     @property
     def author(self) -> str:

--- a/skytemple_files/patch/handler/display_script_var.py
+++ b/skytemple_files/patch/handler/display_script_var.py
@@ -45,7 +45,9 @@ class DisplayScriptVarPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def description(self) -> str:
-        return _('Displays a script variable in a string with the text tag [var:x:y], where "x" is the variable ID and "y" is the index!')
+        return _(
+            'Displays a script variable in a string with the text tag [var:x:y], where "x" is the variable ID and "y" is the index!'
+        )
 
     @property
     def author(self) -> str:

--- a/skytemple_files/patch/handler/display_script_var.py
+++ b/skytemple_files/patch/handler/display_script_var.py
@@ -20,6 +20,7 @@ from typing import Callable
 
 from ndspy.rom import NintendoDSRom
 
+from skytemple_files.common.i18n_util import _
 from skytemple_files.common.ppmdu_config.data import (
     GAME_REGION_EU,
     GAME_REGION_US,
@@ -44,7 +45,7 @@ class DisplayScriptVarPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def description(self) -> str:
-        return 'Displays a script variable in a string with the text tag [var:x:y], where "x" is the variable ID and "y" is the index!'
+        return _('Displays a script variable in a string with the text tag [var:x:y], where "x" is the variable ID and "y" is the index!')
 
     @property
     def author(self) -> str:

--- a/skytemple_files/patch/handler/pitfall_trap_tweak.py
+++ b/skytemple_files/patch/handler/pitfall_trap_tweak.py
@@ -20,6 +20,7 @@ from typing import Callable
 
 from ndspy.rom import NintendoDSRom
 
+from skytemple_files.common.i18n_util import _
 from skytemple_files.common.ppmdu_config.data import (
     GAME_REGION_EU,
     GAME_REGION_US,
@@ -44,7 +45,7 @@ class PitfallTrapTweakPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def description(self) -> str:
-        return "Makes Pitfall Traps send the leader back by one floor in ascending dungeons. If the leader activates a Pitfall Trap on 1F, they will restart 1F with a different seed."
+        return _("Makes Pitfall Traps send the leader back by one floor in ascending dungeons. If the leader activates a Pitfall Trap on 1F, they will restart 1F with a different seed.")
 
     @property
     def author(self) -> str:

--- a/skytemple_files/patch/handler/pitfall_trap_tweak.py
+++ b/skytemple_files/patch/handler/pitfall_trap_tweak.py
@@ -45,7 +45,9 @@ class PitfallTrapTweakPatchHandler(AbstractPatchHandler, DependantPatch):
 
     @property
     def description(self) -> str:
-        return _("Makes Pitfall Traps send the leader back by one floor in ascending dungeons. If the leader activates a Pitfall Trap on 1F, they will restart 1F with a different seed.")
+        return _(
+            "Makes Pitfall Traps send the leader back by one floor in ascending dungeons. If the leader activates a Pitfall Trap on 1F, they will restart 1F with a different seed."
+        )
 
     @property
     def author(self) -> str:


### PR DESCRIPTION
Oops, I forgot to make my patches' descriptions translatable, so I tweaked them (plus one of Frostbyte's).
Is this enough, or is there more that's needed for the translation stuff to just work? I'm pretty unfamiliar with it.