### PR TITLE
TeamStatsPain filepath correction

### DIFF
--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -1370,7 +1370,7 @@
         </Patch>
 
         <Patch id="TeamStatsPain">
-          <OpenBin filepath="overlay_0010.bin">
+          <OpenBin filepath="overlay/overlay_0010.bin">
 	  	<Include filename ="chesyon_asm_mods/team_stats_pain/selector_overlay10.asm"/>
 	  </OpenBin>
 	  <OpenBin filepath="overlay/overlay_0036.bin">


### PR DESCRIPTION
TeamStatsPain fails to apply in SkyTemple 1.8.4, as the filepath for overlay 10 was invalid. This change remedies this issue.