### PR TITLE
Fix Extract Bar List patch invalid cache read

### DIFF
--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/extract_bar_list/eu/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/extract_bar_list/eu/patch.asm
@@ -88,7 +88,7 @@ full_load:
 	; Get the offset in file
 	mov r0,r7
 	mov r1, r6, lsr 0x9
-	mov r1, r1, lsl #0x9
+	mov r1, r1, lsl #0xA
 	mov r2,#0x1 ; Relative seek
 	bl FStreamSeek
 	mov r0,r7

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/extract_bar_list/jp/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/extract_bar_list/jp/patch.asm
@@ -88,7 +88,7 @@ full_load:
 	; Get the offset in file
 	mov r0,r7
 	mov r1, r6, lsr 0x9
-	mov r1, r1, lsl #0x9
+	mov r1, r1, lsl #0xA
 	mov r2,#0x1 ; Relative seek
 	bl FStreamSeek
 	mov r0,r7

--- a/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/extract_bar_list/na/patch.asm
+++ b/skytemple_files/_resources/patches/asm_patches/anonymous_asm_mods/extract_bar_list/na/patch.asm
@@ -88,7 +88,7 @@ full_load:
 	; Get the offset in file
 	mov r0,r7
 	mov r1, r6, lsr 0x9
-	mov r1, r1, lsl #0x9
+	mov r1, r1, lsl #0xA
 	mov r2,#0x1 ; Relative seek
 	bl FStreamSeek
 	mov r0,r7


### PR DESCRIPTION
Causes read to invalid range for items after ID 0x200 (e.g. 0x100-0x300 for items 0x200-0x400)