### PR TITLE
Add OutdatedPatchDependency exception

### DIFF
--- a/skytemple_files/common/exceptions/outdated_patch_dependency.py
+++ b/skytemple_files/common/exceptions/outdated_patch_dependency.py
@@ -1,0 +1,25 @@
+from skytemple_files.common.i18n_util import _
+
+
+class OutdatedPatchDependencyError(Exception):
+    """
+    Raised when trying to apply an ASM patch that depends on another patches that exist but are outdated
+    """
+
+    def __init__(self, patch_name: str, outdated_dependencies: list[str]):
+        """
+        Creates a new OutdatedPatchDependencyError
+        :param patch_name: Name of the patch that failed to apply due to outdated dependencies
+        :param outdated_dependencies: List containing the names of each outdated dependency
+        """
+        self.patch_name = patch_name
+        self.outdated_dependencies = outdated_dependencies
+
+    def __str__(self):
+        msg = (_(f"The patch {self.patch_name} cannot be applied because the following patches it depends on "
+               f"are outdated:"))
+        for dependency in self.outdated_dependencies:
+            msg += f"\n- {dependency}"
+        msg += _("Please reapply these patches first.")
+
+        return msg

--- a/skytemple_files/common/exceptions/outdated_patch_dependency.py
+++ b/skytemple_files/common/exceptions/outdated_patch_dependency.py
@@ -16,8 +16,10 @@ class OutdatedPatchDependencyError(Exception):
         self.outdated_dependencies = outdated_dependencies
 
     def __str__(self):
-        msg = (_(f"The patch {self.patch_name} cannot be applied because the following patches it depends on "
-               f"are outdated:"))
+        msg = _(
+            f"The patch {self.patch_name} cannot be applied because the following patches it depends on "
+            f"are outdated:"
+        )
         for dependency in self.outdated_dependencies:
             msg += f"\n- {dependency}"
         msg += _("Please reapply these patches first.")

--- a/skytemple_files/patch/handler/abstract.py
+++ b/skytemple_files/patch/handler/abstract.py
@@ -82,6 +82,8 @@ class AbstractPatchHandler(ABC):
 
         :raises RuntimeError: On error applying the patch. If this is raised, the ROM will not be modified.
         :raises ValueError: On error applying the patch. If this is raised, the ROM will not be modified.
+        :raises OutdatedPatchDependencyError: If one of the patches this patch depends on is applied but outdated.
+         The user will be prompted to reapply it first, and the ROM will not be modified.
         """
 
     @abstractmethod


### PR DESCRIPTION
Allows ASM patches to raise an exception if any of their dependencies is outdated and needs to be reapplied.
Needed for #556.