### PR TITLE
Add "Ai Item Improvements" and "Ai Item Optimizations" Skypatches to SkyTemple

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_improvements/common/improvements_ov29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_improvements/common/improvements_ov29.asm
@@ -30,7 +30,6 @@
 ;   - Will use Ginseng on themselves, rather than being forced to throw at an ally
 ;   - Oren Berries can be used or thrown on any low HP pokemon! (The Ai may eat or throw them!!!)
 ;   - Foes will only use Trawl Orbs if a Kec shop is NOT on the floor!
-;   - Secret Easter Egg if Species is Lapras :P
 
     stmdb sp!,{r3,r4,r5,r6,r7,r8,r9,lr}; Push a bunch of registers, we need room to "function"
     mov r7,r0; Keep our precious monster pointer safe
@@ -660,7 +659,7 @@ label1:
     cmpne r1,r2;
     addne r2,#8;
     cmpne r1,r2;
-    beq odds_100;
+    beq odds_0; Fine I'll remove it Ches
     b ItemChecks;
 
 IsHailOrb:

--- a/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_improvements/common/improvements_ov29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_improvements/common/improvements_ov29.asm
@@ -1,0 +1,805 @@
+.org AiOrbCheck
+.area 0x4
+    cmp r9,#16; This will always return false. Used to be a check for whether the item-category was "Orbs", but is completely neutered! 
+.endarea
+
+.org GetAiUseItemProbability
+.area IsAdjacentToEnemy - GetAiUseItemProbability 
+; Changelog
+;   - Made Gold Thorns and Rare Fossils Throwable by the Ai!
+;   - Fixed Gravelyrock bug that only checked male Bonsly and Sudowoodo.
+;   - Fixed Violent Seed Bug that only checked SPA instead of both ATK and SPA
+;   - Vile Seed now runs a check similar to Violent Seed to ensure foe is not at minimum defenses already
+;   - Via Seeds now behave like Warp Seeds
+;   - Gravelyrocks will be thrown unless the user or target is Sudowoodo/Bonsly
+;   - Favored Gummis (Resisted or Better) will be eaten. Wonder/Wander/Nectar will always be eaten!
+;   - Violent Seeds, Rebound Orbs, and All-Hit Orbs will be used at enemies over 3/4 HP!
+;   - Warp/Via Seeds, Gone Pebbles, Vanish Seeds, Invisify Orbs, Rollcall Orbs (Enemies only), and Pure Seeds will be used if below 1/4 HP!
+;   - Sleep Seeds now check for sleeplessness and yawning!
+;   - Chesto Berries will only ever be used if sleeping, nightmared, or yawning!
+;   - For Sticks and Stones, Team members have a throw chance that depends on the foe's HP!
+;       - Allies have a 5% chance, unless the foe has low HP. If they do, it's an 80% chance! 
+;       - Foes still have 70% throw chance.
+;   - Allies will always use Rollcall Orbs if given one! Enemies will use them at low health!
+;   - Grimy Food will be eaten at sufficiently low hunger, or thrown: 80% if the target is healthy, and 30% otherwise.
+;   - Will use Weather Orbs if it would change the weather, and they "benefit" from the weather change
+;       - Hail: Ice types only   Sandstorm: Rock, Ground, Steel     Sunny: Fire, Grass      Rainy: Water, Electric
+;   - Will use Keys if they are in front of a Key Door
+;   - Will use Drought Orbs if they cannot swim and secondary terrain is water!
+;   - Will eat Blast Seeds if next to enemies!
+;   - Will use Ginseng on themselves, rather than being forced to throw at an ally
+;   - Oren Berries can be used or thrown on any low HP pokemon! (The Ai may eat or throw them!!!)
+;   - Foes will only use Trawl Orbs if a Kec shop is NOT on the floor!
+;   - Secret Easter Egg if Species is Lapras :P
+
+    stmdb sp!,{r3,r4,r5,r6,r7,r8,r9,lr}; Push a bunch of registers, we need room to "function"
+    mov r7,r0; Keep our precious monster pointer safe
+    and r5,r2,0x1; If r5 is 0x1, the item is being thrown!
+    and r4,r2,0x2; If r4 is 0x2, the item is being used on an enemy!
+    ldr r6,[r7,#0xb4]; Extract the monster pointer, or smthn. We'll use r6 to check the monster's data  
+    mov r3, r1; Retain the Item Pointer in case we need it!
+    ldrsh r1,[r1,#0x4]; Extract the Item ID.
+    b label1
+ItemChecks:
+    cmp r1,#0x0a; Sticks and Stones
+        ble SticksAndStones; If Throwing, 70% (If teammate, 20% + 0.5 * ItemsHeld)
+
+    cmp r1,#0x0e; Y-Ray Specs
+    cmpne r1,#0x0f; Gaggle Specs
+        beq IsGaggleOrYRaySpecs; If Throwing, 80%
+
+    cmp r1,#0x14; Patsy Band
+        beq odds_40; In general, 40% (shouldn't be usable though)
+
+    cmp r1,#0x22; Diet Ribbon
+        beq IsDietRibbon; If Throwing at non-zero belly, 50%
+
+    cmp r1,#0x2F; Whiff Specs
+    cmpne r1, 0x30; No-Aim Scope
+        beq IsWhifforNoAim; If Throwing, 50%
+
+    cmp r1,#0x45; Heal Seed
+    cmpne r1,0x5C; Gabite Scale
+        beq IsHealSeed; If Negative Status, 80%
+
+    cmp r1,#0x46; Oran Berry
+    cmpne r1,#0x47; Sitrus Berry
+    cmpne r1,#0x75; Oren Berry
+        beq IsOranOrSitrusBerry; If HP >= Max, 0%. If Below Quarter health...
+        ; If below 1/4 and Throwing: 50%
+	    ; If below 1/4 and Using: if adjacent to Enemy 100%, else 50%
+
+    cmp r1,#0x48; EyeDrop Seed
+        beq IsEyeDropSeed; If not EyeDropped (Goggle Specs counts!): If adjacent to enemy, 80%, else 5%.
+    
+    cmp r1,#0x4a; Blinker Seed
+        beq IsBlinkerSeed; If not blinded: If adjacent to enemy, 80%, else 5%.
+    
+    cmp r1,#0x4B; Doom Seed
+        beq IsDoomSeed; If not level 1, 80%
+
+    cmp r1,#0x4c; X-Eye Seed
+        beq IsXEyeSeed; If not Cross-Eyed: If adjacent to enemy, 80%, else 5%.
+    
+    cmp r1,#0x4d; Life Seed
+        beq IsLifeSeed; If Thrown: If Adjacent to Enemy, 10%, else 100%.
+    
+    cmp r1,#0x4e; Rawst Berry
+        beq IsRawstBerry; If Burned, 50% chance.     
+    
+    cmp r1,#0x4f; Hunger Seed
+        beq IsHungerSeed; If non-zero belly, 50% chance.
+    
+    cmp r1,#0x50; Quick Seed
+        beq IsQuickSeed; If +3 or slower: if Adjacent to enemy, 80%, else 5%.   
+    
+    cmp r1,#0x51; Pecha Berry
+        beq IsPechaBerry; If Poisoned or Badly Poisoned: If Adjacent to enemy, 50%, else 100%.
+    
+    cmp r1,#0x52; Cheri Berry
+        beq IsCheriBerry; If Paralyzed: If Adjacent to enemy, 30%, else 80%.
+    
+    cmp r1,#0x53; Totter Seed
+        beq IsTotterSeed; If Not Confused: If Adjacent to enemy, 15%, else 80%.
+    
+    cmp r1,#0x54; Sleep Seed
+        beq IsSleepSeed; If Not immune to sleep or sleeping (Sleepless, Nightmared, Napping, Yawning, Asleep), Adjacent 80/5 Use!
+
+    cmp r1,#0x56; Warp Seed
+        cmpne r1,#0x6b; Via Seed
+        beq IsWarpSeed; If Using, HP must be low. If throwing, Adjacent 40/5. 
+
+    cmp r1,#0x57; Blast Seed
+        beq IsBlastSeed; If Adjacent to Enemy, 80%, else 30%
+
+    cmp r1,#0x58; Ginseng
+        beq IsGinseng; If first move slot can be Ginsenged, 80% chance. Else 0. 
+    
+    cmp r1,#0x59; Joy Seed
+        beq IsJoySeed; If level <= 99, 80%
+    
+    cmp r1,#0x5a; Chesto Berry
+        beq IsChestoBerry; If Not Sleepless, 5%
+    
+    cmp r1,#0x5b; Stun Seed
+        beq IsStunSeed; If not stunned: If Adjacent to Enemy, 80%, else 5%.
+    
+    cmp r1,#0x5e; Vile Seed
+        beq IsVileSeed; If Throwing, and target would lose defense, 70% 
+    
+    cmp r1,#0x5f; Pure Seed
+        beq IsPureSeed; Use if HP low enough
+
+    cmp r1,#0x60; Violent Seed
+        beq IsViolentSeed; If above 3/4 HP and below +20 (+10) SPA OR ATK, 80%.
+    
+    cmp r1,#0x61; Vanish Seed
+        beq IsVanishSeed; If not invisible and below 1/4 HP, 80%.
+    
+    cmp r1,#0x63; Max Elixir
+        beq IsMaxElixir; Scales with PP use: (+30% per empty move slot, +6% for not-filled move slots). Caps at 99%... for some reason
+
+    cmp r1,#0x74; Mix Elixir
+        beq IsMixElixir; If target is a linoone, same as Max Elixir!
+
+    cmp r1,#0x64; Protein
+        beq IsProtein; If ATK < 250, 100%. 
+        
+    cmp r1,#0x65; Calcium
+        beq IsCalcium; If SPATK < 250, 100%.
+        
+    cmp r1,#0x66; Iron
+        beq IsIron; If DEF < 250, 100%.
+
+    cmp r1,#0x68; DropEye Seed
+        beq IsDropEye; If Throwing and Not Drop-Eyed, 80%.
+
+    cmp r1,#0x6a; Slip Seed
+        beq IsSlipSeed; If mobility type isn't 0 or 4, and not slipping: If Adjacent to Enemy, 100%, else 10%.
+       
+
+    cmp r1,#0x6c; Zinc
+        beq IsZinc; If SPDEF < 250, 100%.
+        
+    cmp r1,#0x6d; Apple
+    cmpne r1,#0x6e; Big Apple
+    cmpne r1,#0x70; Huge Apple
+        beq IsApple; If Belly < 10, 100%.
+
+    cmp r1,#0x6f; Grimy Food
+        beq IsGrimyFood; If thrown, 30%. If using, only use at low belly!
+     
+    cmp r1,#0x76; Dough Seed
+        beq IsDoughSeed; If on the team, 100%. (In other words, wild dungeon pokemon cannot use this!)
+
+    cmp r1,#0x89; Gravelyrock
+        beq IsGravelyrock; If Bonsly or Sudowoodo, If thrown 70%, Used 100%.
+    
+    cmp r1,#0xa7; Gone Pebble
+        beq IsGonePebble; If not enduring, and adjacent to an enemy, 80%. 5% throw chance
+    
+    cmp r1,#0xa8; Wander Gummi
+    cmpne r1,#0x67; Nectar
+    moveq r1,#0x88; Pretend is Wonder Gummi
+    .if AddTypesApplied
+    cmpne r1,#0x8A; All Gummis! (Will not catch Gravelyrock bc that was checked above!)
+    .else
+    cmpne r1,#0x87; All Gummis! (Will not catch Gravelyrock bc that was checked above!)
+    .endif
+        movle r2,#0x77; 
+        cmple r2,r1; ID between 0x77 and 0x8A (or 0x87 if Fairy Gummi doesn't exist!)
+        ble IsGummi;
+    
+    cmp r1,#0xB6; Key
+        beq IsKey;
+
+    cmp r1,#0xFF; Giga Impact TM (has no actual interaction, yet...)
+        ble odds_0; If not above #0xFF, the ride ends here!
+    
+    sub r1,#0x100; Now do the same checks for IDs 0x100-0x1FF, except the immediates are all legal again!
+
+    cmp r1,#0x2D; Hail Orb
+        beq IsHailOrb; If Ice-Type and not hailing, 80% to use. Neglects abilities
+
+    cmp r1,#0x2E; Sunny Orb
+        beq IsSunnyOrb; If Fire or Grass and not Sunny, 80% to use. Neglects abilities
+
+    cmp r1,#0x2F; Rainy Orb
+        beq IsRainyOrb; If Water or Electric and not Raining, 80% to use. Neglects abilities
+
+    cmp r1,#0x31; Sandy Orb
+        beq IsSandyOrb; If Ground, Rock, or Steel and not Sandy, 80% to use. Neglects abilities
+
+    cmp r1,#0x30; Evasion Orb
+        beq IsEmergencyOrb; Use if below 1/4 HP
+
+    cmp r1,#0x36; Rebound Orb 
+        cmpne r1,#0x66;  All-Hit Orb
+        beq IsBolsteringOrb; If above 3/4 HP: 80% if Adjacent to an enemy, else 5%.
+    
+    cmp r1,#0x3E; Luminous Orb
+        beq IsLuminousOrb; Same as Dough Seed. Only Teammates can use it.
+
+    cmp r1,#0x42; Trawl Orb
+        beq IsTrawlOrb; If Kec shop is on floor, 0%. Else 80%.
+
+    cmp r1,#0x4D; Drought Orb 
+    cmpne r1,#0x5C; Mobile Orb
+        beq IsDroughtOrb; Same as Slip Seed.
+    
+    cmp r1,#0x4F; Rollcall orb
+        beq IsRollCallOrb; 
+
+    cmp r1,#0x50; Invisify Orb
+        beq IsInvisifyOrb; Same as Vanish Seed
+
+    cmp r1,#0xAB; All Unown Rocks
+        movle r2,#0x90; 
+        cmple r2,r1; ID between 0x77 and 0x8A
+        ble SticksAndStones;
+    ; Any item NOT listed above will never be used by the AI.
+odds_0:
+    mov r0, #0; reset it just to prevent random 1% use chances...
+    b exit;   
+
+WeatherOrbTypeCheck:
+; Checks if the mon is the type specified in r1. Adds the result to r4, ensuring a cumulative check for use. 
+    cmp r5,#0x1; If Throwing...
+    beq odds_0; Don't bother
+    push r0,r14;
+    mov r0,r7
+    bl MonsterIsType
+    add r4,r0; If r0 is true, it is added to r4. 
+    pop r0, r15;
+
+
+
+;SmartCheckIfHoldingItem:
+;    push r0, r14;
+;    cmp r3,
+;    ldr r0, [r6,#0x68]; Retrieve Target's held item pointer
+;    ldrsh r0, [r0,#0x4]; Retrieve Target's held item ID.
+;    cmp r0,#0x0; Is there a held item?
+;    pop r0, r15;
+
+
+SticksAndStones:
+    cmp r5,#0x1; True if Thrown
+    bne odds_0;
+    ldrb r4,[r6,#0x6]; Check if on the team   
+    cmp r4,#0x0; If not on team...
+    beq odds_70;
+    bl GetMaxAndRemainingHP;
+    cmp r3,r2, LSR #0x2; If Remaining HP > Max HP Divided By 4...
+    bge odds_5; If not below 1/4 HP, Low throwing chance!  
+    b odds_80;
+
+ComputeHunger:
+; Returns hunger in r4, leaves r0 as it was found!
+    push r0,r14;
+    add r0, r6, #0x100
+    ldrh r1, [r0, #0x46]
+    sub r2, sp, #4
+    strh r1, [r2]
+    ldrh r0, [r0, #0x48]
+    strh r0, [r2, #2]
+    ldr r0, [r2]
+    bl CeilFixedPoint
+    mov r4, r0;
+    pop r0,r15;
+
+IsDietRibbon:
+    cmp r5,#0x0; If using...
+    beq odds_0;
+IsHungerSeed:
+    bl ComputeHunger; Custom function above. Returns hunger in r4.
+    cmp r4,#0
+    beq odds_0;
+    b odds_50;  
+ 
+IsWhifforNoAim:
+    cmp r5,#0x1; If throwing... 
+True_50_False_0:
+    beq odds_50;    
+    b odds_0;
+
+GetMaxAndRemainingHP:
+; Returns Max HP in r2, and Remaining HP in r3. Leaves r0, r1, and r4 untouched!!!
+    push r0,r1,r4,r14;
+    ldr r4,=#999; +1 pool
+    ldrsh r0,[r6,#0x12]; Get "Base Max" HP  
+    ldrsh r1,[r6,#0x16]; Get Boosts to Max HP
+    add r2,r0,r1; r2 = r0 + r1
+    ldrsh r3,[r6,#0x10]; Get remaining HP
+    cmp r2,r4;
+    movgt r2,r4;
+    cmp r3,r4;
+    movgt r3,r4;
+    pop r0,r1,r4,r15;
+
+IsRollCallOrb:
+    ldrb r4,[r6,#0x6]; Get team status
+    cmp r4,#0x0; If on team...
+    beq odds_100; Always use!
+IsEmergencyOrb:
+    cmp r5,#0x1; If Throwing
+    beq odds_0; Don't use
+IsOranOrSitrusBerry:
+    bl GetMaxAndRemainingHP;
+    cmp r3,r2, LSR #0x2; If Remaining HP > Max HP Divided By 4...
+    bge odds_0; If not below 1/4 HP, don't bother!  
+    cmp r5,#0x1; If throwing...
+    beq odds_50;
+Adjacent_100_50:
+    mov r0,r7   
+    bl IsAdjacentToEnemy
+    cmp r0,#0x1; If true, IS Adjacent    
+True_100_False_50:
+    mov r0,#0;
+    beq odds_100; 
+    b odds_50;
+
+IsBolsteringOrb:
+    bl GetMaxAndRemainingHP;
+    mov r1,#0x3;
+    mul r2,r2,r1; Multiply HP by 3!
+    cmp r3,r2, LSR #0x2; If Remaining HP > Max HP Divided By 4...
+    ble odds_0; If not above 3/4 HP, don't bother!  
+    b Adjacent_80_5;
+
+IsMixElixir:
+; I'm not touching that loop. I WILL make Mix Elixirs use their own label though!  
+    ldrsh r1,[r6,#0x4]; Get apparent species 
+    cmp r1,#0x124; Is it Linoone M?
+    cmpne r1,#0x37c; No, but is it Linoone F?
+    bne odds_0; No, so 0%.
+IsMaxElixir:
+    mov r8,#0x0; Counts the number of moves examined so far
+    add r7,r6,#0x124; Despite coincidentally being Zigzagoon's ID, this is an offest for move slots!
+    mov r4,#0x0;
+ElixirBeginLoop:
+    add r9,r7,r8, lsl #0x3; r9 = r7 + (r8 << 3); Adjust the pointer to the "r8th" move slot.
+    ldrb r2, [r9,#0x0]; Loads move data bitfield for the "r8th" move the mon knows
+    and r2,#0x1;
+    cmp r2,#0x1; Does the mon have a move in this slot?
+    beq ElixirEndLoop;
+    ldrh r3, [r9,#0x6]; Loads remaining PP for the "r8th" move move the mon knows
+    cmp r3,#0;
+    addeq r4,#30; Add 30 if the mon is out of PP for this move!
+    mov r0,r9;
+    bl GetMaxPpWrapper
+    cmp r0,r3; If Max PP > Current PP...
+    addgt r4,#6; Add 6 if the mon is not at full PP for this move!
+    add r8,#1;
+    cmp r8,#4;
+    ble ElixirBeginLoop;
+ElixirEndLoop:
+    cmp r4,#100; If the odds are over 99%...
+    movgt r4,#100; Make the odds 99%. (This is base-game, and stupid!) 
+    mov r0,r4; Put the odds into r0!
+    b exit; Custom odds, so go to exit directly!  
+
+IsHealSeed:
+    mov r0,r7    
+    mov r1,#0x1    
+    bl MonsterHasNegativeStatus
+    cmp r0,#0x1; If has negative status...
+True_80_False_0:
+    mov r0,#0;
+    beq odds_80; 
+    b odds_0;
+
+IsProtein:
+    ldrb r4,[r6,#0x1a]; Extract ATK stat   
+    b VitaminCheck;
+
+IsCalcium:
+    ldrb r4,[r6,#0x1b]; Extract SPATK stat   
+    b VitaminCheck;
+    
+IsIron:
+    ldrb r4,[r6,#0x1c]; Extract DEF stat
+    b VitaminCheck;
+
+IsZinc:
+    ldrb r4,[r6,#0x1d]; Extract SPDEF stat   
+VitaminCheck:
+    cmp r4,#0xFA; If STAT >= 250...  
+    bcs odds_0;
+    b odds_100;
+
+IsLifeSeed:
+    cmp r5,#0x1; If throwing...     
+False_Adjacent_10_100:
+    beq odds_0;
+    mov r0,r7
+    bl IsAdjacentToEnemy
+    cmp r0,#0x1
+    mov r0,#0;
+    beq odds_10;  
+    b odds_100;    
+ 
+IsEyedropSeed:
+    mov r0,r7    
+    bl CanSeeInvisibleMonsters
+    cmp r0,#0x1; Can see invisible Mons. AKA Has Eyedrop Status!
+False_Adjacent_80_5:
+    beq odds_0;
+Adjacent_80_5:
+    mov r0,r7   
+    bl IsAdjacentToEnemy
+    cmp r0,#0x1;
+    mov r0,#0;
+    beq odds_80;   
+    b odds_5;
+
+IsQuickSeed:
+    ldr r4,[r6,#0x110]; Get current speed stage   
+    cmp r4,#0x3; Compare against 3.
+    bgt odds_0; If above 3, don't use!  
+    b Adjacent_80_5; 
+
+IsXEyeSeed:
+    ldrb r4,[r6,#0xf1]; Get BlindClass Status   
+    cmp r4,#0x2; If Cross-Eyed...
+    b False_Adjacent_80_5;
+  
+IsCheriBerry:
+    ldrb r4,[r6,#0xbf]; Get BurnClass Status (which contains paralysis) 
+    cmp r4,#0x4; If Paralyzed...
+    bne odds_0;   
+IsBlastSeed:
+Adjacent_80_30:
+    mov r0,r7    
+    bl IsAdjacentToEnemy
+    cmp r0,#0x1 
+    mov r0,#0x0
+    beq odds_80;
+    cmp r5,#0x1; If Throwing
+    beq odds_30;
+    b odds_0;
+
+IsTotterSeed:
+    ldrb r4,[r6,#0xd0]; Get CringeClass Status (which contains Confusion)   
+    cmp r4,#0x2; If Confused...
+    beq odds_0;   
+Adjacent_80_15:
+    mov r0,r7    
+    bl IsAdjacentToEnemy
+    cmp r0,#0x1 
+    mov r0,#0x0
+    beq odds_80;   
+    b odds_15;
+
+IsPechaBerry:
+    ldrb r4,[r6,#0xbf]; Get BurnClass Status (which contains all poison types)   
+    cmp r4,#0x2; If Poisoned
+    cmpne r4,#0x3; Else If Badly Poisoned
+    bne odds_0; Only bother using if Poisoned!  
+    b Adjacent_100_50;
+
+IsBlinkerSeed:
+    mov r0,r7    
+    mov r1,#0x1    
+    bl IsBlinded
+    cmp r0,#0x1    
+    mov r0,#0;
+    b False_Adjacent_80_5;
+
+IsPureSeed:
+    cmp r5,#0x0; If using...
+    cmpne r4,#0x2; If throwing at an ally...
+    beq IsOranOrSitrusBerry; Treat as low HP item
+    b odds_0;
+
+IsWarpSeed:
+    cmp r5,#0x0; If using...
+    cmpne r4,#0x2; If throwing at an ally...
+    beq IsOranOrSitrusBerry; Treat as low HP item
+Adjacent_40_5:
+    mov r0,r7    
+    bl IsAdjacentToEnemy
+    cmp r0,#0x0   
+    mov r0,#0x0
+    bne odds_40;    
+    b odds_5;   
+
+IsTrawlOrb:
+    ldrb r4,[r6,#0x6]; Check if on the team   
+    cmp r4,#0x0; If on team...
+    beq odds_0; Don't use! (This way you can't test for Kec shops with trawl orbs!)
+    ldr r4, =DUNGEON_PTR; +1 pool
+    ldr r4,[r4];
+    ldr r3,=0x40c6; +1 pool
+    ldrb r4, [r4,r3];
+    cmp r4, 0x0; If true, no Kec shop present!!!
+    bne odds_0;
+    b odds_80;
+
+IsSleepSeed:
+    ldrb r4,[r6,#0xbd]; Get SleepClass Statuses
+    cmp r4,#0x0; If not Sleepless, Asleep, Napping, Nightmared, or Yawning...
+    bne odds_0;
+    b Adjacent_80_5;
+
+IsChestoBerry:
+    ldrb r4,[r6,#0xbd]; Get SleepClass Statuses   
+    cmp r4,#0x2; Is Sleepless?
+    cmpne r4,#0x0; Is Wide Awake?
+    cmpne r4,#0x5; Is napping? (Aka using rest to restore HP)
+    beq odds_0; Don't try it! 
+    b odds_100; Otherwise, is afflicted with some kind of sleep, so use!
+
+IsJoySeed: 
+    ldrb r4,[r6,#0xa]; Get current level   
+    cmp r4,#0x63; Compare against 99...
+    bgt odds_0;
+    b odds_80;
+
+IsGinseng:
+    add r7,r6,#0x124; Despite coincidentally being Zigzagoon's ID, this is an offest for move slots!
+    mov r0,r7
+    bl HasMaxGinsengBoost99;
+    cmp r0,#0x1; 
+    beq odds_80;
+    b odds_0;
+
+IsRawstBerry:
+    ldrb r4,[r6,#0xbf]; Get BurnClass Statuses   
+    cmp r4,#0x1; If Burned...
+    beq odds_50;
+    b odds_0;
+
+IsDoomSeed:
+    ldrb r4,[r6,#0xa]; Get current level   
+    cmp r4,#0x1; If level greater than 1...
+    bgt odds_80;
+    b odds_0;
+
+IsStunSeed:
+    ldrb r4,[r6,#0xc4]; Get FreezeClass Statuses  
+    cmp r4,#0x6; If Stunned...
+    b False_Adjacent_80_5;
+
+IsGrimyFood:
+    cmp r5,#0x0; If Using...
+    cmpne r4,#0x0; If Allied...
+    beq IsApple; Treat like an apple
+    mov r0,r7; Monster Struct   
+    mov r1,#0x1; 
+    bl MonsterHasNegativeStatus
+    cmp r0,#0x1; If has negative status...
+    beq odds_30; 30% chance to throw.
+    b odds_80; 
+
+IsLuminousOrb:
+    cmp r5,#0x1; If Throwing
+    beq odds_0; Don't bother
+IsDoughSeed:
+    ldrb r4,[r6,#0x6]; Check if on the team   
+    cmp r4,#0x1; If not on team...
+    beq odds_0; Enemies will never use this!!!
+    b odds_100;
+
+IsDroughtOrb:
+    cmp r5,#0x1; If Throwing
+    beq odds_0; Don't bother
+IsSlipSeed:
+    ldrsh r0,[r6,#0x2]; Get true species (Ditto)  
+    bl GetMobilityType
+    cmp r0,#0x0
+    cmpne r0,#0x4    
+    moveq r0,#0x1    
+    movne r0,#0x0    
+    tst r0,#0xff 
+    mov r0,#0;
+; "ldrneb" is fucking weird
+    ldrneb r4,[r6,#0xef]; Get InvisibleClass Statuses  
+    cmpne r4,#0x4; Is Slipping?
+    b False_Adjacent_10_100;
+
+IsGonePebble: 
+    cmp r5,#0x1; If throwing...
+    beq odds_5; 5% use chance
+    ldrb r4,[r6,#0xd5]; Get ReflectClass Statuses   
+    cmp r4,#0x9; If Enduring...
+    beq odds_0;
+    b IsEmergencyOrb;
+
+IsVileSeed:
+    ldr r4,[r6,#0x28]; Retrieve both DEF and SPDEF  
+    cmp r5,#0x0; False if Thrown
+    cmpne r4,#0x0; If both stats are zero...
+    bne odds_70;    
+    b odds_0;
+    
+
+IsViolentSeed:
+    ldr r4,[r6,#0x24]; Retrieve both Atk and SPA
+    ldr r3,=#0x140014; +1 pool
+    cmp r4,r3; If ATK boosts are 20 or more...
+    bge odds_0;
+    b IsBolsteringOrb;
+  
+IsInvisifyOrb:
+    cmp r5,#0x1; If Throwing...
+    beq odds_0; Don't bother
+IsVanishSeed:
+    ldrb r4,[r6,#0xef]; Get InvisibleClass Statuses   
+    cmp r4,#0x0; If NOT invisible... 
+    beq IsOranOrSitrusBerry; Treat as low HP item
+    b odds_0;
+  
+IsApple:
+    bl ComputeHunger;
+    cmp r4,#0xa; If belly below 10...
+    blt odds_100;
+    b odds_0;    
+
+IsDropEye:
+    ldrb r4,[r6,#0xf1]; Get BlindClass Status 
+    cmp r4,#0x4; If DropEyed...
+    beq odds_0;
+    b odds_80;
+
+IsGaggleOrYRaySpecs:
+    cmp r5,#0x1; If throwing...
+    b True_80_False_0;
+
+label1:
+    ldrsh r0,[r6,#0x4]; Get Apparant Species
+    push r1-r3;
+    bl FemaleToMaleForm
+    pop r1-r3;
+    cmp r0,#0x83
+    mov r0,#0x0;
+    bne ItemChecks
+    mov r2,#0x138;
+    cmp r1,r2;
+    addne r2,#1;
+    cmpne r1,r2;
+    addne r2,#8;
+    cmpne r1,r2;
+    beq odds_100;
+    b ItemChecks;
+
+IsHailOrb:
+    mov r4,#0x0;
+    mov r1,#0x6; Ice Type
+    bl WeatherOrbTypeCheck
+    mov r5,#0x5; Hail
+    b WeatherOrbsCheck
+
+IsSunnyOrb:
+    mov r4,#0x0;
+    mov r1,#0x2; Fire Type
+    bl WeatherOrbTypeCheck
+    mov r1,#0x4; Grass Type
+    bl WeatherOrbTypeCheck
+    mov r5,#0x1; Sunny
+    b WeatherOrbsCheck
+
+IsRainyOrb:
+    mov r4,#0x0;
+    mov r1,#0x3; Water Type
+    bl WeatherOrbTypeCheck
+    mov r1,#0x5; Electric Type
+    bl WeatherOrbTypeCheck
+    mov r5,#0x4; Rain
+    b WeatherOrbsCheck
+
+IsSandyOrb:
+    mov r4,#0x0;
+    mov r1,#0x9; Ground Type
+    bl WeatherOrbTypeCheck
+    mov r1,#0xD; Rock Type
+    bl WeatherOrbTypeCheck
+    mov r1,#0x11; Steel Type
+    bl WeatherOrbTypeCheck
+    mov r5,#0x2; Sandstorm
+WeatherOrbsCheck:
+    mov r0,r7;
+    bl GetApparentWeather
+    cmp r4,#0x0; Is the mon the wrong type?
+    cmpne r0,r5; Is the weather already out?
+    mov r0,#0x0;
+    bne odds_80;
+    b odds_0;
+
+IsKey:
+	cmp r5,0x1; If throwing...
+    beq odds_0;
+    ldrsh r1,[r7,#+0x6]; Get Y-Coord of monster
+	ldrsh r0,[r7,#+0x4]; Get X-Coord of monster
+	sub r1,r1,#0x1; Look one tile above
+	bl GetTileSafe; Get that tile
+	ldrh r0,[r0]; Load the tle
+	tst r0,#0x1000; Is the tile a Key-Door? (False if so)
+    mov r0,#0x0;
+    bne odds_100;
+    b odds_0;
+
+IsGravelyrock:
+    ldrsh r0,[r6,#0x4]; Get Apparant Species
+    bl FemaleToMaleForm
+    cmp r0,#0x1e0; Is Bonsly?    
+    cmpne r0,#0xb9; Is Sudowoodo?
+    mov r0,#0;
+    bne SticksAndStones;
+    cmp r4,#0x2; If Using/Throwing at a foe...   
+    beq odds_0;
+    ; Else continue to odds_100
+odds_100:
+    add r0,#20;
+odds_80:
+    add r0,#10;
+odds_70:
+    add r0,#20;
+odds_50:
+    add r0,#10;
+odds_40:
+    add r0,#10;
+odds_30:
+    add r0,#10;
+odds_20:
+    add r0,#5;
+odds_15:
+    add r0,#5;
+odds_10:
+    add r0,#5;
+odds_5:
+    add r0,#5;
+exit:     
+    ldmia sp!,{r3,r4,r5,r6,r7,r8,r9,pc} 
+IsGummi:
+    .if AddTypesApplied
+        cmp r1,#0x88; Wonder Gummi
+        subgt r1,#0x2; Put Fairy Gummi in the right slot
+        beq odds_80; If Wonder Gummi, 80% use chance!
+        sub r1,#0x76; Convert Item ID to Gummi Type
+        ;lsl r1,#0x1; Double Gummi Type to increment by half-words
+        ldrb r2,[r6,#0x5E]; Get type 1
+        ldrb r3,[r6,#0x5F]; Get type 2
+        ldr r4,=IQ_GUMMI_GAIN_TABLE;
+        mov r5,#0x19; Waste a register and an instruction bc MUL doesn't allow immediates :(
+        ; Gummi Type 1
+        smulbb r2,r2,r5; Multiply by 18 bytes (?)
+        add r2,r2,r1; Add Gummi Type
+        ldrb r2,[r4,r2]; Load the "r2th" entry of the Gummi IQ Table!
+        ; Gummi Type 2
+        smulbb r3,r3,r5; Multiply by 18 bytes (?)
+        add r3,r3,r1; Add Gummi Type
+        ldrb r3,[r4,r3]; Load the "r2th" entry of the Gummi IQ Table!
+        cmp r2,r3; Compare the type results
+        movlt r2,r3; Take the bigger gummi boost
+        cmp r2, NeutralGummiBoost;
+    .else
+        cmp r1,#0x88; Wonder Gummi
+        beq odds_80; If Wonder Gummi, 80% use chance!
+        sub r1,#0x76; Convert Item ID to Gummi Type
+        lsl r1,#0x1; Double Gummi Type to increment by half-words
+        ldrb r2,[r6,#0x5E]; Get type 1
+        ldrb r3,[r6,#0x5F]; Get type 2
+        ldr r4,=IQ_GUMMI_GAIN_TABLE;
+        mov r5,#0x24; Waste a register and an instruction bc MUL doesn't allow immediates :(
+        ; Gummi Type 1
+        smulbb r2,r2,r5; Multiply by 18 bytes (?)
+        add r2,r2,r1; Add Gummi Type
+        ldrsh r2,[r4,r2]; Load the "r2th" entry of the Gummi IQ Table!
+        ; Gummi Type 2
+        smulbb r3,r3,r5; Multiply by 18 bytes (?)
+        add r3,r3,r1; Add Gummi Type
+        ldrsh r3,[r4,r3]; Load the "r2th" entry of the Gummi IQ Table!
+        cmp r2,r3; Compare the type results
+        movlt r2,r3; Take the bigger gummi boost
+        cmp r2, NeutralGummiBoost;
+    .endif
+    bgt odds_80; 80% Chance
+    b odds_0;
+
+.pool; Constants will go here. Currently 4 things in the pool!
+; Put at the end because it has a variable amount of instructions.
+
+FreeSpaceStart:
+    .fill IsAdjacentToEnemy - FreeSpaceStart, 0
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_improvements/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_improvements/eu/offsets.asm
@@ -1,0 +1,25 @@
+.relativeinclude on
+.nds
+.arm
+
+; Function Starts
+.definelabel GetAiUseItemProbability, 0x0231EAC4
+.definelabel AiOrbCheck, 0x230f668
+
+; Functions Used
+.definelabel CeilFixedPoint, 0x205139C; 2051064
+.definelabel IsAdjacentToEnemy, 0x231F358; 231E8F0
+.definelabel GetMaxPpWrapper, 0x231F458; 231E9F0
+.definelabel MonsterHasNegativeStatus, 0x2301060; 2300634
+.definelabel CanSeeInvisibleMonsters, 0x2302918; 2301EEC
+.definelabel IsBlinded, 0x2318244; 23177E4
+.definelabel GetMobilityType, 0x2052BAC; 2052874
+.definelabel FemaleToMaleForm, 0x2054F5C; 2054BE0
+.definelabel MonsterIsType, 0x230287C; 2301E50
+.definelabel HasMaxGinsengBoost99, 0x2325200; 2324798
+.definelabel GetApparentWeather, 0x2335748; 2335748
+.definelabel GetTileSafe, 0x2336D34; 2336164
+.definelabel DUNGEON_PTR, 0x2354138; 2353538
+
+; Tables
+.definelabel IQ_GUMMI_GAIN_TABLE, 0x20A2834;

--- a/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_improvements/selector_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_improvements/selector_overlay29.asm
@@ -1,0 +1,11 @@
+.relativeinclude on
+
+.if PPMD_GameVer == GameVer_EoS_NA
+    .include "na/offsets.asm"
+    .include "common/improvements_ov29.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+    .include "eu/offsets.asm"
+    .include "common/improvements_ov29.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_improvements/us/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_improvements/us/offsets.asm
@@ -1,0 +1,25 @@
+.relativeinclude on
+.nds
+.arm
+
+; Function Starts
+.definelabel GetAiUseItemProbability, 0x231E05C
+.definelabel AiOrbCheck, 0x230EBF4
+
+; Functions Used
+.definelabel CeilFixedPoint, 0x2051064
+.definelabel IsAdjacentToEnemy, 0x231E8F0
+.definelabel GetMaxPpWrapper, 0x231E9F0
+.definelabel MonsterHasNegativeStatus, 0x2300634
+.definelabel CanSeeInvisibleMonsters, 0x2301EEC
+.definelabel IsBlinded, 0x23177E4
+.definelabel GetMobilityType, 0x2052874
+.definelabel FemaleToMaleForm, 0x2054BE0
+.definelabel MonsterIsType, 0x2301E50
+.definelabel HasMaxGinsengBoost99, 0x2324798
+.definelabel GetApparentWeather, 0x2334D08
+.definelabel GetTileSafe, 0x2336164
+.definelabel DUNGEON_PTR, 0x2353538
+
+; Tables
+.definelabel IQ_GUMMI_GAIN_TABLE, 0x20A22B0;

--- a/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_optimizations/common/optimizations_ov29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_optimizations/common/optimizations_ov29.asm
@@ -1,0 +1,402 @@
+.org GetAiUseItemProbability
+.area IsAdjacentToEnemy - GetAiUseItemProbability 
+; Changelog
+;   - Removed Unused Warp Seed Ally Code (saved 8 instructions)
+
+    stmdb sp!,{r3,r4,r5,r6,r7,r8,r9,lr}; Push a bunch of registers, we need room to "function"
+    mov r7,r0; Keep our precious monster pointer safe
+    mov r0,#0x0;
+    mov r4,#0x0;
+    and r5,r2,0x1; If r5 is 0x1, the item is being thrown!
+    ldr r6,[r7,#0xb4]; Extract the monster pointer, or smthn. We'll use r6 to check the monster's data  
+    ldrsh r1,[r1,#0x4]; Extract the item ID
+    
+    cmp r1,#0x5e; Vile seed.
+    cmplt r1,#0x0a; Sticks and Stones...
+    cmple r5,#0x1;
+        beq odds_70; 
+
+    cmp r1,#0x0e; Y-Ray Specs
+    cmpne r1,#0x0f; Gaggle Specs
+    cmpne r1,#0x6b; Via Seed ???
+    cmpne r1,#0x75; Oren Berry ???
+    cmpne r1,#0xa8; Wander Gummi ???
+        beq IsGaggleOrYRaySpecs; If Throwing, 80%
+
+    cmp r1,#0x14; Patsy Band
+        beq odds_40; In general, 40% (shouldn't be usable though)
+
+    cmp r1,#0x22; Diet Ribbon
+        beq IsDietRibbon; If Throwing at non-zero belly, 50%
+
+    cmp r1,#0x2F; Whiff Specs
+    cmpne r1, 0x30; No-Aim Scope
+        beq IsWhifforNoAim; If Throwing, 50%
+
+    subs r2, r1,#0x45
+    bmi Continue
+    cmp r1, #0x5D
+    addlt pc, pc, r2, lsl #0x2
+        b Continue
+        b IsHealSeed; If Negative Status, 80%
+        b IsOranOrSitrusBerry; If HP >= Max, 0%. If Below Quarter health...
+        b IsOranOrSitrusBerry; If HP >= Max, 0%. If Below Quarter health...
+        b IsEyeDropSeed; If not EyeDropped (Goggle Specs counts!): If adjacent to enemy, 80%, else 5%.
+        b odds_0; Reviver Seed
+        b IsBlinkerSeed; If not blinded: If adjacent to enemy, 80%, else 5%.
+        b IsDoomSeed; If not level 1, 80%
+        b IsXEyeSeed; If not Cross-Eyed: If adjacent to enemy, 80%, else 5%.
+        b IsLifeSeed; If Thrown: If Adjacent to Enemy, 100%, else 10%.
+        b IsRawstBerry; If Burned, 50% chance.
+        b IsHungerSeed; If non-zero belly, 50% chance.
+        b IsQuickSeed; If +3 or slower: if Adjacent to enemy, 80%, else 5%.
+        b IsPechaBerry; If Poisoned or Badly Poisoned: If Adjacent to enemy, 50%, else 100%.
+        b IsCheriBerry; If Paralyzed: If Adjacent to enemy, 30%, else 80%.
+        b IsTotterSeed; If Not Confused: If Adjacent to enemy, 15%, else 80%.
+        b IsSleepSeed; If Not Asleep/Nightmared/Napping: If Adjacent to Enemy, 5%, else 80%. (Just check the list instead, the Ai is better off)
+        b odds_0; Plain Seed
+        b IsWarpSeed; If Adjacent, 40% else 5%.
+        b IsBlastSeed; If Adjacent to Enemy, 80%, else 30%
+        b odds_80; IN GENERAL, 80%
+        b IsJoySeed; If level <= 99, 80%
+        b IsChestoBerry; If Not Sleepless, 5%
+        b IsStunSeed; If not stunned: If Adjacent to Enemy, 80%, else 5%.
+        b IsHealSeed; If Negative Status, 80%
+Continue:
+    cmp r1,#0x60; Violent Seed
+        beq IsViolentSeed; If below +20 (+10) SPA, 80%. (Never checks ATK)
+    
+    cmp r1,#0x61; Vanish Seed
+        beq IsVanishSeed; If not invisible, 80%.
+    
+    cmp r1,#0x63; Max Elixir
+        beq IsMaxElixir; Scales with PP use: (+30% per empty move slot, +6% for not-filled move slots). Caps at 99%... for some reason
+
+    cmp r1,#0x74; Mix Elixir
+        beq IsMixElixir; If target is a linoone, same as Max Elixir!
+
+    cmp r1,#0x6c; Zinc
+        addeq r4, #0x1; SPDEF is stat 4
+    cmpne r1,#0x66; Iron
+        addeq r4, #0x1; DEF is stat 3
+    cmpne r1,#0x65; Calcium
+        addeq r4, #0x1; SPA is stat 2
+    cmpne r1,#0x64; Protein
+        addeq r4, #0x1a; Stat offset is 0x1a (+1 for each subsequent stat!)  
+        beq VitaminCheck;  If STAT < 250, 100%.
+
+    cmp r1,#0x68; DropEye Seed
+        beq IsDropEye; If Throwing and Not Drop-Eyed, 80%.
+
+    cmp r1,#0x6a; Slip Seed
+        beq IsSlipSeed; If mobility type isn't 0 or 4, and not slipping: If Adjacent to Enemy, 100%, else 10%.
+
+    cmp r1,#0x6d; Apple
+    cmpne r1,#0x6e; Big Apple
+    cmpne r1,#0x70; Huge Apple
+        beq IsApple; If Belly < 10, 100%.
+
+    cmp r1,#0x6f; Grimy Food
+        beq odds_30; IN GENERAL, 30%. 
+     
+    cmp r1,#0x76; Dough Seed
+        beq IsDoughSeed; If on the team, 100%. (In other words, wild dungeon pokemon cannot use this!)
+
+    cmp r1,#0x89; Gravelyrock
+        beq IsGravelyrock; If Bonsly or Sudowoodo, If thrown 70%, Used 100%.
+    
+    cmp r1,#0xa7; Gone Pebble
+        beq IsGonePebble; If not enduring, and adjacent to an enemy, 80%.
+
+    eor r1,#0x100; If 0x14F, becomes 0x4F.
+    cmp r1,#0x4F; Rollcall Orb
+        cmpeq r5,#0x0; If using...    
+            moveq r0,#20; Add 20%   
+            beq exit; Exit with whatever % we have!
+    ; See the Optimizations patch for info on how to better set up item IDs above 0xFF;
+    ; Any item NOT listed above will never be used by the AI.
+odds_0:
+    mov r0, #0; reset it just to prevent random 1% use chances...
+    b exit;   
+
+
+ComputeHunger:
+; Returns hunger in r4, leaves r0 as it was found!
+    push r0,r2,r14;
+    add r0, r6, #0x100
+    ldrh r1, [r0, #0x46]
+    sub r2, sp, #4
+    strh r1, [r2]
+    ldrh r0, [r0, #0x48]
+    strh r0, [r2, #2]
+    ldr r0, [r2]
+    bl CeilFixedPoint
+    mov r4, r0;
+    pop r0,r2,r15;
+
+IsDietRibbon:
+    cmp r5,#0x0; If using...
+    beq odds_0;
+IsHungerSeed:
+    bl ComputeHunger; Custom function above. Returns hunger in r4.
+    cmp r4,#0
+    beq odds_0;
+    b odds_50;  
+ 
+IsWhifforNoAim:
+    cmp r5,#0x1; If throwing... 
+True_50_False_0:
+    beq odds_50;    
+    b odds_0;
+
+; These lines are stupidly common. Might as well make a proper function!
+Adjacent2Enemy:
+    push r14;
+    mov r0,r7; 
+    bl IsAdjacentToEnemy
+    cmp r0,#0x1;
+    mov r0,#0;
+    pop r15;
+
+IsOranOrSitrusBerry:
+    mov r0,r7;
+    bl HasLowHealth;
+    cmp r0,#0x1; If true, has low health
+    mov r0,#0x0;
+    bne odds_0; If not below 1/4 HP, don't bother!  
+    cmp r5,#0x1; If throwing...
+    beq odds_50;
+Adjacent_100_50:
+    bl Adjacent2Enemy;
+    beq odds_100; 
+    b odds_50;
+
+IsMixElixir:
+; I'm not touching that loop. I WILL make Mix Elixirs use their own label though!  
+    ldrsh r0,[r6,#0x4]; Get apparent species 
+    bl FemaleToMaleForm;
+    cmp r0,#0x124; Is it Linoone?
+    bne odds_0; No, so 0%.
+IsMaxElixir:
+    mov r8,#0x0; Counts the number of moves examined so far
+    add r7,r6,#0x124; Despite coincidentally being Zigzagoon's ID, this is an offest for move slots!
+ElixirBeginLoop:
+    add r9,r7,r8, lsl #0x3; r9 = r7 + (r8 << 3); Adjust the pointer to the "r8th" move slot.
+    ldrb r2, [r9,#0x0]; Loads move data bitfield for the "r8th" move the mon knows
+    ands r2,#0x1; Returns True of r2 & 0x1 == 0
+    beq ElixirEndLoop; The mon has no move in this slot!
+    ldrh r3, [r9,#0x6]; Loads remaining PP for the "r8th" move move the mon knows
+    cmp r3,#0;
+    addeq r4,#30; Add 30 if the mon is out of PP for this move!
+    mov r0,r9; r0 is reset here, so we don't need to erase it
+    bl GetMaxPpWrapper
+    cmp r0,r3; If Max PP > Current PP...
+    addgt r4,#6; Add 6 if the mon is not at full PP for this move!
+    add r8,#1;
+    cmp r8,#4;
+    ble ElixirBeginLoop;
+ElixirEndLoop:
+    cmp r4,#99; If the odds are over 99%...
+    movgt r4,#99; Make the odds 99%. (This is base-game, and stupid!) 
+    mov r0,r4; Put the odds into r0!
+    b exit; Custom odds, so go to exit directly!  
+
+IsHealSeed:
+    mov r0,r7    
+    mov r1,#0x1    
+    bl MonsterHasNegativeStatus
+    cmp r0,#0x1; If has negative status...
+True_80_False_0:
+    mov r0,#0;
+    beq odds_80; 
+    b odds_0;
+
+VitaminCheck:
+    ldrb r4,[r6,r4]; Extract SPDEF stat
+    cmp r4,#0xFA; If STAT >= 250...  
+    bcs odds_0;
+    b odds_100;
+
+IsLifeSeed:
+    cmp r5,#0x1; If throwing...     
+False_Adjacent_10_100:
+    bne odds_0;
+    bl Adjacent2Enemy;
+    beq odds_10;  
+    b odds_100;    
+ 
+IsEyedropSeed:
+    mov r0,r7    
+    bl CanSeeInvisibleMonsters
+    cmp r0,#0x1; Can see invisible Mons. AKA Has Eyedrop Status!
+False_Adjacent_80_5:
+    beq odds_0;
+Adjacent_80_5:
+    bl Adjacent2Enemy;
+    beq odds_80;   
+    b odds_5;
+
+IsQuickSeed:
+    ldr r4,[r6,#0x110]; Get current speed stage   
+    cmp r4,#0x3; Compare against 3.
+    bgt odds_0; If above 3, don't use!  
+    b Adjacent_80_5; 
+
+IsXEyeSeed:
+    ldrb r4,[r6,#0xf1]; Get BlindClass Status   
+    cmp r4,#0x2; If Cross-Eyed...
+    b False_Adjacent_80_5;
+  
+IsCheriBerry:
+    ldrb r4,[r6,#0xbf]; Get BurnClass Status (which contains paralysis) 
+    cmp r4,#0x4; If Paralyzed...
+    bne odds_0;   
+IsBlastSeed:
+Adjacent_80_30:
+    bl Adjacent2Enemy;
+    beq odds_80;   
+    b odds_30; 
+
+IsTotterSeed:
+    ldrb r4,[r6,#0xd0]; Get CringeClass Status (which contains Confusion)   
+    cmp r4,#0x2; If Confused...
+    beq odds_0;   
+Adjacent_80_15:
+    bl Adjacent2Enemy;
+    subne r0,#65;
+    b odds_80;
+
+IsPechaBerry:
+    ldrb r4,[r6,#0xbf]; Get BurnClass Status (which contains all poison types)   
+    cmp r4,#0x2; If Poisoned
+    cmpne r4,#0x3; Else If Badly Poisoned
+    bne odds_0; Only bother using if Poisoned!  
+    b Adjacent_100_50;
+
+IsBlinkerSeed:
+    mov r0,r7    
+    mov r1,#0x1    
+    bl IsBlinded
+    cmp r0,#0x1    
+    b False_Adjacent_80_5;
+
+IsWarpSeed:
+    bl Adjacent2Enemy;
+    beq odds_40;    
+    b odds_5;   
+
+IsSleepSeed:
+    mov r0,r7;
+    bl IsMonsterSleeping
+    b False_Adjacent_80_5;
+
+IsChestoBerry:
+    ldrb r4,[r6,#0xbd]; Get SleepClass Statuses   
+    cmp r4,#0x2; Is Sleepless?
+    beq odds_0; Don't try it!    
+    b odds_5; Otherwise, 5% at all times (???)
+
+IsJoySeed: 
+    ldrb r4,[r6,#0xa]; Get current level   
+    cmp r4,#0x63; Compare against 99...
+    bgt odds_0;
+IsGinseng:
+    b odds_80;
+
+IsRawstBerry:
+    ldrb r4,[r6,#0xbf]; Get BurnClass Statuses   
+    cmp r4,#0x1; If Burned...
+    beq odds_50;
+    b odds_0;
+
+IsDoomSeed:
+    ldrb r4,[r6,#0xa]; Get current level   
+    cmp r4,#0x1; If level greater than 1...
+    bgt odds_80;
+    b odds_0;
+
+IsStunSeed:
+    ldrb r4,[r6,#0xc4]; Get FreezeClass Statuses  
+    cmp r4,#0x6; If Stunned...
+    b False_Adjacent_80_5;
+
+IsDoughSeed:
+    ldrb r4,[r6,#0x6]; Check if on the team   
+    cmp r4,#0x0; If on team...
+    bne odds_0; Enemies will never use this!!!
+    b odds_100;
+   
+IsSlipSeed:
+    ldrsh r0,[r6,#0x2]; Get true species (Ditto)  
+    ldrb r1,[r6,0xef]; Get Invisibility Class Status (Slip is 0x4, 0x5 and beyond is unused!)
+    lsr r1,#0x2; Is Slipping?
+    bl GetMobilityTypeCheckSlip
+    cmp r0,#0x0
+    cmpne r0,#0x4
+    b False_Adjacent_10_100;
+
+IsGonePebble: 
+    ldrb r4,[r6,#0xd5]; Get ReflectClass Statuses   
+    cmp r4,#0x9; If Enduring...
+    beq odds_0;    
+Adjacent_0_80:
+    bl Adjacent2Enemy;
+    b True_80_False_0;
+
+IsViolentSeed:
+    ldrsh r4,[r6,#0x26]; Retrieve SPA value (Bug? Should also check ATK)   
+    cmp r4,#0x14; 
+    bge odds_0;    
+    b odds_80;
+  
+IsVanishSeed:
+    ldrb r4,[r6,#0xef]; Get InvisibleClass Statuses   
+    cmp r4,#0x1; If Invisible...
+    bne odds_0;
+    b odds_80;
+  
+IsApple:
+    bl ComputeHunger;
+    cmp r4,#0xa; If belly below 10...
+    blt odds_100;
+    b odds_0;  
+
+IsDropEye:
+    ldrb r4,[r6,#0xf1]; Get BlindClass Status 
+    cmp r4,#0x4; If DropEyed...
+    beq odds_0;
+    b odds_80;
+
+IsGaggleOrYRaySpecs:
+    cmp r5,#0x1; If throwing...
+    b True_80_False_0;
+
+IsGravelyrock:
+    ldrsh r4,[r6,#0x4]; Get Apparant Species, This is bugged to only check males!
+    cmp r4,#0x1e0; Is Bonsly?    
+    cmpne r4,#0xb9; Is Sudowoodo?
+    bne odds_0;   
+    cmp r5,#0x1; If Throwing...   
+    beq odds_70;
+    ; Else continue to odds_100
+odds_100:
+    add r0,#20;
+odds_80:
+    add r0,#10;
+odds_70:
+    add r0,#20;
+odds_50:
+    add r0,#10;
+odds_40:
+    add r0,#10;
+odds_30:
+    add r0,#20;
+odds_10:
+    add r0,#5;
+odds_5:
+    add r0,#5;
+exit:     
+    ldmia sp!,{r3,r4,r5,r6,r7,r8,r9,pc} 
+FreeSpaceStart:
+    .fill IsAdjacentToEnemy - FreeSpaceStart, 0
+.endarea

--- a/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_optimizations/eu/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_optimizations/eu/offsets.asm
@@ -1,0 +1,19 @@
+.relativeinclude on
+.nds
+.arm
+
+; Function Start
+.definelabel GetAiUseItemProbability, 0x0231EAC4
+
+; Functions Used
+.definelabel CeilFixedPoint, 0x205139C; 2051064
+.definelabel IsAdjacentToEnemy, 0x231F358; 231E8F0
+.definelabel GetMaxPpWrapper, 0x231F458; 231E9F0
+.definelabel MonsterHasNegativeStatus, 0x2301060; 2300634
+.definelabel CanSeeInvisibleMonsters, 0x2302918; 2301EEC
+.definelabel IsBlinded, 0x2318244; 23177E4
+.definelabel GetMobilityType, 0x2052BAC; 2052874
+.definelabel FemaleToMaleForm, 0x2054F5C; 2054BE0
+.definelabel HasLowHealth, 0x22FC01C; 22FB610
+.definelabel IsMonsterSleeping, 0x23011D4; 23007A8
+.definelabel GetMobilityTypeCheckSlip, 0x2300058; 22FF62C

--- a/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_optimizations/selector_overlay29.asm
+++ b/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_optimizations/selector_overlay29.asm
@@ -1,0 +1,11 @@
+.relativeinclude on
+
+.if PPMD_GameVer == GameVer_EoS_NA
+    .include "na/offsets.asm"
+    .include "common/optimizations_ov29.asm"
+.elseif PPMD_GameVer == GameVer_EoS_EU
+    .include "eu/offsets.asm"
+    .include "common/optimizations_ov29.asm"
+.endif
+
+.relativeinclude off

--- a/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_optimizations/us/offsets.asm
+++ b/skytemple_files/_resources/patches/asm_patches/happylappy_asm_mods/ai_item_optimizations/us/offsets.asm
@@ -1,0 +1,19 @@
+.relativeinclude on
+.nds
+.arm
+
+; Function Start
+.definelabel GetAiUseItemProbability, 0x231E05C
+
+; Functions Used
+.definelabel CeilFixedPoint, 0x2051064
+.definelabel IsAdjacentToEnemy, 0x231E8F0
+.definelabel GetMaxPpWrapper, 0x231E9F0
+.definelabel MonsterHasNegativeStatus, 0x2300634
+.definelabel CanSeeInvisibleMonsters, 0x2301EEC
+.definelabel IsBlinded, 0x23177E4
+.definelabel GetMobilityType, 0x2052874
+.definelabel FemaleToMaleForm, 0x2054BE0
+.definelabel HasLowHealth, 0x22FB610
+.definelabel IsMonsterSleeping, 0x23007A8
+.definelabel GetMobilityTypeCheckSlip, 0x22FF62C

--- a/skytemple_files/_resources/ppmdu_config/pmd2data.xml
+++ b/skytemple_files/_resources/ppmdu_config/pmd2data.xml
@@ -1377,6 +1377,23 @@
 	  	<Include filename ="chesyon_asm_mods/team_stats_pain/selector_overlay36.asm"/>
 	  </OpenBin>
         </Patch>
+        <Patch id="AiItemOptimizations">
+	  <OpenBin filepath="overlay/overlay_0029.bin">
+            <Include filename ="happylappy_asm_mods/ai_item_optimizations/selector_ov29.asm"/>
+          </OpenBin>
+        </Patch>
+        <Patch id="AiItemImprovements">
+	  <OpenBin filepath="overlay/overlay_0029.bin">
+            <Include filename ="happylappy_asm_mods/ai_item_improvements/selector_ov29.asm"/>
+          </OpenBin>
+	  <Parameters>
+	     <Param name="NeutralGummiBoost" label="Amount of IQ a neutral Gummi gives (If larger, Ai will eat the gummi!)" min="0" max="255" default="3" type="int"/>	
+            <Param name="AssignAiFlags" label="Assign AI flags (idk explanify further)" type="select">
+              <Option label="Yes" type="int">1</Option>
+              <Option label="No" type="int">0</Option>
+            </Param>	     
+	  </Parameters>
+        </Patch>
 
       </Game>
     </Patches>

--- a/skytemple_files/patch/handler/ai_item_improvements.py
+++ b/skytemple_files/patch/handler/ai_item_improvements.py
@@ -1,0 +1,204 @@
+#  Copyright 2020-2025 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import (
+    annotations,
+)
+from typing import Callable
+
+from ndspy.rom import NintendoDSRom
+from skytemple_files.data.item_p.handler import ItemPHandler
+from skytemple_files.common.util import read_u32, get_binary_from_rom
+from skytemple_files.common.ppmdu_config.data import (
+    Pmd2Data,
+    GAME_VERSION_EOS,
+    GAME_REGION_US,
+    GAME_REGION_EU,
+    GAME_REGION_JP,
+)
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+from skytemple_files.common.i18n_util import f, _
+
+MODIFIED_INSTRUCTION = 0xE8BD83F8  # ldmia all the shit
+OFFSET_EU = 0x231F29C - 0x22DCB80  # location of the instruction minus starting point of overlay 29
+OFFSET_US = 0x231E834 - 0x22DC240  # same but US HeHeHaHa
+
+ADD_TYPES_ADDRESS_NA = 0x2EAA4
+ADD_TYPES_ADDRESS_EU = 0x2EBD8
+ADD_TYPES_ORIGINAL_CODE = 0xE3A00024
+
+
+# the function where all the magic happens
+def set_item_ai_flags(item_p_model, item_id: int, ai_flag_1: bool, ai_flag_2: bool, ai_flag_3: bool):
+    item = item_p_model.item_list[item_id]
+    item.ai_flag_1 = ai_flag_1
+    item.ai_flag_2 = ai_flag_2
+    item.ai_flag_3 = ai_flag_3
+
+
+class AiItemImprovementsHandler(AbstractPatchHandler, DependantPatch):
+    @property
+    def name(self) -> str:
+        return "AiItemImprovements"
+
+    @property
+    def description(self) -> str:
+        return _("Tweaks team and enemy AI to use more types of items, and use them more effectively.")
+
+    @property
+    def author(self) -> str:
+        return "happylappy"
+
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+
+    def depends_on(self) -> list[str]:
+        return []
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.NEW_MECHANIC
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        patch_area = get_binary_from_rom(rom, config.bin_sections.overlay29)
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_u32(patch_area, OFFSET_US) == MODIFIED_INSTRUCTION
+            if config.game_region == GAME_REGION_EU:
+                return read_u32(patch_area, OFFSET_EU) == MODIFIED_INSTRUCTION
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:
+        param = self.get_parameters()
+        # do an is_applied check for AddTypes. let's say the result is stored to bool add_types_applied
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                add_types_applied = (
+                    read_u32(rom.loadArm9Overlays([29])[29].data, ADD_TYPES_ADDRESS_NA) != ADD_TYPES_ORIGINAL_CODE
+                )
+            elif config.game_region == GAME_REGION_EU:
+                add_types_applied = (
+                    read_u32(rom.loadArm9Overlays([29])[29].data, ADD_TYPES_ADDRESS_EU) != ADD_TYPES_ORIGINAL_CODE
+                )
+            else:
+                raise NotImplementedError()
+        else:
+            raise NotImplementedError()
+        if add_types_applied:
+            param["AddTypesApplied"] = 1
+        else:
+            param["AddTypesApplied"] = 0
+        self.__parameters = param
+        if param["AssignAiFlags"] == "1":
+            # load rom data
+            item_p_model = ItemPHandler.deserialize(rom.getFileByName("BALANCE/item_p.bin"))
+            # call set_item_ai_flags for every item you want to modify
+            # Gold Thorn & Rare Fossil
+            set_item_ai_flags(item_p_model, 9, True, False, False)
+            set_item_ai_flags(item_p_model, 10, True, False, False)
+            # Warp/Via/Gravelyrock/Gone Pebble/Wander Gummi Fire on all cylindars
+            set_item_ai_flags(item_p_model, 86, True, True, True)
+            set_item_ai_flags(item_p_model, 107, True, True, True)
+            set_item_ai_flags(item_p_model, 137, True, False, True)
+            set_item_ai_flags(item_p_model, 167, True, False, True)
+            set_item_ai_flags(item_p_model, 168, True, True, True)
+
+            # Blast Seed Eat but don't throw at allies
+            set_item_ai_flags(item_p_model, 87, True, False, True)
+            # Ginseng Allow use on self
+            set_item_ai_flags(item_p_model, 88, False, True, True)
+            # Pure Seeds need use on self or allies
+            set_item_ai_flags(item_p_model, 95, False, True, True)
+            # Grimy Food/Oren enable all use cases!
+            set_item_ai_flags(item_p_model, 111, True, True, True)
+            set_item_ai_flags(item_p_model, 117, True, True, True)
+            # All Gummis/Nectar need self-use flag
+            set_item_ai_flags(item_p_model, 103, False, True, True)
+            set_item_ai_flags(item_p_model, 119, False, True, True)
+            set_item_ai_flags(item_p_model, 120, False, True, True)
+            set_item_ai_flags(item_p_model, 121, False, True, True)
+            set_item_ai_flags(item_p_model, 122, False, True, True)
+            set_item_ai_flags(item_p_model, 123, False, True, True)
+            set_item_ai_flags(item_p_model, 124, False, True, True)
+            set_item_ai_flags(item_p_model, 125, False, True, True)
+            set_item_ai_flags(item_p_model, 126, False, True, True)
+            set_item_ai_flags(item_p_model, 127, False, True, True)
+            set_item_ai_flags(item_p_model, 128, False, True, True)
+            set_item_ai_flags(item_p_model, 129, False, True, True)
+            set_item_ai_flags(item_p_model, 130, False, True, True)
+            set_item_ai_flags(item_p_model, 131, False, True, True)
+            set_item_ai_flags(item_p_model, 132, False, True, True)
+            set_item_ai_flags(item_p_model, 133, False, True, True)
+            set_item_ai_flags(item_p_model, 134, False, True, True)
+            set_item_ai_flags(item_p_model, 135, False, True, True)
+            set_item_ai_flags(item_p_model, 136, False, True, True)
+            if param["AddTypesApplied"] == 1:
+                set_item_ai_flags(item_p_model, 138, False, True, True)
+            # Enable Key Use
+            set_item_ai_flags(item_p_model, 182, False, False, True)
+            # Enable the use of certain orbs:
+            set_item_ai_flags(item_p_model, 301, False, False, True)
+            set_item_ai_flags(item_p_model, 302, False, False, True)
+            set_item_ai_flags(item_p_model, 303, False, False, True)
+            set_item_ai_flags(item_p_model, 304, False, False, True)
+            set_item_ai_flags(item_p_model, 305, False, False, True)
+            set_item_ai_flags(item_p_model, 310, False, False, True)
+            set_item_ai_flags(item_p_model, 312, False, False, True)
+            set_item_ai_flags(item_p_model, 313, False, False, True)
+            set_item_ai_flags(item_p_model, 318, False, False, True)
+            set_item_ai_flags(item_p_model, 321, False, False, True)
+            set_item_ai_flags(item_p_model, 322, False, False, True)
+            set_item_ai_flags(item_p_model, 333, False, False, True)
+            set_item_ai_flags(item_p_model, 336, False, False, True)
+            set_item_ai_flags(item_p_model, 348, False, False, True)
+            # Unown Rock go brrrrrrrrrr
+            set_item_ai_flags(item_p_model, 400, True, False, False)
+            set_item_ai_flags(item_p_model, 401, True, False, False)
+            set_item_ai_flags(item_p_model, 402, True, False, False)
+            set_item_ai_flags(item_p_model, 403, True, False, False)
+            set_item_ai_flags(item_p_model, 404, True, False, False)
+            set_item_ai_flags(item_p_model, 405, True, False, False)
+            set_item_ai_flags(item_p_model, 406, True, False, False)
+            set_item_ai_flags(item_p_model, 407, True, False, False)
+            set_item_ai_flags(item_p_model, 408, True, False, False)
+            set_item_ai_flags(item_p_model, 409, True, False, False)
+            set_item_ai_flags(item_p_model, 410, True, False, False)
+            set_item_ai_flags(item_p_model, 411, True, False, False)
+            set_item_ai_flags(item_p_model, 412, True, False, False)
+            set_item_ai_flags(item_p_model, 413, True, False, False)
+            set_item_ai_flags(item_p_model, 414, True, False, False)
+            set_item_ai_flags(item_p_model, 415, True, False, False)
+            set_item_ai_flags(item_p_model, 416, True, False, False)
+            set_item_ai_flags(item_p_model, 417, True, False, False)
+            set_item_ai_flags(item_p_model, 418, True, False, False)
+            set_item_ai_flags(item_p_model, 419, True, False, False)
+            set_item_ai_flags(item_p_model, 420, True, False, False)
+            set_item_ai_flags(item_p_model, 421, True, False, False)
+            set_item_ai_flags(item_p_model, 422, True, False, False)
+            set_item_ai_flags(item_p_model, 423, True, False, False)
+            set_item_ai_flags(item_p_model, 424, True, False, False)
+            set_item_ai_flags(item_p_model, 425, True, False, False)
+            set_item_ai_flags(item_p_model, 426, True, False, False)
+            set_item_ai_flags(item_p_model, 427, True, False, False)
+            # save rom data
+            rom.setFileByName("BALANCE/item_p.bin", ItemPHandler.serialize(item_p_model))
+        # Apply the patch
+        apply()
+
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/handler/ai_item_optimizations.py
+++ b/skytemple_files/patch/handler/ai_item_optimizations.py
@@ -1,0 +1,83 @@
+#  Copyright 2020-2025 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import (
+    annotations,
+)
+from typing import Callable
+
+from ndspy.rom import NintendoDSRom
+
+from skytemple_files.common.util import read_u32, get_binary_from_rom
+from skytemple_files.common.ppmdu_config.data import (
+    Pmd2Data,
+    GAME_VERSION_EOS,
+    GAME_REGION_US,
+    GAME_REGION_EU,
+    GAME_REGION_JP,
+)
+from skytemple_files.patch.category import PatchCategory
+from skytemple_files.patch.handler.abstract import AbstractPatchHandler, DependantPatch
+from skytemple_files.common.i18n_util import f, _
+
+MODIFIED_INSTRUCTION = 0xE8BD83F8  # ldmia all the shit
+OFFSET_EU = (
+    0x231F358 - 1084 - 0x22DCB80
+)  # location of the next function minus the number of saved bytes minus 4 minus starting point of overlay 29
+OFFSET_US = 0x231E8F0 - 1084 - 0x22DC240  # same but US HeHeHaHa
+
+
+class AiItemOptimizationsHandler(AbstractPatchHandler, DependantPatch):
+    @property
+    def name(self) -> str:
+        return "AiItemOptimizations"
+
+    @property
+    def description(self) -> str:
+        return _(
+            "Reduces the size of GetAiUseItemProbability without changing anything else, creating 1080 bytes of free space in overlay29."
+        )
+
+    @property
+    def author(self) -> str:
+        return "happylappy"
+
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+
+    def depends_on(self) -> list[str]:
+        return []
+
+    @property
+    def category(self) -> PatchCategory:
+        return PatchCategory.UTILITY
+
+    def is_applied(self, rom: NintendoDSRom, config: Pmd2Data) -> bool:
+        patch_area = get_binary_from_rom(rom, config.bin_sections.overlay29)
+        if config.game_version == GAME_VERSION_EOS:
+            if config.game_region == GAME_REGION_US:
+                return read_u32(patch_area, OFFSET_US) == MODIFIED_INSTRUCTION
+            if config.game_region == GAME_REGION_EU:
+                return read_u32(patch_area, OFFSET_EU) == MODIFIED_INSTRUCTION
+        raise NotImplementedError()
+
+    def apply(self, apply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data) -> None:
+        # Apply the patch
+        apply()
+
+    def unapply(self, unapply: Callable[[], None], rom: NintendoDSRom, config: Pmd2Data):
+        raise NotImplementedError()

--- a/skytemple_files/patch/patches.py
+++ b/skytemple_files/patch/patches.py
@@ -55,6 +55,10 @@ from skytemple_files.patch.handler.add_type import AddTypePatchHandler
 from skytemple_files.patch.handler.add_key_check import (
     AddKeyCheckPatchHandler,
 )
+
+from skytemple_files.patch.handler.ai_item_optimizations import AiItemOptimizationsHandler
+from skytemple_files.patch.handler.ai_item_improvements import AiItemImprovementsHandler
+
 from skytemple_files.patch.handler.allow_unrecruitable_mons import (
     AllowUnrecruitableMonsPatchHandler,
 )
@@ -213,6 +217,8 @@ class PatchType(Enum):
     REMOVE_BODY_SIZE_CHECK = RemoveBodySizeCheckPatchHandler
     FAST_CHIMECHO = FastChimechoPatchHandler
     TEAM_STATS_PAIN = TeamStatsPainPatchHandler
+    AI_ITEM_OPTIMIZATONS = AiItemOptimizationsHandler
+    AI_ITEM_IMPROVEMENTS = AiItemImprovementsHandler
 
 
 class Patcher:


### PR DESCRIPTION
Ai Item Optimizations reduces the size of GetAiUseItemProbability without changing anything else, creating 1080 bytes of free space in overlay29.

Ai Item Improvements replaces the same function with one that tweaks team and enemy AI to use more types of items, and use them more effectively. Here's a full list of all the things it adds/modifies:
   - Made Gold Thorns and Rare Fossils Throwable by the Ai!
   - Fixed Gravelyrock bug that only checked male Bonsly and Sudowoodo.
   - Fixed Violent Seed Bug that only checked SPA instead of both ATK and SPA
   - Vile Seed now runs a check similar to Violent Seed to ensure foe is not at minimum defenses already
   - Via Seeds now behave like Warp Seeds
   - Gravelyrocks will be thrown unless the user or target is Sudowoodo/Bonsly
   - Favored Gummis (Resisted or Better) will be eaten. Wonder/Wander/Nectar will always be eaten!
   - Violent Seeds, Rebound Orbs, and All-Hit Orbs will be used at enemies over 3/4 HP!
   - Warp/Via Seeds, Gone Pebbles, Vanish Seeds, Invisify Orbs, Rollcall Orbs (Enemies only), and Pure Seeds will be used if below 1/4 HP!
   - Sleep Seeds now check for sleeplessness and yawning!
   - Chesto Berries will only ever be used if sleeping, nightmared, or yawning!
   - For Sticks and Stones, Team members have a throw chance that depends on the foe's HP!
       - Allies have a 5% chance, unless the foe has low HP. If they do, it's an 80% chance! 
       - Foes still have 70% throw chance.
   - Allies will always use Rollcall Orbs if given one! Enemies will use them at low health!
   - Grimy Food will be eaten at sufficiently low hunger, or thrown: 80% if the target is healthy, and 30% otherwise.
   - Will use Weather Orbs if it would change the weather, and they "benefit" from the weather change
       - Hail: Ice only | Sandstorm: Rock, Ground, Steel | Sunny: Fire, Grass  |Rainy: Water, Electric
   - Will use Keys if they are in front of a Key Door
   - Will use Drought Orbs if they cannot swim and secondary terrain is water!
   - Will eat Blast Seeds if next to enemies!
   - Will use Ginseng on themselves, rather than being forced to throw at an ally
   - Oren Berries can be used or thrown on any low HP pokemon! (The Ai may eat or throw them!!!)
   - Foes will only use Trawl Orbs if a Kecleon shop is NOT on the floor!